### PR TITLE
fix(#138): null guard in api_remaining, api_ledger, api_account — prevent server crash on invalid input

### DIFF
--- a/routes/api_account.js
+++ b/routes/api_account.js
@@ -21,6 +21,9 @@ export default {
         required: false
       }],
     });
+    if (!account) {
+      return res.status(404).json({ error: `Account not found: ${account_code}` });
+    }
     res.json(account);
   },
   get_class: (req, res, next) => {
@@ -73,6 +76,9 @@ export default {
         accountCode: req.body.code
       }
     });
+    if (!account) {
+      return res.status(404).json({ error: `Account not found: ${req.body.code}` });
+    }
     account.key = req.body.key;
     account.name = req.body.name;
     account.taxClass = req.body.tax_class;

--- a/routes/api_ledger.js
+++ b/routes/api_ledger.js
@@ -105,20 +105,25 @@ export const	get_details = async (fy, account, sub_account, tenantId) => {
 }
 
 export default {
-  get: (req, res, next) => {
+  get: async (req, res, next) => {
     const tenantId = req.currentTenantId;
     let term =  parseInt(req.params.term);
     let account = req.params.account;
     let sub_account = parseInt(req.params.sub_account);
-    models.FiscalYear.findOne({
-      where: {
-        tenantId,
-        term: term
+    try {
+      const fy = await models.FiscalYear.findOne({
+        where: {
+          tenantId,
+          term: term
+        }
+      });
+      if (!fy) {
+        return res.status(404).json({ error: `Fiscal year not found: term=${term}` });
       }
-    }).then((fy) => {
-      get_details(fy, account, sub_account, tenantId).then((ledger)=> {
-        res.json(ledger);
-      })
-    });
+      const ledger = await get_details(fy, account, sub_account, tenantId);
+      res.json(ledger);
+    } catch (err) {
+      next(err);
+    }
   },
 };

--- a/routes/api_remaining.js
+++ b/routes/api_remaining.js
@@ -16,6 +16,9 @@ export default {
 					['term', 'ASC']
 				]
 			});
+			if (!d) {
+				return res.status(404).json({ error: `No fiscal year found for tenant ${tenantId}` });
+			}
 			term = d.term;
 		}
 
@@ -25,6 +28,9 @@ export default {
 				accountCode: account
 			}
 		});
+		if (!account_rec) {
+			return res.status(404).json({ error: `Account not found: ${account}` });
+		}
 		if ( sub_account ) {
 			let sub_account_rec = await models.SubAccount.findOne({
 				where: {
@@ -33,17 +39,18 @@ export default {
 					subAccountCode: sub_account,
 				}
 			});
-			if	( sub_account_rec )	{
-				remaining = await models.SubAccountRemaining.findOne({
-					where: {
-						[Op.and]: {
-							tenantId,
-							term: term,
-							subAccountId: sub_account_rec.id
-						}
-					}
-				});
+			if	( !sub_account_rec )	{
+				return res.status(404).json({ error: `Sub-account not found: ${account}/${sub_account}` });
 			}
+			remaining = await models.SubAccountRemaining.findOne({
+				where: {
+					[Op.and]: {
+						tenantId,
+						term: term,
+						subAccountId: sub_account_rec.id
+					}
+				}
+			});
 		} else {
 			remaining = await models.AccountRemaining.findOne({
 				where: {


### PR DESCRIPTION
Part of epic:bilingual-foundation

Server crashed with `TypeError: Cannot read properties of null
(reading 'id')` when `/api/remaining/1/<invalid-code>` was called.
Process exit killed all in-flight requests and disconnected every
user. Repro: navigate to `/ledger/100` (accountCode 100 not in DB)
in the running app → `/api/remaining/1/100` triggers
`account_rec.id` dereference on null record → process.exit.

**Fixed (5 sites, 3 files):**

1. `routes/api_remaining.js` — 3 null guards added:
   - accountCode lookup → 404 (was: dereference → CRASH)
   - subAccountCode lookup → 404 (was: dereference → CRASH)
   - FiscalYear term=0 lookup → 404 (was: dereference → CRASH)

2. `routes/api_ledger.js` — refactored `.then()` chain to
   `async/await` with `try/catch` + 404 on FiscalYear miss

3. `routes/api_account.js` — both `get` and `update`
   endpoints return 404 on account miss (was: `res.json(null)`
   silently, crash on `.name = ...` save)

**Out of scope:**
- `routes/api_setup.js:74` has same pattern but only runs once
  during initial data setup, not part of runtime crash path.

**Verified end-to-end** via Chrome DevTools fetch on running server
after applying the fix:

| Endpoint | Status | Body |
|---|---|---|
| /api/remaining/1/999 (was 500+crash) | 404 | `{"error":"Account not found: 999"}` |
| /api/remaining/1/999/1 | 404 | same |
| /api/remaining/0/1000000 (happy) | 200 | remaining JSON |
| /api/account/999 (was null) | 404 | `{"error":"Account not found: 999"}` |
| /api/ledger/999/100 (was 500) | 404 | `{"error":"Fiscal year not found: term=999"}` |
| /api/menu (server alive?) | 200 | — |

Server stayed alive across all crash-attempt requests.

Build: 29.55s ✅ | Test: 33 pass / 13 fail (pre-existing
`database 'hieronymus_test' does not exist` blocker, not from
this change)

Fixes #138