### PR TITLE
fix(#141): use getDataValue() for enriched nameVi in libs/accounts.js

### DIFF
--- a/libs/accounts.js
+++ b/libs/accounts.js
@@ -47,7 +47,7 @@ export default class {
           sub_lines.push({
             key: sub.key,
             name: sub.name,
-            nameVi: sub.nameVi || '',
+            nameVi: sub.getDataValue('nameVi') || '',
             code: sub.subAccountCode,
             taxClass: sub.taxClass
           });
@@ -55,7 +55,7 @@ export default class {
         lines.push({
           key: acc.key,
           name: acc.name,
-          nameVi: acc.nameVi || '',
+          nameVi: acc.getDataValue('nameVi') || '',
           code: acc.accountCode,
           taxClass: acc.taxClass,
           subAccounts: sub_lines
@@ -64,7 +64,7 @@ export default class {
         lines.push({
           key: acc.key,
           name: acc.name,
-          nameVi: acc.nameVi || '',
+          nameVi: acc.getDataValue('nameVi') || '',
           code: acc.accountCode,
           taxClass: acc.taxClass
         });
@@ -115,7 +115,7 @@ export default class {
             id: suba.id,
             key: suba.key,
             name: suba.name,
-            nameVi: suba.nameVi || '',
+            nameVi: suba.getDataValue('nameVi') || '',
             code: suba.subAccountCode,
             taxClass: suba.taxClass,
             debit: rem ? rem.debit : 0,
@@ -139,7 +139,7 @@ export default class {
           minor_name: acc.accountClass.minor,
           key: acc.key,
           name: acc.name,
-          nameVi: acc.nameVi || '',
+          nameVi: acc.getDataValue('nameVi') || '',
           code: acc.accountCode,
           taxClass: acc.taxClass,
           subAccounts: sub_lines,
@@ -164,7 +164,7 @@ export default class {
           minor_name: acc.accountClass.minor,
           key: acc.key,
           name: acc.name,
-          nameVi: acc.nameVi || '',
+          nameVi: acc.getDataValue('nameVi') || '',
           code: acc.accountCode,
           taxClass: acc.taxClass,
           debit: rem ? rem.debit : 0,
@@ -265,7 +265,7 @@ export default class {
               id: suba.id,
               key: suba.key,
               name: suba.name,
-              nameVi: suba.nameVi || '',
+              nameVi: suba.getDataValue('nameVi') || '',
               code: suba.subAccountCode,
               taxClass: suba.taxClass,
               ...subRem
@@ -277,7 +277,7 @@ export default class {
             id: acc.id,
             key: acc.key,
             name: acc.name,
-            nameVi: acc.nameVi || '',
+            nameVi: acc.getDataValue('nameVi') || '',
             code: acc.accountCode,
             taxClass: acc.taxClass,
             subAccounts: sub_lines,
@@ -289,7 +289,7 @@ export default class {
             id: acc.id,
             key: acc.key,
             name: acc.name,
-            nameVi: acc.nameVi || '',
+            nameVi: acc.getDataValue('nameVi') || '',
             code: acc.accountCode,
             taxClass: acc.taxClass,
             ...accRem
@@ -365,7 +365,7 @@ export default class {
   id: suba.id,
   key: suba.key,
   name: suba.name,
-  nameVi: suba.nameVi || '',
+  nameVi: suba.getDataValue('nameVi') || '',
   code: suba.subAccountCode,
   taxClass: suba.taxClass,
   debit: rem ? rem.debit : 0,
@@ -391,7 +391,7 @@ export default class {
   acl_code: make_klass(acl.field, acl.adding),
   key: acc.key,
   name: acc.name,
-  nameVi: acc.nameVi || '',
+  nameVi: acc.getDataValue('nameVi') || '',
   code: acc.accountCode,
   taxClass: acc.taxClass,
   subAccounts: sub_lines,
@@ -418,7 +418,7 @@ export default class {
   acl_code: make_klass(acl.field, acl.adding),
   key: acc.key,
   name: acc.name,
-  nameVi: acc.nameVi || '',
+  nameVi: acc.getDataValue('nameVi') || '',
   code: acc.accountCode,
   taxClass: acc.taxClass,
   debit: rem ? rem.debit : 0,


### PR DESCRIPTION
Part of epic:bilingual-foundation

PR #133 added enrichBilingual('Account', ...) which calls
`rec.setDataValue('nameVi', translated)`. However libs/accounts.js
read the value back via `acc.nameVi` — but `nameVi` is NOT a declared
field on the Account/SubAccount Sequelize models, so the property
accessor returns undefined and falls back to `''`.

This caused the API to silently return `nameVi: ""` for every account
even when translation rows existed in the Translations table.

**Fixed 12 sites** in `libs/accounts.js` (all/all2/all3/all4):
- `acc.nameVi` → `acc.getDataValue('nameVi')`  (8 sites)
- `suba.nameVi` → `suba.getDataValue('nameVi')` (3 sites)
- `sub.nameVi` → `sub.getDataValue('nameVi')`  (1 site)

**Verified end-to-end** with languagePair=ja/vi:

| Account code | name | nameVi |
|---|---|---|
| 100 | 現金 | Tiền mặt |
| 89910 | 受取利息 | Lãi tiền gửi |
| 89911 | 受取配当金 | Cổ tức nhận được |
| 89912 | 雑収入 | Thu nhập khác |
| 89913 | 支払利息 | Chi phí lãi vay |
| 89914 | 特別利益 | Lợi nhuận bất thường |

6/6 test accounts return `nameVi` correctly — includes all 5 names
from the original screenshot dropdown 営業外.

**Build:** 27.15s ✅
**Test:** 33 pass / 13 fail (pre-existing hieronymus_test DB blocker,
no regression)

Fixes #141