### PR TITLE
fix(#147): bank-ledger title overlap and account dropdown shows raw key

### DIFF
--- a/front/svelte/bank-ledger/bank-ledger.svelte
+++ b/front/svelte/bank-ledger/bank-ledger.svelte
@@ -1,28 +1,28 @@
 <div class="list">
   <div class="page-title d-flex justify-content-between">
-    <h1><BilingualText key="bank_ledger" /></h1>
+    <h1 class="page-title-bilingual"><BilingualText key="bank_ledger" inline={true} /></h1>
   </div>
   <ul class="page-subtitle d-flex justify-content-between">
     <div class="nav">
     <li class="nav-item dropdown">
       <button type="button"
-        class="btn nav-link dropdown-toggle"
+        class="btn nav-link dropdown-toggle account-dropdown-toggle"
         style="background-color:var(--bs-primary);color:white;"
-        rolw="button" data-bs-toggle="dropdown" aria-expanded="false">
+        role="button" data-bs-toggle="dropdown" aria-expanded="false">
         {#if accountCode}
-        {$bi(BANK_ACCOUNTS.find((el) => el[0] == accountCode)[1])}
+        <BilingualText key={BANK_ACCOUNTS.find((el) => el[0] == accountCode)[1]} inline={true} />
         {:else}
-        <BilingualText key="account" />
+        <BilingualText key="account" inline={true} />
         {/if}
       </button>
       <ul class="dropdown-menu" aria-labelledby="field">
         {#each BANK_ACCOUNTS as account}
         <li>
-          <button type="button" class="btn btn-link dropdown-item"
+          <button type="button" class="btn btn-link dropdown-item account-dropdown-item"
             on:click={() => {
               openAccount(account[0])}
             }>
-            {account[1]}
+            <BilingualText primary={account[1]} inline={true} />
           </button>
         </li>
         {/each}
@@ -161,6 +161,37 @@
 {/if}
   
 <style>
+/* Bilingual H1 + buttons need more height than the global
+   `.page-title { height: 50px }` to avoid the H1 overflowing
+   into the `.page-subtitle` row (which contains the account
+   dropdown — see issue #147). */
+.page-title {
+  height: auto;
+  min-height: 50px;
+  flex-wrap: wrap;
+  row-gap: 0.25rem;
+}
+.page-title-bilingual {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.3;
+  margin: 4px 0;
+}
+.account-dropdown-toggle,
+.account-dropdown-item {
+  min-height: 44px;
+  line-height: 1.2;
+  white-space: normal;
+  padding: 0.25rem 0.6rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.account-dropdown-item {
+  width: 100%;
+  text-align: left;
+  text-decoration: none;
+}
 </style>
 
 <script>
@@ -169,7 +200,6 @@ import {onMount, afterUpdate} from 'svelte';
 import {ledgerLines} from '../../../libs/ledger';
 import {setAccounts} from '../../javascripts/cross-slip';
 import CrossSlipModal from '../cross-slip/cross-slip-modal.svelte';
-import { bi } from '../../javascripts/bilingual.js';
 import BilingualText from '../components/bilingual-text.svelte';
 import {DateString} from '../../../libs/utils.js';
 import {currentPage} from '../../javascripts/router.js';


### PR DESCRIPTION
## Summary

Fixes #147 — the `/bank-ledger` page had two visible bugs:

1. **H1 "銀行元帳 / Sổ tiền gửi ngân hàng" was overlapped** by the
   `科目 / Tài khoản` account dropdown directly below it. Root cause:
   the global `.page-title { height: 50px }` rule in `style.scss`
   is too short for a 2-line bilingual H1, so the second line spilled
   down into `.page-subtitle`.
2. **Account dropdown items rendered the raw translation key**
   (`bank_checking_dep`, `bank_savings_dep`, `bank_time_dep`,
   `bank_fixed_dep`) instead of the resolved bilingual label
   (`当座預金 / Tiền vãng lai`, ...).

## Changes

`front/svelte/bank-ledger/bank-ledger.svelte`:

- H1: add `class="page-title-bilingual"` + `inline={true}` so the
  2-line label sits inside the H1 instead of overflowing it.
- Trigger button: replace `{$bi(BANK_ACCOUNTS.find(...)[1])}` with
  `<BilingualText key={...} inline={true} />`, matching the
  `inline-flex` button pattern from `account-select.svelte` /
  `journal.svelte` (issues #118 / #126).
- Dropdown items: replace raw `{account[1]}` with
  `<BilingualText primary={account[1]} inline={true} />` so the
  locale dictionaries resolve the key into a bilingual label.
  (All 4 keys are present in `ja.json`, `vi.json`, `en.json`.)
- Drive-by: `rolw` typo -> `role`; remove now-unused `bi` import.
- New scoped style: override `.page-title` height (auto / min 50px),
  add `.page-title-bilingual`, `.account-dropdown-toggle`,
  `.account-dropdown-item` with `min-height`, `inline-flex`,
  `gap` so the 2-line bilingual labels render cleanly.

## Test Report

- **Scope:** /bank-ledger page (UI-only change)
- **`npm run build`:** ✅ pass (1703 modules transformed, 28.57s)
- **`npm test`:** 13 pre-existing failures (multi-tenant signup
  flow returning `"result":"NG"`). Verified unrelated by stashing
  the change and re-running — same 33 passing / 13 failing.
  Failures are in `multitenant-foundation.test.mjs` and
  `proof-flow.test.mjs`, not in any bank-ledger code path.
- **Smoke:** `GET /bank-ledger` -> HTTP 302 redirect to `/login`
  (expected for unauthenticated request).

Part of epic:bilingual-foundation