### PR TITLE
fix(#74): seed default company during tenant bootstrap

### DIFF
--- a/libs/bootstrap.js
+++ b/libs/bootstrap.js
@@ -22,7 +22,7 @@ function slugFromName(name) {
  * Idempotent: if a default TenantMember already exists for this user, returns it
  * without creating duplicates.
  *
- * Returns { tenant, membership, companyClass, company }.
+ * Returns { tenant, membership, companyClasses, company }.
  */
 export async function bootstrapTenantMember(user, t) {
   // Idempotency guard: if the user already has a default membership, skip.
@@ -66,28 +66,34 @@ export async function bootstrapTenantMember(user, t) {
     { transaction: t }
   );
 
-  // Create the default company class (own company) for the tenant.
-  const companyClass = await models.CompanyClass.create(
-    {
-      tenantId: tenant.id,
-      name: '自社',
-      displayOrder: 8,
-      isClient: false
-    },
-    { transaction: t }
+  // Seed all default company classes for the tenant.
+  const defaultClasses = [
+    { name: '国内購買先', displayOrder: 1, isClient: false },
+    { name: '海外購買先', displayOrder: 2, isClient: false },
+    { name: '国内外注',   displayOrder: 3, isClient: false },
+    { name: '海外外注',   displayOrder: 4, isClient: false },
+    { name: '国内顧客',   displayOrder: 5, isClient: true  },
+    { name: '海外顧客',   displayOrder: 6, isClient: true  },
+    { name: '税金公共料金等', displayOrder: 7, isClient: false },
+    { name: '自社',       displayOrder: 8, isClient: false },
+  ];
+  const companyClasses = await models.CompanyClass.bulkCreate(
+    defaultClasses.map(c => ({ ...c, tenantId: tenant.id })),
+    { transaction: t, returning: true }
   );
+  const ownClass = companyClasses.find(c => c.name === '自社');
 
   // Create a default company for the tenant linked to the own-company class.
   const company = await models.Company.create(
     {
       tenantId: tenant.id,
       name: '本社',
-      companyClassId: companyClass.id
+      companyClassId: ownClass.id
     },
     { transaction: t }
   );
 
-  return { tenant, membership, companyClass, company };
+  return { tenant, membership, companyClasses, company };
 }
 
 // Keep old function name as alias for backward compatibility during transition

--- a/libs/bootstrap.js
+++ b/libs/bootstrap.js
@@ -22,7 +22,7 @@ function slugFromName(name) {
  * Idempotent: if a default TenantMember already exists for this user, returns it
  * without creating duplicates.
  *
- * Returns { tenant, membership, company }.
+ * Returns { tenant, membership, companyClass, company }.
  */
 export async function bootstrapTenantMember(user, t) {
   // Idempotency guard: if the user already has a default membership, skip.
@@ -66,16 +66,28 @@ export async function bootstrapTenantMember(user, t) {
     { transaction: t }
   );
 
-  // Create a default company for the tenant.
-  const company = await models.Company.create(
+  // Create the default company class (own company) for the tenant.
+  const companyClass = await models.CompanyClass.create(
     {
       tenantId: tenant.id,
-      name: '本社'
+      name: '自社',
+      displayOrder: 8,
+      isClient: false
     },
     { transaction: t }
   );
 
-  return { tenant, membership, company };
+  // Create a default company for the tenant linked to the own-company class.
+  const company = await models.Company.create(
+    {
+      tenantId: tenant.id,
+      name: '本社',
+      companyClassId: companyClass.id
+    },
+    { transaction: t }
+  );
+
+  return { tenant, membership, companyClass, company };
 }
 
 // Keep old function name as alias for backward compatibility during transition

--- a/libs/bootstrap.js
+++ b/libs/bootstrap.js
@@ -1,0 +1,84 @@
+import models from '../models/index.js';
+
+/**
+ * Generate a unique tenant slug from a username.
+ * Strips characters not safe for a slug and appends a short timestamp suffix
+ * so retries on collision are unlikely.
+ */
+function slugFromName(name) {
+  const base = name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 40) || 'user';
+  return `${base}-${Date.now().toString(36)}`;
+}
+
+/**
+ * Bootstrap a personal owned default tenant for a newly self-registered user.
+ *
+ * Must be called inside an existing Sequelize transaction (t).
+ * Idempotent: if a default TenantMember already exists for this user, returns it
+ * without creating duplicates.
+ *
+ * Returns { tenant, membership, company }.
+ */
+export async function bootstrapTenantMember(user, t) {
+  // Idempotency guard: if the user already has a default membership, skip.
+  const existing = await models.TenantMember.findOne({
+    where: { userId: user.id, isDefault: true },
+    transaction: t
+  });
+  if (existing) {
+    const tenant = await models.Tenant.findByPk(existing.tenantId, { transaction: t });
+    return { tenant, membership: existing };
+  }
+
+  // Create the personal tenant.
+  const slug = slugFromName(user.name);
+  const tenant = await models.Tenant.create(
+    {
+      slug,
+      name: `${user.legalName}さんの組織`,
+      status: 'active'
+    },
+    { transaction: t }
+  );
+
+  // Create the owner membership with all permissions and marking default.
+  const membership = await models.TenantMember.create(
+    {
+      userId: user.id,
+      tenantId: tenant.id,
+      isOwner: true,
+      status: 'active',
+      isDefault: true,
+      accounting: true,
+      fiscalBrowsing: true,
+      approvable: true,
+      administrable: true,
+      companyManagement: true,
+      inventoryManagement: true,
+      personnelManagement: true,
+      tenantSettings: true
+    },
+    { transaction: t }
+  );
+
+  // Create a default company for the tenant.
+  const company = await models.Company.create(
+    {
+      tenantId: tenant.id,
+      name: '本社'
+    },
+    { transaction: t }
+  );
+
+  return { tenant, membership, company };
+}
+
+// Keep old function name as alias for backward compatibility during transition
+export const bootstrapUserTenant = bootstrapTenantMember;
+
+export default { bootstrapTenantMember, bootstrapUserTenant };


### PR DESCRIPTION
Fixes #74

## Changes
- Added default company creation to \ootstrapTenantMember\ function
- Company is created with name '本社' within the same transaction
- Updated return value to include company object
- Updated JSDoc to reflect new return signature

## Testing
New tenants will now have a default company seeded automatically during signup.