### PR TITLE
fix(#158): changes header — inline title, spacing above dropdowns

### DIFF
--- a/front/svelte/changes/changes.svelte
+++ b/front/svelte/changes/changes.svelte
@@ -1,6 +1,6 @@
-<div class="page-title d-flex justify-content-between align-items-center mt-2">
+<div class="page-title d-flex justify-content-between align-items-center">
   <div class="d-flex align-items-center">
-    <h1><BilingualText key="changes" /></h1>
+    <h1 class="page-title-bilingual mb-0"><BilingualText key="changes" inline={true} /></h1>
     {#if account}
       <h2 class="ms-3 mb-0 fs-4">{account.name}</h2>
     {/if}
@@ -65,6 +65,15 @@
     lines={lines}/>
 </div>
 <style>
+.page-title-bilingual {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.3;
+}
+.page-title {
+  margin-top: 0.75rem;
+  margin-bottom: 1rem;
+}
 </style>
 
 <script>


### PR DESCRIPTION
Part of epic:bilingual-foundation. Closes #158 on epic merge.

Changes-page header was misaligned: the title rendered as a *stacked* BilingualText (no inline), so the `<h1>` box was as wide as the longer Vietnamese line (`Biểu đồ xu hướng`), pushing the selected account name (`売上高`) far right. The header also had no margin-bottom, so the account name sat flush against the field dropdown row.

Fix matches the canonical ledger/trial-balance pattern: `inline={true}` title with `.page-title-bilingual`, plus `.page-title` margin-top/bottom.

Build: `npm run build` ✅ (exit 0).