### PR TITLE
fix(#120): journal page — add margin-bottom between H1 title and month button row

### DIFF
--- a/front/svelte/journal/journal.svelte
+++ b/front/svelte/journal/journal.svelte
@@ -54,6 +54,9 @@
 {/key}
 {/if}
 <style>
+.page-title {
+  margin-bottom: 1rem;
+}
 .month-btn {
   min-height: 56px;
   line-height: 1.2;


### PR DESCRIPTION
## Summary

Sau khi H1 tiêu đề chuyển sang 2 dòng stacked (PR #119 / #118), khoảng cách giữa H1 và hàng 12 nút tháng phía dưới quá sát. Thêm `margin-bottom: 1rem` cho `.page-title` (scoped trong `journal.svelte`).

### Files Changed

- `front/svelte/journal/journal.svelte` — thêm 1 rule `.page-title { margin-bottom: 1rem; }` trong `<style>` scoped

### Test Plan

- [x] `npm run build` exit 0 (27.23s)
- [ ] Runtime visual check (blocked: local Postgres)

Part of epic:bilingual-foundation

Closes #120