### PR TITLE
fix(#118): journal page — stacked bilingual for h1, btn Download, btn Detail Entry, h2

### DIFF
--- a/front/svelte/journal/journal.svelte
+++ b/front/svelte/journal/journal.svelte
@@ -1,7 +1,7 @@
 <div class="list">
   <div class="page-title d-flex justify-content-between">
-  	<h1><BilingualText key="journal" stacked={false} /></h1>
-  	<a href="/forms/explanatory_journal/{status.fy.term}?format=pdf" download="仕訳日記帳-{today}.pdf" class="btn btn-primary"><BilingualText key="download_journal" stacked={false} /><i class="bi bi-download"></i>
+  	<h1 class="page-title-bilingual"><BilingualText key="journal" inline={true} /></h1>
+  	<a href="/forms/explanatory_journal/{status.fy.term}?format=pdf" download="仕訳日記帳-{today}.pdf" class="btn btn-primary btn-bilingual"><BilingualText key="download_journal" inline={true} /><i class="bi bi-download"></i>
   	</a>
 	</div>
 	<ul class="page-subtitle nav">
@@ -26,13 +26,13 @@
   	{/each}
 	</ul>
 	<div class="page-subtitle d-flex justify-content-between">
-  	<h2 class="d-flex align-items-baseline gap-2">
-  		<span>{year}{$bi('year_label')}</span>
-  		<BilingualText key={`month_${month}`} stacked={true} />
+  	<h2 class="d-flex align-items-center gap-3">
+  		<BilingualText primary={year} secondary={$bi('year_label')} inline={true} />
+  		<BilingualText key={`month_${month}`} inline={true} />
   	</h2>
   	<div>
-    	<button type="button" class="btn btn-primary" id="open-cross-slip"
-    		on:click={openSlip}><BilingualText key="journal_detail_entry_space" stacked={false} /><i class="bi bi-pencil-square"></i>
+    	<button type="button" class="btn btn-primary btn-bilingual" id="open-cross-slip"
+    		on:click={openSlip}><BilingualText key="journal_detail_entry_space" inline={true} /><i class="bi bi-pencil-square"></i>
       </button>
   	</div>
 	</div>
@@ -59,6 +59,20 @@
   line-height: 1.2;
   white-space: normal;
   padding: 0.25rem 0.5rem;
+}
+.btn-bilingual {
+  min-height: 56px;
+  line-height: 1.2;
+  white-space: normal;
+  padding: 0.25rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.page-title-bilingual {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.3;
 }
 </style>
 


### PR DESCRIPTION
## Summary

PR #117 (issue #116) đã fix nút tháng + i18n `&nbsp;` literal. Còn 4 thành phần trên trang journal vẫn dùng `stacked={false}` (1 dòng ngang `ja / en`) — không nhất quán với nút tháng 2 dòng.

Change này chuyển 4 thành phần sang 2 dòng dọc:
1. H1 tiêu đề trang → wrap trong `.page-title-bilingual`
2. Nút Download Journal → thêm `.btn-bilingual` class
3. H2 page subtitle → tách thành 2 `<BilingualText>` (year + month) cùng stacked
4. Nút Journal Detail Entry → thêm `.btn-bilingual` class

### Files Changed

- `front/svelte/journal/journal.svelte` — 4 call site update + 2 CSS class mới (`.btn-bilingual`, `.page-title-bilingual`) trong `<style>` scoped. Không động chạm BilingualText component hay i18n JSON (year_label đã có sẵn ở 3 locale: 年/Year/Năm).

### CSS Classes Mới

- `.btn-bilingual` — dùng chung cho `.btn` Download + `.btn` Detail Entry. `min-height: 56px; line-height: 1.2; white-space: normal; display: inline-flex; align-items: center; gap: 0.4rem;`
- `.page-title-bilingual` — riêng cho h1. `line-height: 1.3; display: inline-flex; align-items: center;`

### BilingualText Component Usage

- Bỏ `stacked={false}` ở 4 call site
- Thêm `inline={true}` để BilingualText render `inline-flex` (giữ content-width trong `.btn` thay vì expand full block)
- H2 dùng `primary={year} secondary={$bi('year_label')}` — dynamic, year_label lấy từ i18n

### Test Plan

- [x] `npm run build` exit 0 (26.51s)
- [ ] Runtime smoke `/journal/2027/3` (blocked: local Postgres chưa setup)

Part of epic:bilingual-foundation

Closes #118