### PR TITLE
feat(#106): login page — row labels, drop hint text, compact signup link

### DIFF
--- a/front/javascripts/locales/en.json
+++ b/front/javascripts/locales/en.json
@@ -552,7 +552,7 @@
   "signup_error_username_length": "Username must be 4-20 characters.",
   "signup_error_username_required": "Please enter a username.",
   "signup_heading": "Sign Up",
-  "signup_link": "Create an account",
+  "signup_link": "Sign up",
   "signup_register_fail": "Registration failed.",
   "signup_register_success": "Registration complete. Redirecting to the login page...",
   "signup_title": "Account Registration",

--- a/front/javascripts/locales/ja.json
+++ b/front/javascripts/locales/ja.json
@@ -6,7 +6,7 @@
   "password": "パスワード",
   "user_name_placeholder": "ユーザー名",
   "password_placeholder": "パスワード",
-  "signup_link": "アカウント登録はこちら",
+  "signup_link": "登録",
   "signup_title": "アカウント登録",
   "signup_button": "アカウントを作成",
   "logon_title": "テナント選択",

--- a/front/javascripts/locales/vi.json
+++ b/front/javascripts/locales/vi.json
@@ -6,7 +6,7 @@
   "password": "Mật khẩu",
   "user_name_placeholder": "Tên người dùng",
   "password_placeholder": "Mật khẩu",
-  "signup_link": "Đăng ký tài khoản",
+  "signup_link": "Đăng ký",
   "signup_title": "Đăng ký tài khoản",
   "signup_button": "Tạo tài khoản",
   "logon_title": "Chọn tổ chức",

--- a/front/svelte/components/bilingual-text.svelte
+++ b/front/svelte/components/bilingual-text.svelte
@@ -3,22 +3,27 @@
   Primary language on top (bold), secondary below (smaller, muted).
 
   Props:
-    key       — dictionary key, auto-resolves both languages
-    primary   — override primary text (alternative to key)
-    secondary — override secondary text (alternative to key)
-    inline    — use inline-flex (default: inline-block)
+    key              — dictionary key, auto-resolves both languages
+    primary          — override primary text (alternative to key)
+    secondary        — override secondary text (alternative to key)
+    inline           — use inline-flex (default: inline-block)
+    layout           — 'column' (pri on top, sec below) | 'row' (pri left, sec right). Default: 'column'.
+    secondaryStrong  — render secondary text in the same color/weight as primary (no muted look). Default: false.
 
   Usage examples:
     <BilingualText key="save" />
     <BilingualText primary="保存" secondary="Lưu" />
     <BilingualText key="save" inline />
+    <BilingualText key="username" layout="row" secondaryStrong />
 -->
 <span
   class="bilingual-text"
-  style="display:{inline ? 'inline-flex' : 'flex'};flex-direction:column;line-height:1.4;vertical-align:middle"
+  class:bilingual-text--row={layout === 'row'}
+  class:bilingual-text--column={layout !== 'row'}
+  style="display:{inline ? 'inline-flex' : 'flex'};line-height:1.4;vertical-align:middle"
 >
   <span class="bilingual-primary" style="font-weight:600;line-height:1.4">{_primary}</span>
-  <span class="bilingual-secondary" style="font-size:0.78em;color:#666;line-height:1.25">{_secondary}</span>
+  <span class="bilingual-secondary" style="font-size:0.78em;{secondaryStrong ? '' : 'color:#666;'}line-height:1.25">{_secondary}</span>
 </span>
 
 <script>
@@ -32,6 +37,10 @@
   export let secondary = undefined;
   /** @type {boolean} */
   export let inline = false;
+  /** @type {'column' | 'row'} */
+  export let layout = 'column';
+  /** @type {boolean} */
+  export let secondaryStrong = false;
 
   // Dictionaries are loaded in index.svelte via loadDictionaries(),
   // stored in a module-level variable in bilingual.js. Here we access
@@ -61,3 +70,14 @@
     return dict[k] ?? k ?? '';
   }
 </script>
+
+<style>
+  .bilingual-text--column {
+    flex-direction: column;
+  }
+  .bilingual-text--row {
+    flex-direction: row;
+    align-items: baseline;
+    gap: 0.4em;
+  }
+</style>

--- a/front/svelte/login/login.svelte
+++ b/front/svelte/login/login.svelte
@@ -8,12 +8,12 @@
         <p class="fs-4 text-center "><BilingualText key="login" /></p>
         <p class="text-{msg_type} text-center">{message}</p>
         <div class="mb-3">
-          <label for="user_input"><BilingualText key="username" /></label>
-          <input type="text" bind:value={user_name} class="form-control" placeholder={$bi('user_name_placeholder')}>
+          <label for="user_input"><BilingualText key="username" layout="row" secondaryStrong /></label>
+          <input type="text" bind:value={user_name} class="form-control">
         </div>
         <div class="mb-3">
-          <label for="password_input"><BilingualText key="password" /></label>
-          <input type="password" bind:value={password} class="form-control" placeholder={$bi('password_placeholder')}>
+          <label for="password_input"><BilingualText key="password" layout="row" secondaryStrong /></label>
+          <input type="password" bind:value={password} class="form-control">
         </div>
         <div class="row d-flex justify-content-center">
           <div class="col-lg-8 col-4 d-grid">


### PR DESCRIPTION
## Summary

Part of #106 (per-page bilingual layout). First commit: login page only.

### Changes

1. **`front/svelte/components/bilingual-text.svelte`** — 2 new props:
   - `layout="column" | "row"` (column = default, backward compatible)
   - `secondaryStrong` (default false) — render secondary text in same color as primary (drops the muted `#666` look)
   - Added `.bilingual-text--row` / `.bilingual-text--column` CSS classes

2. **`front/svelte/login/login.svelte`** — username/password labels now use `layout="row"` + `secondaryStrong` so they render as `ユーザー名 / Tên người dùng` / `パスワード / Mật khẩu` on a single line. Drop redundant `placeholder` (was identical to the label).

3. **Locales** — `signup_link` shortened:
   - `ja.json`: `アカウント登録はこちら` → `登録`
   - `vi.json`: `Đăng ký tài khoản` → `Đăng ký`
   - `en.json`: `Create an account` → `Sign up` (consistency)

### Test report
- `npm run build`: ✓ built in 26.74s
- Visual: Chrome screenshot confirms row labels, no placeholder, compact signup link
- Screenshot: `docs/verify/login-after-106.png`

### Dependencies
Part of #106. Builds on #104 (already merged into epic).