### PR TITLE
fix(#156): changes/ledger chart dropdowns show raw keys

### DIFF
--- a/front/svelte/changes/changes.svelte
+++ b/front/svelte/changes/changes.svelte
@@ -121,22 +121,22 @@ let subAccountCode;
 
 let fields = [
   {
-    title: 'chart_assets',
+    titleKey: 'chart_assets',
     accounts: []
   },{
-    title: 'chart_liabilities',
+    titleKey: 'chart_liabilities',
     accounts: []
   },{
-    title: 'chart_net_assets',
+    titleKey: 'chart_net_assets',
     accounts: []
   },{
-    title: 'chart_revenue',
+    titleKey: 'chart_revenue',
     accounts: []
   },{
-    title: 'chart_cost_of_sales',
+    titleKey: 'chart_cost_of_sales',
     accounts: []
   },{
-    title: 'chart_non_operating',
+    titleKey: 'chart_non_operating',
     accounts: []
   }
 ];

--- a/front/svelte/components/account-select.svelte
+++ b/front/svelte/components/account-select.svelte
@@ -5,7 +5,7 @@
       id="field_{index}"
       rolw="button"
       data-bs-toggle="dropdown" aria-expanded="false">
-      <BilingualText primary={field.title} secondary={field.titleVi} inline={true} />
+      <BilingualText key={field.titleKey} inline={true} />
     </button>
     <ul class="dropdown-menu" aria-labelledby="field_{index}">
       {#each field.accounts as account}

--- a/front/svelte/ledger/ledger.svelte
+++ b/front/svelte/ledger/ledger.svelte
@@ -138,28 +138,22 @@ let sums;
 let lines;
 let fields = [
   {
-    title: '資産',
-    titleVi: 'Tài sản',
+    titleKey: 'chart_assets',
     accounts: []
   },{
-    title: '負債',
-    titleVi: 'Nợ phải trả',
+    titleKey: 'chart_liabilities',
     accounts: []
   },{
-    title: '純資産',
-    titleVi: 'Vốn chủ sở hữu',
+    titleKey: 'chart_net_assets',
     accounts: []
   },{
-    title: '売上高',
-    titleVi: 'Doanh thu',
+    titleKey: 'chart_revenue',
     accounts: []
   },{
-    title: '売上原価',
-    titleVi: 'Giá vốn',
+    titleKey: 'chart_cost_of_sales',
     accounts: []
   },{
-    title: '営業外',
-    titleVi: 'Ngoài HĐKD',
+    titleKey: 'chart_non_operating',
     accounts: []
   }
 ];


### PR DESCRIPTION
Part of epic:bilingual-foundation.

Changes-page field dropdowns rendered raw dictionary keys (`chart_assets`, `chart_liabilities`…) instead of translated bilingual labels.

Root cause: `account-select.svelte` rendered `field.title` as a BilingualText `primary` override, bypassing dictionary lookup. `changes.svelte` passed raw `chart_*` keys with no `titleVi`, so literal keys rendered. (`ledger.svelte`, the other caller, passed pre-resolved strings.)

Fix: switch the shared component to `key={field.titleKey}` (dictionary lookup, reactive) and migrate both callers (changes + ledger) to `titleKey`. Single resolution path, no fallback branch.

### Test Report
- `npm run build` ✅ (exit 0)
- `npm test` — proof-flow 8 passing in isolation on base + fix branch; full-suite signup failures are pre-existing DB-state contamination, unrelated to this frontend change