### PR TITLE
fix(#110): render fiscal header as full strings per language

### DIFF
--- a/front/svelte/common/nav.svelte
+++ b/front/svelte/common/nav.svelte
@@ -3,16 +3,11 @@
   </ul>
   <span class="havbar-text">
     {#if ( status.fy.startDate && status.fy.endDate )}
-    {$bi('term')}{status.fy.term}{$bi('period_suffix')}
-    ({status.fy.startDate.getFullYear()}{$bi('nav_year_suffix')}
-    ({wareki(status.fy.startDate)})
-        {status.fy.startDate.getMonth()+1}{$bi('nav_month_suffix')}
-        {status.fy.startDate.getDate()}{$bi('nav_day_suffix')}
-    〜
-    {status.fy.endDate.getFullYear()}{$bi('nav_year_suffix')}
-    ({wareki(status.fy.endDate)})
-        {status.fy.endDate.getMonth()+1}{$bi('nav_month_suffix')}
-        {status.fy.endDate.getDate()}{$bi('nav_day_suffix')})
+    {#if fiscalHeader.primary === fiscalHeader.secondary}
+      {fiscalHeader.primary}
+    {:else}
+      {fiscalHeader.primary} / {fiscalHeader.secondary}
+    {/if}
     {:else}
     <span class="text-danger fw-bold"><i class="bi bi-exclamation-diamond-fill"></i><BilingualText key="select_fiscal_year" /></span>
     {/if}
@@ -59,17 +54,22 @@
 
 <script>
 import axios from 'axios';
-import {wareki} from '../../../libs/utils';
+import {formatFiscalHeader} from '../../../libs/utils';
 import ProfileModal from './profile-modal.svelte';
 import LanguagePairSelector from '../widgets/language-pair-selector.svelte';
 
 import BilingualText from '../components/bilingual-text.svelte';
-import { bi } from '../../javascripts/bilingual.js';
+import { bi, languagePair } from '../../javascripts/bilingual.js';
 export let status;
 
 let profileModal;
 let switchingTenant = false;
 let creatingTenant = false;
+
+$: fiscalHeader = {
+  primary: formatFiscalHeader(status.fy, $languagePair?.primary || 'ja'),
+  secondary: formatFiscalHeader(status.fy, $languagePair?.secondary || 'vi')
+};
 
 const openProfile = () => profileModal?.show();
 

--- a/libs/utils.js
+++ b/libs/utils.js
@@ -69,6 +69,40 @@ export const wareki = (date) => {
   return dateTimeFormat.format(new Date(date));
 }
 
+/**
+ * Build a single, locale-shaped fiscal-year header string.
+ *
+ * Replaces the old token-level \$bi() approach (which inserted \`/\` and the
+ * secondary suffix inside every date component). One complete string per
+ * language — the caller joins primary and secondary.
+ *
+ * @param {{term: number, startDate: Date, endDate: Date} | null | undefined} fy
+ * @param {string} lang - 'ja' | 'vi' | 'en'
+ * @returns {string}
+ */
+export const formatFiscalHeader = (fy, lang) => {
+  if (!fy || !fy.startDate || !fy.endDate) return '';
+  const term = fy.term;
+  const s = fy.startDate;
+  const e = fy.endDate;
+  const pad2 = (n) => String(n).padStart(2, '0');
+
+  switch (lang) {
+    case 'ja': {
+      const wS = wareki(s);
+      const wE = wareki(e);
+      return `第${term}期 ${s.getFullYear()}年${s.getMonth() + 1}月${s.getDate()}日（${wS}）〜 ${e.getFullYear()}年${e.getMonth() + 1}月${e.getDate()}日（${wE}）`;
+    }
+    case 'vi':
+      return `Kỳ ${term}: ${pad2(s.getDate())}/${pad2(s.getMonth() + 1)}/${s.getFullYear()} – ${pad2(e.getDate())}/${pad2(e.getMonth() + 1)}/${e.getFullYear()}`;
+    case 'en':
+    default: {
+      const monthFmt = new Intl.DateTimeFormat('en-US', { month: 'short' });
+      return `Term ${term}: ${monthFmt.format(s)} ${s.getDate()}, ${s.getFullYear()} – ${monthFmt.format(e)} ${e.getDate()}, ${e.getFullYear()}`;
+    }
+  }
+}
+
 export const DateString = (d) => {
   return	DateFormat(d, 'YYYY-MM-DD');
 }


### PR DESCRIPTION
Part of epic:bilingual-foundation

## Summary

Navbar built the active fiscal-year header by tokenizing each date component and wrapping every suffix in $bi(). That injected a secondary suffix and `/` into the middle of the date, producing unreadable output like `期 / Term1期 / period (2026年 / (令和8年)4月 / /1日 / ...)`.

- Add `formatFiscalHeader(fy, lang)` in `libs/utils.js`. Returns a complete, locale-shaped string:
  - ja: `第N期 yyyy年m月d日（令和N年）〜 ...（令和N年）`
  - vi: `Kỳ N: dd/mm/yyyy – dd/mm/yyyy`
  - en: `Term N: MMM d, yyyy – MMM d, yyyy`
- Wareki included only in the ja branch.
- `nav.svelte` derives `fiscalHeader` reactively from `$languagePair` and renders `primary / secondary`, or just `primary` when both languages match.
- Empty-state (no FY selected) preserved.

## Test

- `npm run build` ✅ (26.67s)
- Helper smoke test: ja/vi/en strings verified; null-fy → `` (empty, template shows the existing `select_fiscal_year` error).
- GitNexus: low risk, 0 affected processes.

## Out of scope

`front/svelte/home/term.svelte` has the same anti-pattern in the term list (lines 21, 26, 31, 36). Tracked separately to keep this PR focused on the navbar complaint.