### PR TITLE
feat(#92): Add language pair resolution API, preference persistence, UI selector in sidebar

### DIFF
--- a/front/javascripts/locales/en.json
+++ b/front/javascripts/locales/en.json
@@ -161,6 +161,8 @@
   "language_pair_vi_ja": "Vietnamese / Japanese",
   "language_pair_vi_en": "Vietnamese / English",
   "language_pair_ja_en": "Japanese / English",
+  "language_pair_ja_vi": "Japanese / Vietnamese",
+  "language_pair_en_ja": "English / Japanese",
 
   "no_data": "No data",
   "loading": "Loading...",

--- a/front/javascripts/locales/ja.json
+++ b/front/javascripts/locales/ja.json
@@ -161,6 +161,8 @@
   "language_pair_vi_ja": "ベトナム語／日本語",
   "language_pair_vi_en": "ベトナム語／英語",
   "language_pair_ja_en": "日本語／英語",
+  "language_pair_ja_vi": "日本語／ベトナム語",
+  "language_pair_en_ja": "英語／日本語",
 
   "no_data": "データがありません",
   "loading": "読み込み中...",

--- a/front/javascripts/locales/vi.json
+++ b/front/javascripts/locales/vi.json
@@ -161,6 +161,8 @@
   "language_pair_vi_ja": "Tiếng Nhật / Tiếng Việt",
   "language_pair_vi_en": "Tiếng Việt / Tiếng Anh",
   "language_pair_ja_en": "Tiếng Nhật / Tiếng Anh",
+  "language_pair_ja_vi": "Tiếng Nhật / Tiếng Việt",
+  "language_pair_en_ja": "Tiếng Anh / Tiếng Nhật",
 
   "no_data": "Không có dữ liệu",
   "loading": "Đang tải...",

--- a/front/svelte/common/sidebar.svelte
+++ b/front/svelte/common/sidebar.svelte
@@ -133,6 +133,7 @@
       {/each}
     </ul>
   </nav>
+  <LanguagePairSelector />
 </div>
 
 
@@ -147,6 +148,7 @@ import {onMount, afterUpdate, createEventDispatcher, tick} from 'svelte';
 import menu from '../../../config/module-list.js';
 import Sortable from 'sortablejs';
 import Icon from '@iconify/svelte';
+import LanguagePairSelector from '../widgets/language-pair-selector.svelte';
 import eventBus from '../../javascripts/event-bus.js';
 import {currentMenu, getStore} from '../../javascripts/current-record.js'
 import { currentPage, link } from '../../javascripts/router.js';

--- a/front/svelte/index.svelte
+++ b/front/svelte/index.svelte
@@ -74,7 +74,7 @@ import OkModal from './common/ok-modal.svelte';
 import Router from './components/router.svelte';
 import BilingualText from './components/bilingual-text.svelte';
 import {currentPage, getStore} from '../javascripts/router.js';
-import { loadDictionaries } from '../javascripts/bilingual.js';
+import { loadDictionaries, languagePair } from '../javascripts/bilingual.js';
 import { getCompanyInfo } from '../../libs/utils.js';
 import ja from '../javascripts/locales/ja.json';
 import vi from '../javascripts/locales/vi.json';
@@ -183,6 +183,17 @@ onMount(async () => {
   console.log('index onMount');
   status.pathname = location.pathname;
   // currentPage.set(location.pathname);
+
+  // Fetch language pair preference from server
+  try {
+    const langRes = await axios.get('/api/user/language-pair');
+    if (langRes.data && langRes.data.languagePair) {
+      languagePair.set(langRes.data.languagePair);
+    }
+  } catch (e) {
+    console.log('language-pair fetch failed, using default', e);
+  }
+
   const res = await axios.get('/api/user');
   status.user = res.data.user;
   status.company = await getCompanyInfo();

--- a/front/svelte/widgets/language-pair-selector.svelte
+++ b/front/svelte/widgets/language-pair-selector.svelte
@@ -1,0 +1,54 @@
+<!--
+  LanguagePairSelector — dropdown in sidebar for selecting language pair.
+
+  Props: none (reads/writes languagePair store + calls API)
+-->
+<div class="p-2 border-top" style="margin-top:auto">
+  <label class="form-label small text-muted mb-1" style="font-size:0.75rem">
+    {$_b('language_pair').primary}<br>
+    <span style="font-size:0.7rem">{$_b('language_pair').secondary}</span>
+  </label>
+  <select class="form-select form-select-sm" bind:value={selectedPair} on:change={onChange}>
+    <option value="ja,vi">{$_b('language_pair_ja_vi').primary}<br>{$_b('language_pair_ja_vi').secondary}</option>
+    <option value="vi,ja">{$_b('language_pair_vi_ja').primary}<br>{$_b('language_pair_vi_ja').secondary}</option>
+    <option value="ja,en">{$_b('language_pair_ja_en').primary}<br>{$_b('language_pair_ja_en').secondary}</option>
+    <option value="en,ja">{$_b('language_pair_en_ja').primary}<br>{$_b('language_pair_en_ja').secondary}</option>
+  </select>
+</div>
+
+<script>
+  import axios from 'axios';
+  import { _bDerived, languagePair } from '../../javascripts/bilingual.js';
+  import ja from '../../javascripts/locales/ja.json';
+  import vi from '../../javascripts/locales/vi.json';
+  import en from '../../javascripts/locales/en.json';
+
+  const DICT = { ja, vi, en };
+
+  // Simple local lookup for the selector labels
+  function _b(key) {
+    const pair = $languagePair || { primary: 'ja', secondary: 'vi' };
+    const pd = DICT[pair.primary] || {};
+    const sd = DICT[pair.secondary] || {};
+    return { primary: pd[key] ?? key, secondary: sd[key] ?? key };
+  }
+
+  let selectedPair = 'ja,vi';
+
+  // Sync dropdown to store on init
+  $: if ($languagePair) {
+    selectedPair = `${$languagePair.primary},${$languagePair.secondary}`;
+  }
+
+  async function onChange() {
+    const [primary, secondary] = selectedPair.split(',');
+    const newPair = { primary, secondary };
+    languagePair.set(newPair);
+
+    try {
+      await axios.put('/api/user/language-pair', newPair);
+    } catch (e) {
+      console.log('Failed to persist language pair', e);
+    }
+  }
+</script>

--- a/locales/en.json
+++ b/locales/en.json
@@ -161,6 +161,8 @@
   "language_pair_vi_ja": "Vietnamese / Japanese",
   "language_pair_vi_en": "Vietnamese / English",
   "language_pair_ja_en": "Japanese / English",
+  "language_pair_ja_vi": "Japanese / Vietnamese",
+  "language_pair_en_ja": "English / Japanese",
 
   "no_data": "No data",
   "loading": "Loading...",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -161,6 +161,8 @@
   "language_pair_vi_ja": "ベトナム語／日本語",
   "language_pair_vi_en": "ベトナム語／英語",
   "language_pair_ja_en": "日本語／英語",
+  "language_pair_ja_vi": "日本語／ベトナム語",
+  "language_pair_en_ja": "英語／日本語",
 
   "no_data": "データがありません",
   "loading": "読み込み中...",

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -161,6 +161,8 @@
   "language_pair_vi_ja": "Tiếng Nhật / Tiếng Việt",
   "language_pair_vi_en": "Tiếng Việt / Tiếng Anh",
   "language_pair_ja_en": "Tiếng Nhật / Tiếng Anh",
+  "language_pair_ja_vi": "Tiếng Nhật / Tiếng Việt",
+  "language_pair_en_ja": "Tiếng Anh / Tiếng Nhật",
 
   "no_data": "Không có dữ liệu",
   "loading": "Đang tải...",

--- a/routes/api.js
+++ b/routes/api.js
@@ -45,6 +45,8 @@ router.delete('/admin/backup/:date', is_authenticated, requireTenant, admin.dele
 router.get('/user', is_authenticated, user.get);
 router.get('/user/tenants', is_authenticated, user.tenants);
 router.get('/user/session-status', is_authenticated, user.sessionStatus);
+router.get('/user/language-pair', is_authenticated, requireTenant, user.languagePair);
+router.put('/user/language-pair', is_authenticated, requireTenant, user.updateLanguagePair);
 router.post('/user/select-tenant', is_authenticated, user.selectTenant);
 router.post('/user/tenant', is_authenticated, user.createTenant);
 router.post('/tenant', is_authenticated, user.createTenant);

--- a/routes/api_user.js
+++ b/routes/api_user.js
@@ -694,6 +694,72 @@ export default {
       res.json({ result: 'NG', message: 'ログオフに失敗しました。' });
     }
   },
+  languagePair: async (req, res, next) => {
+    if (!req.session || !req.session.user) {
+      return res.status(401).json({ result: 'NG', message: '認証されていません。' });
+    }
+
+    try {
+      const systemDefault = { primary: 'ja', secondary: 'vi' };
+
+      // 1. Try TenantMember override
+      if (req.currentTenantId) {
+        const membership = await models.TenantMember.findOne({
+          where: { userId: req.session.user.id, tenantId: req.currentTenantId, status: 'active' }
+        });
+        if (membership && membership.languagePair) {
+          return res.json({ result: 'OK', languagePair: membership.languagePair, source: 'member' });
+        }
+      }
+
+      // 2. Try Tenant default
+      if (req.currentTenantId) {
+        const tenant = await models.Tenant.findByPk(req.currentTenantId);
+        if (tenant && tenant.settings && tenant.settings.languagePair) {
+          return res.json({ result: 'OK', languagePair: tenant.settings.languagePair, source: 'tenant' });
+        }
+      }
+
+      // 3. System fallback
+      return res.json({ result: 'OK', languagePair: systemDefault, source: 'system' });
+    } catch (err) {
+      console.error('languagePair error', err);
+      res.status(500).json({ result: 'NG', message: '言語設定の取得に失敗しました。' });
+    }
+  },
+  updateLanguagePair: async (req, res, next) => {
+    if (!req.session || !req.session.user) {
+      return res.status(401).json({ result: 'NG', message: '認証されていません。' });
+    }
+    if (!req.currentTenantId) {
+      return res.status(403).json({ result: 'NG', message: 'テナントが選択されていません。' });
+    }
+
+    const { primary, secondary } = req.body;
+    if (!primary || !secondary || !['ja', 'vi', 'en'].includes(primary) || !['ja', 'vi', 'en'].includes(secondary)) {
+      return res.status(400).json({ result: 'NG', message: '無効な言語ペアです。' });
+    }
+    if (primary === secondary) {
+      return res.status(400).json({ result: 'NG', message: 'primary と secondary は異なる言語を指定してください。' });
+    }
+
+    try {
+      const membership = await models.TenantMember.findOne({
+        where: { userId: req.session.user.id, tenantId: req.currentTenantId, status: 'active' }
+      });
+      if (!membership) {
+        return res.status(404).json({ result: 'NG', message: 'メンバーシップが見つかりません。' });
+      }
+
+      membership.languagePair = { primary, secondary };
+      await membership.save();
+
+      res.json({ result: 'OK', languagePair: membership.languagePair });
+    } catch (err) {
+      console.error('updateLanguagePair error', err);
+      res.status(500).json({ result: 'NG', message: '言語設定の更新に失敗しました。' });
+    }
+  },
   selectTenant: async (req, res, next) => {
     if (!req.session || !req.session.user) {
       return res.status(401).json({


### PR DESCRIPTION
Part of epic:bilingual-foundation

### Changes
- **GET /api/user/language-pair**: Resolves pair from TenantMember > Tenant.settings > system fallback (ja/vi)
- **PUT /api/user/language-pair**: Saves to TenantMember.languagePair JSONB column
- **Language pair selector UI**: Dropdown in sidebar, bottom of nav
- **App init**: Fetches resolved pair on mount, sets languagePair store reactively
- **Locale files**: Added ja_vi and en_ja pair labels

### Verification
- `npm run build` ✅