### PR TITLE
fix(#130): ledger page bilingual stacked layout + spacing

### DIFF
--- a/front/svelte/ledger/ledger.svelte
+++ b/front/svelte/ledger/ledger.svelte
@@ -98,6 +98,9 @@
   align-items: center;
   line-height: 1.3;
 }
+.page-title {
+  margin-bottom: 0.75rem;
+}
 </style>
 
 <script>

--- a/front/svelte/ledger/ledger.svelte
+++ b/front/svelte/ledger/ledger.svelte
@@ -1,6 +1,6 @@
 <div class="page-title d-flex justify-content-between">
-  <h1><BilingualText key="ledger" /></h1>
-  <a href="/forms/general_ledger/{status.fy.term}?format=pdf" download="{$bi('form_print_gl')}-{today}.pdf" class="btn btn-primary"><BilingualText key="download_general_ledger" /><i class="bi bi-download"></i>
+  <h1 class="page-title-bilingual"><BilingualText key="ledger" inline={true} /></h1>
+  <a href="/forms/general_ledger/{status.fy.term}?format=pdf" download="{$bi('form_print_gl')}-{today}.pdf" class="btn btn-primary btn-bilingual"><BilingualText key="download_general_ledger" inline={true} /><i class="bi bi-download"></i>
   </a>
 </div>
 <AccountSelect
@@ -21,18 +21,18 @@
   {/if}
   <div>
     {#if (account)}
-    <button type="button" class="btn btn-info"
+    <button type="button" class="btn btn-info btn-bilingual"
       on:click={() => {
         if (subAccountCode) {
           link(`/changes/${status.fy.term}/${accountCode}/${subAccountCode}`)
         } else {
           link(`/changes/${status.fy.term}/${accountCode}`)
         }
-      }}><BilingualText key="view_trends" /></button>
+      }}><BilingualText key="view_trends" inline={true} /></button>
     {/if}
-    <button type="button" class="btn btn-primary" id="open-cross-slip"
+    <button type="button" class="btn btn-primary btn-bilingual" id="open-cross-slip"
     	on:click={openSlip}>
-      {$bi('voucher_entry')}&nbsp;<i class="bi bi-pencil-square"></i>
+      <BilingualText key="voucher_entry" inline={true} /><i class="bi bi-pencil-square"></i>
     </button>
   </div>
 </nav>
@@ -49,12 +49,12 @@
       {/key}
     </div>
     <div class="col-4" style="text-align:right;">
-      <button type="button" class="btn btn-info"
+      <button type="button" class="btn btn-info btn-bilingual"
         on:click={() => {
           link(`/changes/${status.fy.term}/${accountCode}/${subAccountCode}`)
         }}
-        disabled={!subAccountCode}><BilingualText key="view_trends" /></button>
-      <a href="/forms/subsidiary_ledger/{status.fy.term}?format=pdf" download="{$bi('form_print_sl')}-{today}.pdf" class="btn btn-primary"><BilingualText key="download_sub_ledger" /><i class="bi bi-download"></i>
+        disabled={!subAccountCode}><BilingualText key="view_trends" inline={true} /></button>
+      <a href="/forms/subsidiary_ledger/{status.fy.term}?format=pdf" download="{$bi('form_print_sl')}-{today}.pdf" class="btn btn-primary btn-bilingual"><BilingualText key="download_sub_ledger" inline={true} /><i class="bi bi-download"></i>
       </a>
     </div>
   </div>
@@ -82,6 +82,23 @@
   on:close={updateList}></CrossSlipModal>
 {/key}
 {/if}
+
+<style>
+.btn-bilingual {
+  min-height: 56px;
+  line-height: 1.2;
+  white-space: normal;
+  padding: 0.25rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.page-title-bilingual {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.3;
+}
+</style>
 
 <script>
 


### PR DESCRIPTION
Part of epic:bilingual-foundation

## Commits
- 4daef5f fix(#130): ledger page bilingual stacked layout — h1, btn Download, btn View Trends, btn Voucher Entry, btn Download Sub Ledger
- 7cb37dd fix(#130): ledger page spacing — add margin between H1 title and AccountSelect row

## What
Apply journal fix pattern (PR #119) to ledger.svelte. Adds scoped .btn-bilingual and .page-title-bilingual CSS so the default stacked BilingualText renders cleanly inside Bootstrap .btn (~38px) and the .page-title h1. Switches 6 BilingualText call sites to inline={true}; replaces the raw $bi('voucher_entry')&nbsp; in Voucher Entry btn with BilingualText for consistency. Adds margin-bottom 0.75rem to .page-title so the stacked H1 doesn't clip into the AccountSelect dropdown row.

## Scope
- 1 file changed: front/svelte/ledger/ledger.svelte (+29 / -9)
- CSS scoped to ledger.svelte — no other page affected

## Test
- npm run build: pass (28.12s, exit 0)
- npm test: 33 passing / 13 failing (all 13 are pre-existing signupAndLogin Postgres auth blocker; no failure touches BilingualText, ledger.svelte, or this CSS — same blocker noted in #116)

## Follow-up
Opened #131 for the broader Account dropdown bilingual bug (dropdown items show only account.name, no Vietnamese) — that requires backend enrichBilingual wiring on Account table, out of scope for this styling fix.