### PR TITLE
fix(#136): ledger axios calls now send languagePair to backend

### DIFF
--- a/front/svelte/ledger/ledger.svelte
+++ b/front/svelte/ledger/ledger.svelte
@@ -118,7 +118,7 @@ import {setAccounts} from '../../javascripts/cross-slip';
 import parse_account_code from '../../../libs/parse_account_code';
 import {currentPage, link} from '../../javascripts/router.js';
 
-import {bi} from '../../javascripts/bilingual.js';
+import {bi, languagePair} from '../../javascripts/bilingual.js';
 import BilingualText from '../components/bilingual-text.svelte';
 export let status;
 
@@ -171,6 +171,12 @@ const _link = (event) => {
   link(event.detail);
 }
 
+// Build `?languagePair=<json>` suffix so backend can enrich via enrichBilingual
+const lpQuery = () => {
+  const pair = $languagePair;
+  return `?languagePair=${encodeURIComponent(JSON.stringify(pair))}`;
+}
+
 const accountSelect = (code) => {
   let href;
   if  ( code.sub )  {
@@ -184,7 +190,7 @@ const accountSelect = (code) => {
 }
 
 const update = async (list) => {
-  let result = await axios.get(`/api/account/${accountCode}`);
+  let result = await axios.get(`/api/account/${accountCode}${lpQuery()}`);
   account = result.data;
   console.log('update', account);
   //console.log('account', account);
@@ -213,7 +219,7 @@ const checkPage = () => {
 }
 
 onMount(() => {
-  axios.get(`/api/accounts`).then((res) => {
+  axios.get(`/api/accounts${lpQuery()}`).then((res) => {
     accounts = res.data;
     setAccounts(accounts);
     for ( let i = 0; i < accounts.length; i ++ ) {
@@ -274,9 +280,9 @@ const updateList = () => {
   let pr;
   if ( subAccountCode ) {
     console.log('sub');
-    pr = axios.get(`/api/ledger/${status.fy.term}/${accountCode}/${subAccountCode}`);
+    pr = axios.get(`/api/ledger/${status.fy.term}/${accountCode}/${subAccountCode}${lpQuery()}`);
   } else {
-    pr = axios.get(`/api/ledger/${status.fy.term}/${accountCode}`);
+    pr = axios.get(`/api/ledger/${status.fy.term}/${accountCode}${lpQuery()}`);
   }
   details = [];
   pr.then((result) => {


### PR DESCRIPTION
Part of epic:bilingual-foundation

## What
PR #133 wired enrichBilingual backend, but ledger.svelte wasn't passing languagePair in axios calls. Server fell back to req.session?.languagePair — empty when user navigates directly to /ledger/:code without hitting /index first (which is the only path that populates the session via /api/user/language-pair). Dropdown rendered raw account.name (Japanese only) instead of bilingual.

## Commits
- a23afe1 fix(#136): ledger axios calls now send languagePair to backend

## Files (1)
- front/svelte/ledger/ledger.svelte (+11 / -5):
  - Import { languagePair } from bilingual.js store
  - Add lpQuery() helper: builds `?languagePair=<urlencoded-json>`
  - Append lpQuery() to 4 axios calls: /api/account/:code, /api/accounts, /api/ledger/:term/:code, /api/ledger/:term/:code/:sub

## Test
- npm run build: pass (28.74s, exit 0) — ✅

## Why session fallback fails
index.svelte L189 is the only frontend path that calls /api/user/language-pair. A user opening /ledger/:code directly (e.g. deep link, refresh) skips index, so session.languagePair is undefined, and the server's `req.query.languagePair ?? req.session?.languagePair` resolves to undefined — no enrichment.

## Pattern reuse
Same lpQuery() helper can be reused on other pages that need enriched account names (journal, voucher-entry, cross-slip, etc.). Backend already supports the param.

## Closes
Closes #136