### PR TITLE
fix(#112): page headers and table <th> cells stop overlapping bilingual lines

### DIFF
--- a/front/svelte/components/bilingual-text.svelte
+++ b/front/svelte/components/bilingual-text.svelte
@@ -1,18 +1,20 @@
 <!--
   BilingualText — renders text in a stacked bilingual layout.
   Primary language on top (bold), secondary below (smaller, muted).
+  Set `stacked={false}` to render a single line "primary / secondary"
+  (or just one value when both languages resolve to the same string).
+  Useful for compact headers and table <th> cells where the stacked
+  layout would overlap.
 
   Props:
     key       — dictionary key, auto-resolves both languages
     primary   — override primary text (alternative to key)
     secondary — override secondary text (alternative to key)
     inline    — use inline-flex (default: inline-block)
-
-  Usage examples:
-    <BilingualText key="save" />
-    <BilingualText primary="保存" secondary="Lưu" />
-    <BilingualText key="save" inline />
+    stacked   — render primary on top of secondary (default: true).
+                When false, render on a single line: "p / s" or just "p".
 -->
+{#if stacked}
 <span
   class="bilingual-text"
   style="display:{inline ? 'inline-flex' : 'flex'};flex-direction:column;line-height:1.4;vertical-align:middle"
@@ -20,6 +22,17 @@
   <span class="bilingual-primary" style="font-weight:600;line-height:1.4">{_primary}</span>
   <span class="bilingual-secondary" style="font-size:0.78em;color:#666;line-height:1.25">{_secondary}</span>
 </span>
+{:else}
+<span class="bilingual-text bilingual-inline" style="display:{inline ? 'inline-flex' : 'inline-flex'};align-items:baseline;gap:0.25em;white-space:nowrap">
+  {#if _primary === _secondary}
+    <span class="bilingual-primary" style="font-weight:600">{_primary}</span>
+  {:else}
+    <span class="bilingual-primary" style="font-weight:600">{_primary}</span>
+    <span class="bilingual-sep" style="color:#666">/</span>
+    <span class="bilingual-secondary" style="font-size:0.85em;color:#666">{_secondary}</span>
+  {/if}
+</span>
+{/if}
 
 <script>
   import { languagePair } from '../../javascripts/bilingual.js';
@@ -32,6 +45,8 @@
   export let secondary = undefined;
   /** @type {boolean} */
   export let inline = false;
+  /** @type {boolean} */
+  export let stacked = true;
 
   // Dictionaries are loaded in index.svelte via loadDictionaries(),
   // stored in a module-level variable in bilingual.js. Here we access

--- a/front/svelte/forms/components/details.svelte
+++ b/front/svelte/forms/components/details.svelte
@@ -5,7 +5,7 @@
       <th style="width:100px;"><BilingualText key="unit_price" /></th>
       <th style="width:50px;"><BilingualText key="quantity" /></th>
       <th style="width:50px;"><BilingualText key="unit" /></th>
-      <th style="width:100px;"><BilingualText key="amount" /><br/><BilingualText key="tax" /></th>
+      <th style="width:100px;"><BilingualText key="amount" stacked={false} /><br/><BilingualText key="tax" stacked={false} /></th>
       <th><BilingualText key="remarks" /></th>
     </tr>
   </thead>

--- a/front/svelte/forms/components/ledger-page.svelte
+++ b/front/svelte/forms/components/ledger-page.svelte
@@ -12,8 +12,8 @@
         <thead>
           <tr>
             <th colspan="2"><BilingualText key="date_voucher_no" /></th>
-            <th style="width: 100px;"><BilingualText key="counter_account" /><br/><BilingualText key="counter_sub_account" /></th>
-            <th><BilingualText key="application" /><br/><BilingualText key="sub_account" /></th>
+            <th style="width: 100px;"><BilingualText key="counter_account" stacked={false} /><br/><BilingualText key="counter_sub_account" stacked={false} /></th>
+            <th><BilingualText key="application" stacked={false} /><br/><BilingualText key="sub_account" stacked={false} /></th>
             <th style="width: 100px;"><BilingualText key="debit_amount" /></th>
             <th style="width: 100px;"><BilingualText key="credit_amount" /></th>
             <th style="width: 100px;"><BilingualText key="balance" /></th>

--- a/front/svelte/forms/components/page-header.svelte
+++ b/front/svelte/forms/components/page-header.svelte
@@ -1,12 +1,13 @@
 <div class="page-header">
   <div class="ledger-title">
-    {#if titleKey}<BilingualText key={titleKey} inline />{:else}{title}{/if}
+    {#if titleKey}<BilingualText key={titleKey} />{:else}{title}{/if}
   </div>
   <div class="company-name">
     {company.name}
   </div>
   <div class="term">
-    {fy.year}<BilingualText key="fiscal_year" inline />
+    <span class="term-year">{fy.year}</span>
+    <BilingualText key="fiscal_year" />
   </div>
   <div class="date">
     {formatDate(null, 'ja')}

--- a/front/svelte/forms/explanatory-journal/explanatory-journal.svelte
+++ b/front/svelte/forms/explanatory-journal/explanatory-journal.svelte
@@ -19,9 +19,9 @@
           <tr>
             <th scope="col" colspan="2"><BilingualText key="date_voucher_no" /></th>
             <th scope="col" style="width: 120px;"><BilingualText key="debit_amount" /></th>
-            <th scope="col" style="width: 100px;"><BilingualText key="debit_account" /><br/><BilingualText key="sub_account" /></th>
+            <th scope="col" style="width: 100px;"><BilingualText key="debit_account" stacked={false} /><br/><BilingualText key="sub_account" stacked={false} /></th>
             <th scope="col"><BilingualText key="application" /></th>
-            <th scope="col" style="width: 120px;"><BilingualText key="credit_account" /><br/><BilingualText key="sub_account" /></th>
+            <th scope="col" style="width: 120px;"><BilingualText key="credit_account" stacked={false} /><br/><BilingualText key="sub_account" stacked={false} /></th>
             <th scope="col" style="width: 100px;"><BilingualText key="credit_amount" /></th>
           </tr>
         </thead>


### PR DESCRIPTION
Part of epic:bilingual-foundation

## Summary

Cover/inner page headers and table `<th>` cells rendered the bilingual text overlapping the primary and secondary languages. Root cause: `BilingualText` with `inline` (or two adjacent `BilingualText` calls separated only by `<br/>`) could not give the stacked primary+secondary pair enough height in narrow containers, so the lines visually collided.

## Changes

- `BilingualText`: add a `stacked={false}` mode. Renders one line `"primary / secondary"` (or just one value when both languages resolve to the same string). `stacked` defaults to `true`, so every existing call site keeps current behavior.
- `forms/components/page-header.svelte`: drop `inline` on the `ledger-title` and `term` blocks. Wrap the year (`fy.year`) in its own `<span class="term-year">` so the year and the bilingual term label render as separate lines.
- `forms/explanatory-journal/explanatory-journal.svelte`, `forms/components/ledger-page.svelte`, `forms/components/details.svelte`: in `<th>` cells that combine two keys (`debit_account` + `sub_account`, `counter_account` + `counter_sub_account`, `application` + `sub_account`, `amount` + `tax`), apply `stacked={false}` on each `BilingualText` so the cell renders two compact bilingual lines (`借方科目/Debit Account` then `補助科目/Sub Account`) instead of four crushed stacked rows.

## Test

- `npm run build` ✅ (26.48s)
- GitNexus: low risk, 0 affected processes.
- Backward compatible: `stacked` default unchanged.

## Out of scope

Other `<th>` cells that use a single `BilingualText` (account-page, balance-sheet, pl, SGA, trial-balance/print) already stack one key cleanly; no change needed. `front/svelte/home/term.svelte` token-level date issue is tracked separately.