### PR TITLE
feat(#93): Add bilingual enrichment helper, apply to CompanyClass API

### DIFF
--- a/libs/bilingual-helper.js
+++ b/libs/bilingual-helper.js
@@ -1,0 +1,78 @@
+import models from '../models/index.js';
+
+const OP = models.Sequelize.Op;
+
+// Mapping from (tableName, fieldName) to Translation.recordKey pattern
+const TRANSLATION_MAP = {
+  // Master / reference tables
+  CompanyClass: { name: (rec) => `name:${rec.name}` },
+  ItemClass: { name: (rec) => `name:${rec.name}` },
+  TransactionKind: { label: (rec) => `label:${rec.id}-${rec.label}` },
+  VoucherClass: { name: (rec) => `name:${rec.name}` },
+  TaxRule: { label: (rec) => `label:${rec.id}-${rec.label}` },
+  MemberClass: { title: (rec) => `title:${rec.title}` },
+  AccountClass: {
+    major: (rec) => `major:${rec.major}`,
+    middle: (rec) => `middle:${rec.middle}`,
+    minor: (rec) => `minor:${rec.minor}`
+  }
+};
+
+/**
+ * Enrich a batch of master data records with translated values.
+ *
+ * @param {string} tableName - e.g. 'CompanyClass', 'ItemClass'
+ * @param {Array} records - Array of Sequelize model instances
+ * @param {object} languagePair - { primary: 'ja', secondary: 'vi' }
+ * @returns {Array} Same records, each mutated with `{fieldName}Secondary` fields
+ */
+export async function enrichBilingual(tableName, records, languagePair) {
+  if (!records || records.length === 0) return records;
+  const mapping = TRANSLATION_MAP[tableName];
+  if (!mapping) return records;
+
+  const secondary = languagePair?.secondary;
+  if (!secondary) return records;
+
+  const fieldNames = Object.keys(mapping);
+  const keys = new Set();
+  for (const rec of records) {
+    for (const field of fieldNames) {
+      keys.add(mapping[field](rec));
+    }
+  }
+
+  const rows = await models.Translation.findAll({
+    where: {
+      tableName,
+      recordKey: [...keys],
+      field: fieldNames,
+      language: secondary,
+      tenantId: null // System seed only
+    },
+    raw: true
+  });
+
+  // Build lookup: { recordKey: { field: value } }
+  const lookup = {};
+  for (const row of rows) {
+    const rk = row.recordKey;
+    const field = row.field;
+    if (!lookup[rk]) lookup[rk] = {};
+    lookup[rk][field] = row.value;
+  }
+
+  for (const rec of records) {
+    for (const field of fieldNames) {
+      const rk = mapping[field](rec);
+      const translated = lookup[rk]?.[field];
+      if (translated) {
+        rec.setDataValue(`${field}${secondary.charAt(0).toUpperCase() + secondary.slice(1)}`, translated);
+      }
+    }
+  }
+
+  return records;
+}
+
+export default { enrichBilingual, TRANSLATION_MAP };

--- a/routes/api_company.js
+++ b/routes/api_company.js
@@ -1,4 +1,5 @@
 import models from '../models/index.js';
+import { enrichBilingual } from '../libs/bilingual-helper.js';
 import fs from 'fs';
 const Op = models.Sequelize.Op;
 import {getCompanyInfo, putCompanyInfo} from '../libs/utils.js';
@@ -125,19 +126,22 @@ export default {
       });
     }
   },
-  kindsGet: (req, res, next) => {
+  kindsGet: async (req, res, next) => {
     const tenantId = req.currentTenantId;
     res.set('Access-Control-Allow-Origin', '*');
-    models.CompanyClass.findAll({
+    let kinds = await models.CompanyClass.findAll({
       where: { tenantId },
       order: [
         [ 'displayOrder', 'asc']
       ]
-    }).then((kinds) => {
-      res.json({
-        values: kinds
-      })
-    })
+    });
+    const lp = req.query.languagePair ? JSON.parse(req.query.languagePair) : req.session?.languagePair;
+    if (lp) {
+      kinds = await enrichBilingual('CompanyClass', kinds, lp);
+    }
+    res.json({
+      values: kinds
+    });
   },
   kindsPut: async (req, res, next) => {
     const tenantId = req.currentTenantId;


### PR DESCRIPTION
Part of epic:bilingual-foundation

### Changes
- **libs/bilingual-helper.js**: `enrichBilingual(tableName, records, languagePair)` - fetches translations from Translations table and adds `nameVi`, `labelVi` etc. to records
- **CompanyClass API**: `GET /api/company/kinds` now enriches with bilingual translations when `languagePair` param available
- Backward compatible — no lang pair = original behavior

### Verification
- `npm run build` ✅