### PR TITLE
fix(#131): ledger AccountSelect dropdown items now bilingual

### DIFF
--- a/front/svelte/components/account-select.svelte
+++ b/front/svelte/components/account-select.svelte
@@ -5,7 +5,7 @@
       id="field_{index}"
       rolw="button"
       data-bs-toggle="dropdown" aria-expanded="false">
-      {field.title}
+      <BilingualText primary={field.title} secondary={field.titleVi} inline={true} />
     </button>
     <ul class="dropdown-menu" aria-labelledby="field_{index}">
       {#each field.accounts as account}
@@ -13,7 +13,7 @@
         <button type="button" class="dropdown-item btn btn-link"
           on:click={() => {
             select(account.code);
-          }}>{account.name}</button>
+          }}><BilingualText primary={account.name} secondary={account.nameVi} inline={true} /></button>
       </li>
       {/each}
     </ul>
@@ -22,6 +22,7 @@
 </ul>
 <script>
 import {createEventDispatcher} from 'svelte';
+import BilingualText from './bilingual-text.svelte';
 
 const dispatch = createEventDispatcher();
 

--- a/front/svelte/components/subaccount-select.svelte
+++ b/front/svelte/components/subaccount-select.svelte
@@ -6,13 +6,14 @@
         on:click={() => {
           select(account.accountCode, sub.subAccountCode);
         }}>
-        {sub.name}
+        <BilingualText primary={sub.name} secondary={sub.nameVi} inline={true} />
       </button>
     </li>
   {/each}
 </ul>
 <script>
 import {createEventDispatcher} from 'svelte';
+import BilingualText from './bilingual-text.svelte';
 
 export let account;
 export let sub_account_code;

--- a/front/svelte/ledger/ledger.svelte
+++ b/front/svelte/ledger/ledger.svelte
@@ -137,22 +137,28 @@ let sums;
 let lines;
 let fields = [
   {
-    title: $bi('chart_assets'),
+    title: '資産',
+    titleVi: 'Tài sản',
     accounts: []
   },{
-    title: $bi('chart_liabilities'),
+    title: '負債',
+    titleVi: 'Nợ phải trả',
     accounts: []
   },{
-    title: $bi('chart_net_assets'),
+    title: '純資産',
+    titleVi: 'Vốn chủ sở hữu',
     accounts: []
   },{
-    title: $bi('chart_revenue'),
+    title: '売上高',
+    titleVi: 'Doanh thu',
     accounts: []
   },{
-    title: $bi('chart_cost_of_sales'),
+    title: '売上原価',
+    titleVi: 'Giá vốn',
     accounts: []
   },{
-    title: $bi('chart_non_operating'),
+    title: '営業外',
+    titleVi: 'Ngoài HĐKD',
     accounts: []
   }
 ];

--- a/libs/accounts.js
+++ b/libs/accounts.js
@@ -2,17 +2,21 @@ import models from '../models/index.js';
 const Op = models.Sequelize.Op;
 import {make_klass} from  './parse_account_code.js';
 import * as utils from './utils.js';
