### PR TITLE
fix(#126): user profile dropdown items — switch from stacked to inline bilingual

### DIFF
--- a/front/svelte/common/nav.svelte
+++ b/front/svelte/common/nav.svelte
@@ -25,15 +25,15 @@
           aria-labelledby="user_menu">
         <li>
           <a href="#" class="dropdown-item" on:click|preventDefault={openProfile}>
-            <i class="bi bi-person-circle me-1"></i><BilingualText key="profile" /></a>
+            <i class="bi bi-person-circle me-1"></i><BilingualText key="profile" stacked={false} /></a>
         </li>
         <li>
           <a href="#" class="dropdown-item" on:click|preventDefault={openTenantCreate}>
-            <i class="bi bi-building-add me-1"></i><BilingualText key="create_tenant" /></a>
+            <i class="bi bi-building-add me-1"></i><BilingualText key="create_tenant" stacked={false} /></a>
         </li>
         <li>
           <a href="#" class="dropdown-item" on:click|preventDefault={switchTenantFromApp}>
-            <i class="bi bi-arrow-left-right me-1"></i><BilingualText key="nav_tenant_switch" />
+            <i class="bi bi-arrow-left-right me-1"></i><BilingualText key="nav_tenant_switch" stacked={false} />
             {#if switchingTenant}
               <span class="spinner-border spinner-border-sm ms-2" role="status" aria-hidden="true"></span>
             {/if}
@@ -42,7 +42,7 @@
         <li><hr class="dropdown-divider"></li>
         <li>
           <a href="/logout" class="dropdown-item">
-            <i class="bi bi-power me-1"></i><BilingualText key="nav_sign_out" />
+            <i class="bi bi-power me-1"></i><BilingualText key="nav_sign_out" stacked={false} />
           </a>
         </li>
       </ul>


### PR DESCRIPTION
## Summary

User profile dropdown ở navbar hiển thị 4 items với bilingual stacked (JA trên, EN dưới) → menu cao gấp đôi cần thiết cho quick-action context.

Switch 4 items sang `stacked={false}` → render inline `JA / EN` trên 1 dòng. Khi 2 ngôn ngữ giống nhau, BilingualText component tự collapse về 1 chuỗi (xem `bilingual-text.svelte:27-28`).

## Changes

- **`front/svelte/common/nav.svelte`** — thêm `stacked={false}` cho 4 items (profile, create_tenant, nav_tenant_switch, nav_sign_out)

## Test Report

- **Build:** `npm run build` ✅ 27.32s, no errors
- **Visual:** Open app → click user menu → dropdown gọn hơn (4 single-line items thay vì 4 × 2 stacked)
- **No regression:** Sidebar (vẫn stacked) không bị ảnh hưởng

Closes #126

Part of epic:bilingual-foundation