### PR TITLE
fix(#134): ledger page-title spacing — add margin-top, widen margin-bottom

### DIFF
--- a/front/svelte/ledger/ledger.svelte
+++ b/front/svelte/ledger/ledger.svelte
@@ -99,7 +99,8 @@
   line-height: 1.3;
 }
 .page-title {
-  margin-bottom: 0.75rem;
+  margin-top: 0.75rem;
+  margin-bottom: 1rem;
 }
 </style>
 


### PR DESCRIPTION
Part of epic:bilingual-foundation

## What
`.page-title` block (H1 元帳/Ledger + Download General Ledger btn) hugs the fiscal header above and the AccountSelect dropdown row below. Add `margin-top: 0.75rem` to clear the fiscal header, bump `margin-bottom` from 0.75rem → 1rem to widen the gap with the dropdown.

## Commits
- (1) fix(#134): ledger page-title spacing — add margin-top, widen margin-bottom

## Scope
- 1 file: front/svelte/ledger/ledger.svelte (1 line added, 1 line changed in <style>)
- CSS scoped to ledger.svelte

## Test
- npm run build: pass (28.88s, exit 0) — ✅

## Refs
Pattern from journal #120 (commit fad7ea9).