+import { enrichBilingual } from './bilingual-helper.js';
 
 export default class {
   static accounts;
 
-  static async  all (tenantId) {
+  static async  all (tenantId, languagePair) {
     let accounts = await models.Account.findAll({
       where: { tenantId },
       order: [
         ['accountCode']
-      ], 
+      ],
     });
+    if (languagePair) {
+      await enrichBilingual('Account', accounts, languagePair);
+    }
     let lines = [];
     const company = await utils.getCompanyInfo(tenantId);
     if  ( company.showIntercompanyAsSundries )  {
@@ -35,11 +39,15 @@ export default class {
             ['subAccountCode']
           ]
         });
+        if (languagePair) {
+          await enrichBilingual('SubAccount', subs, languagePair);
+        }
         for ( let j = 0; j < subs.length; j ++ ) {
           let sub = subs[j];
           sub_lines.push({
             key: sub.key,
             name: sub.name,
+            nameVi: sub.nameVi || '',
             code: sub.subAccountCode,
             taxClass: sub.taxClass
           });
@@ -47,6 +55,7 @@ export default class {
         lines.push({
           key: acc.key,
           name: acc.name,
+          nameVi: acc.nameVi || '',
           code: acc.accountCode,
           taxClass: acc.taxClass,
           subAccounts: sub_lines
@@ -55,6 +64,7 @@ export default class {
         lines.push({
           key: acc.key,
           name: acc.name,
+          nameVi: acc.nameVi || '',
           code: acc.accountCode,
           taxClass: acc.taxClass
         });
@@ -63,7 +73,7 @@ export default class {
     this.accounts = lines;
     return (lines);
   }
-  static async all2 (tenantId, term) {
+  static async all2 (tenantId, term, languagePair) {
     let accounts = await models.Account.findAll({
       where: { tenantId },
       order: [
@@ -78,6 +88,13 @@ export default class {
         as: 'accountClass'
       }]
     });
+    if (languagePair) {
+      await enrichBilingual('Account', accounts, languagePair);
+      const allSubs = accounts.flatMap(a => a.subAccounts || []);
+      if (allSubs.length > 0) {
+        await enrichBilingual('SubAccount', allSubs, languagePair);
+      }
+    }
     let lines = [];
     for ( let i = 0; i < accounts.length; i ++ ) {
       let acc = accounts[i];
@@ -98,6 +115,7 @@ export default class {
             id: suba.id,
             key: suba.key,
             name: suba.name,
+            nameVi: suba.nameVi || '',
             code: suba.subAccountCode,
             taxClass: suba.taxClass,
             debit: rem ? rem.debit : 0,
@@ -121,6 +139,7 @@ export default class {
           minor_name: acc.accountClass.minor,
           key: acc.key,
           name: acc.name,
+          nameVi: acc.nameVi || '',
           code: acc.accountCode,
           taxClass: acc.taxClass,
           subAccounts: sub_lines,
@@ -145,6 +164,7 @@ export default class {
           minor_name: acc.accountClass.minor,
           key: acc.key,
           name: acc.name,
+          nameVi: acc.nameVi || '',
           code: acc.accountCode,
           taxClass: acc.taxClass,
           debit: rem ? rem.debit : 0,
@@ -156,7 +176,7 @@ export default class {
     this.accounts = lines;
     return (lines);
   }
-  static async all3(tenantId, term) {
+  static async all3(tenantId, term, languagePair) {
     // 1. 残高取得関数
     const getRemaining = async (model, key, field) => {
       const rem = await model.findOne({
@@ -174,7 +194,7 @@ export default class {
         balance: rem?.balance || 0
       };
     };
-    
+
     // 2. データ取得
     const accountClasses = await models.AccountClass.findAll({
       where: { tenantId },
@@ -202,10 +222,22 @@ export default class {
         }
       ]
     });
-    
+
+    // Enrich all accounts and sub-accounts in one pass
+    if (languagePair) {
+      const allAccs = accountClasses.flatMap(acl => acl.accounts || []);
+      if (allAccs.length > 0) {
+        await enrichBilingual('Account', allAccs, languagePair);
+        const allSubs = allAccs.flatMap(a => a.subAccounts || []);
+        if (allSubs.length > 0) {
+          await enrichBilingual('SubAccount', allSubs, languagePair);
+        }
+      }
+    }
+
     // 3. 出力作成
     const lines = [];
-    
+
     for (const acl of accountClasses) {
       const klassInfo = {
         major_name: acl.major,
@@ -214,36 +246,38 @@ export default class {
         acl_id: acl.id,
         acl_code: make_klass(acl.field, acl.adding)
       };
-    
+
       if (!acl.accounts || acl.accounts.length === 0) {
         lines.push(klassInfo);
         continue;
       }
-    
+
       for (const acc of acl.accounts) {
         const accRem = await getRemaining(models.AccountRemaining, acc.id, 'accountId');
-    
+
         if (acc.subAccounts && acc.subAccounts.length > 0) {
           const sub_lines = [];
-    
+
           for (const suba of acc.subAccounts) {
             const subRem = await getRemaining(models.SubAccountRemaining, suba.id, 'subAccountId');
-    
+
             sub_lines.push({
               id: suba.id,
               key: suba.key,
               name: suba.name,
+              nameVi: suba.nameVi || '',
               code: suba.subAccountCode,
               taxClass: suba.taxClass,
               ...subRem
             });
           }
-    
+
           lines.push({
             ...klassInfo,
             id: acc.id,
             key: acc.key,
             name: acc.name,
+            nameVi: acc.nameVi || '',
             code: acc.accountCode,
             taxClass: acc.taxClass,
             subAccounts: sub_lines,
@@ -255,6 +289,7 @@ export default class {
             id: acc.id,
             key: acc.key,
             name: acc.name,
+            nameVi: acc.nameVi || '',
             code: acc.accountCode,
             taxClass: acc.taxClass,
             ...accRem
@@ -262,12 +297,12 @@ export default class {
         }
       }
     }
-    
+
     this.accounts = lines;
     return lines;
   }
     
-  static async all4(tenantId, term)	{   //  科目管理画面で使っている
+  static async all4(tenantId, term, languagePair)	{   //  科目管理画面で使っている
   let accountClasses = await models.AccountClass.findAll({
   where: { tenantId },
   include: [
@@ -289,6 +324,16 @@ export default class {
         ['accounts', 'subAccounts', 'subAccountCode', 'ASC']
   ],
   });
+  if (languagePair) {
+    const allAccs = accountClasses.flatMap(acl => acl.accounts || []);
+    if (allAccs.length > 0) {
+      await enrichBilingual('Account', allAccs, languagePair);
+      const allSubs = allAccs.flatMap(a => a.subAccounts || []);
+      if (allSubs.length > 0) {
+        await enrichBilingual('SubAccount', allSubs, languagePair);
+      }
+    }
+  }
   let	lines = [];
   for	( let i = 0; i < accountClasses.length ; i ++ )	{
   let acl = accountClasses[i];
@@ -320,6 +365,7 @@ export default class {
   id: suba.id,
   key: suba.key,
   name: suba.name,
+  nameVi: suba.nameVi || '',
   code: suba.subAccountCode,
   taxClass: suba.taxClass,
   debit: rem ? rem.debit : 0,
@@ -345,6 +391,7 @@ export default class {
   acl_code: make_klass(acl.field, acl.adding),
   key: acc.key,
   name: acc.name,
+  nameVi: acc.nameVi || '',
   code: acc.accountCode,
   taxClass: acc.taxClass,
   subAccounts: sub_lines,
@@ -371,6 +418,7 @@ export default class {
   acl_code: make_klass(acl.field, acl.adding),
   key: acc.key,
   name: acc.name,
+  nameVi: acc.nameVi || '',
   code: acc.accountCode,
   taxClass: acc.taxClass,
   debit: rem ? rem.debit : 0,

--- a/libs/bilingual-helper.js
+++ b/libs/bilingual-helper.js
@@ -11,6 +11,12 @@ const TRANSLATION_MAP = {
   VoucherClass: { name: (rec) => `name:${rec.name}` },
   TaxRule: { label: (rec) => `label:${rec.label}` },
   MemberClass: { title: (rec) => `title:${rec.title}` },
+  Account: {
+    name: (rec) => `name:${rec.name}`
+  },
+  SubAccount: {
+    name: (rec) => `name:${rec.name}`
+  },
   AccountClass: {
     major: (rec) => `major:${rec.major}`,
     middle: (rec) => `middle:${rec.middle}`,

--- a/routes/api_account.js
+++ b/routes/api_account.js
@@ -102,22 +102,26 @@ export default {
     });
   },
   all: (req, res, next) => {
-    Accounts.all(req.currentTenantId).then((lines) => {
+    const lp = req.query.languagePair ? JSON.parse(req.query.languagePair) : req.session?.languagePair;
+    Accounts.all(req.currentTenantId, lp).then((lines) => {
       res.json(lines);
     });
   },
   all2: async (req, res, next) => {
-    Accounts.all2(req.currentTenantId, req.params.term).then((lines) => {
+    const lp = req.query.languagePair ? JSON.parse(req.query.languagePair) : req.session?.languagePair;
+    Accounts.all2(req.currentTenantId, req.params.term, lp).then((lines) => {
       res.json(lines);
     });
   },
   all3: async (req, res, next) => {
-    Accounts.all3(req.currentTenantId, req.params.term).then((lines) => {
+    const lp = req.query.languagePair ? JSON.parse(req.query.languagePair) : req.session?.languagePair;
+    Accounts.all3(req.currentTenantId, req.params.term, lp).then((lines) => {
       res.json(lines);
     });
   },
   all4: async (req, res, next) => {
-    Accounts.all4(req.currentTenantId, req.params.term).then((lines) => {
+    const lp = req.query.languagePair ? JSON.parse(req.query.languagePair) : req.session?.languagePair;
+    Accounts.all4(req.currentTenantId, req.params.term, lp).then((lines) => {
       res.json(lines);
     });
   }


### PR DESCRIPTION
Part of epic:bilingual-foundation

## What
Wire enrichBilingual through the Account API stack so AccountSelect + SubAccountSelect dropdown items show primary (ja) + secondary (vi) instead of raw account.name.

## Commits
- 7d5c941 fix(#131): ledger AccountSelect dropdown items now bilingual

## Files (6)
- libs/bilingual-helper.js — add Account + SubAccount to TRANSLATION_MAP
- libs/accounts.js — all/all2/all3/all4 accept languagePair, call enrichBilingual
- routes/api_account.js — pass req.query.languagePair / req.session?.languagePair to Accounts.all*
- front/svelte/components/account-select.svelte — render BilingualText for category title + items
- front/svelte/components/subaccount-select.svelte — render BilingualText for sub items
- front/svelte/ledger/ledger.svelte — fields[] carry both title (ja) + titleVi (vi)

## Seed reuse
Translation key pattern `name:<account.name>` reuses existing seed data in migrations/20260602020000-seed-bilingual-translations.cjs (AccountClass minor map already has all common account names like 現金/預金/売掛金/買掛金 etc.). No new seed migration required for common accounts. Custom account names not in seed will gracefully fall back to ja-only.

## Test
- npm run build: pass (27.48s, exit 0) — ✅
- npm test: 33 passing / 13 failing (same pre-existing Postgres signupAndLogin blocker, unrelated)

## Caveat
13 test failures are environmental (Postgres sa auth not configured locally, same blocker as #116 / #130). No failure touches BilingualText, libs/accounts.js, libs/bilingual-helper.js, or routes/api_account.js.

## Closes
Closes #131