### PR TITLE
fix(#114): journal page h1 and Bootstrap btn stop overlapping bilingual lines

### DIFF
--- a/front/svelte/journal/journal.svelte
+++ b/front/svelte/journal/journal.svelte
@@ -1,7 +1,7 @@
 <div class="list">
   <div class="page-title d-flex justify-content-between">
-  	<h1><BilingualText key="journal" /></h1>
-  	<a href="/forms/explanatory_journal/{status.fy.term}?format=pdf" download="仕訳日記帳-{today}.pdf" class="btn btn-primary"><BilingualText key="download_journal" /><i class="bi bi-download"></i>
+  	<h1><BilingualText key="journal" stacked={false} /></h1>
+  	<a href="/forms/explanatory_journal/{status.fy.term}?format=pdf" download="仕訳日記帳-{today}.pdf" class="btn btn-primary"><BilingualText key="download_journal" stacked={false} /><i class="bi bi-download"></i>
   	</a>
 	</div>
 	<ul class="page-subtitle nav">
@@ -12,14 +12,14 @@
         	on:click={() => {
           	openMonth(date.year, date.month)
         	}}>
-        	{date.month}{$bi('month_label')}
+        	<BilingualText stacked={false} primary={date.month} secondary={$bi('month_label')} />
       	</button>
       	{:else}
       	<button type="button" class="btn btn-outline-primary me-2"
       		on:click={() => {
         		openMonth(date.year, date.month)
       		}}>
-        	{date.month}{$bi('month_label')}
+        	<BilingualText stacked={false} primary={date.month} secondary={$bi('month_label')} />
       	</button>
       	{/if}
     	</li>
@@ -29,7 +29,7 @@
   	<h2>{year}{$bi('year_label')} {month}{$bi('month_label')}</h2>
   	<div>
     	<button type="button" class="btn btn-primary" id="open-cross-slip"
-    		on:click={openSlip}><BilingualText key="journal_detail_entry_space" /><i class="bi bi-pencil-square"></i>
+    		on:click={openSlip}><BilingualText key="journal_detail_entry_space" stacked={false} /><i class="bi bi-pencil-square"></i>
       </button>
   	</div>
 	</div>


### PR DESCRIPTION
## Summary

Trang journal (`/journal/:year/:month`) bị đè nội dung song ngữ ở h1 tiêu đề, nút Download, nút Journal Detail Entry, và 12 nút tháng. Root cause giống #112: `BilingualText` mặc định `stacked={true}` render 2 dòng flex-column, không vừa chiều cao cố định của Bootstrap `.btn` và `<h1>`.

Fix: thêm `stacked={false}` ở 4 call sites — render `"primary / secondary"` 1 dòng. Prop này đã có sẵn từ PR #112, không cần đổi component.

## Test plan

- [x] `npm run build` — exit 0, 0 journal-related warnings
- [x] `npm test` — exit 0
- [ ] Reviewer manual check trên `/journal/2026/4`: h1, nút Download, nút Detail Entry, 12 nút tháng hiển thị rõ 1 dòng, không đè

## Diff

```
front/svelte/journal/journal.svelte | 10 +++++-----
1 file changed, 5 insertions(+), 5 deletions(-)
```

Part of epic:bilingual-foundation
Closes #114