### PR TITLE
fix(#160): reduce change-list height calc from 960px to 480px

### DIFF
--- a/front/stylesheets/style.css
+++ b/front/stylesheets/style.css
@@ -135,7 +135,7 @@ body {
 }
 
 .change-list {
-  height: calc(100vh - 960px);
+  height: calc(100vh - 480px);
   overflow-y: auto;
 }
 

--- a/front/stylesheets/style.scss
+++ b/front/stylesheets/style.scss
@@ -126,7 +126,7 @@ body {
   overflow-y: auto;
 }
 .change-list {
-  height: calc(100vh - 960px);
+  height: calc(100vh - 480px);
   overflow-y: auto;
 }
 


### PR DESCRIPTION
Part of epic:bilingual-foundation. Closes #160 on epic merge.

Changes-page table height used `calc(100vh - 960px)` — on a 1080p screen the table got only ~120px, leaving a large empty gap between dropdowns and the table. Reduced to 480px.

`npm run build` ✅ (exit 0).