### PR TITLE
fix(#162): change-list height→max-height, no empty space with few rows

### DIFF
--- a/front/stylesheets/style.css
+++ b/front/stylesheets/style.css
@@ -135,7 +135,7 @@ body {
 }
 
 .change-list {
-  height: calc(100vh - 480px);
+  max-height: calc(100vh - 480px);
   overflow-y: auto;
 }
 

--- a/front/stylesheets/style.scss
+++ b/front/stylesheets/style.scss
@@ -126,7 +126,7 @@ body {
   overflow-y: auto;
 }
 .change-list {
-  height: calc(100vh - 480px);
+  max-height: calc(100vh - 480px);
   overflow-y: auto;
 }
 


### PR DESCRIPTION
Part of epic:bilingual-foundation. Closes #162 on epic merge.

Changes-page table used `height: calc(100vh - 480px)` — with few rows,\nthe extra space appeared as dead gap between dropdowns and content.\n\nFix: `max-height` keeps the scroll behavior when content overflows\nbut lets the table be naturally sized when it's small.\n\n`npm run build` ✅ (exit 0). Chrome DevTools confirmed max-height applied.