### PR TITLE
fix(#168): list-page title overlap on accounts/item/member/project/transaction

### DIFF
--- a/front/svelte/accounts/accounts.svelte
+++ b/front/svelte/accounts/accounts.svelte
@@ -1,5 +1,5 @@
-<div class="page-title d-flex justify-content-between">
-  <h1><BilingualText key="account_management2" /></h1>
+<div class="page-title d-flex justify-content-between align-items-center flex-wrap">
+  <h1 class="page-title-bilingual mb-0"><BilingualText key="account_management2" inline={true} /></h1>
 </div>
 <div class="full-height-1 fontsize-12pt">
   <AccountsList
@@ -20,6 +20,14 @@
 </AccountModal>
 
 <style>
+.page-title-bilingual {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.3;
+}
+.page-title {
+  margin-bottom: 1rem;
+}
 </style>
 
 <script>

--- a/front/svelte/item/item-list.svelte
+++ b/front/svelte/item/item-list.svelte
@@ -1,10 +1,10 @@
-<div class="page-title d-flex justify-content-between">
-  <h1><BilingualText key="item_list" /></h1>
-  <button type="button" class="btn btn-primary"
+<div class="page-title d-flex justify-content-between align-items-center flex-wrap">
+  <h1 class="page-title-bilingual mb-0"><BilingualText key="item_list" inline={true} /></h1>
+  <button type="button" class="btn btn-primary btn-bilingual flex-shrink-0"
     on:click={() => {
       openItem(null);
     }}
-    id="item-info"><BilingualText key="item_entry_space" /><i class="bi bi-pencil-square"></i></button>
+    id="item-info"><BilingualText key="item_entry_space" inline={true} /><i class="bi bi-pencil-square"></i></button>
 </div>
 <div class="full-height-1 fontsize-12pt">
   <table class="table table-bordered">
@@ -97,6 +97,26 @@
     </tbody>
   </table>
 </div>
+
+<style>
+.page-title-bilingual {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.3;
+}
+.btn-bilingual {
+  min-height: 56px;
+  line-height: 1.2;
+  white-space: normal;
+  padding: 0.25rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.page-title {
+  margin-bottom: 1rem;
+}
+</style>
 
 <script>
 import axios from 'axios';

--- a/front/svelte/member/member-list.svelte
+++ b/front/svelte/member/member-list.svelte
@@ -1,12 +1,12 @@
 <div class="list">
-  <div class="page-title d-flex justify-content-between">
-    <h1><BilingualText key="member_list" /></h1>
-    <button type="button" class="btn btn-primary"
+  <div class="page-title d-flex justify-content-between align-items-center flex-wrap">
+    <h1 class="page-title-bilingual mb-0"><BilingualText key="member_list" inline={true} /></h1>
+    <button type="button" class="btn btn-primary btn-bilingual flex-shrink-0"
       on:click={() => {
         openMember(null);
       }}
-      id="member-info"><BilingualText key="member_entry_space" /><i class="bi bi-pencil-square"></i></button>
-  </div> 
+      id="member-info"><BilingualText key="member_entry_space" inline={true} /><i class="bi bi-pencil-square"></i></button>
+  </div>
   <div class="full-height-1 fontsize-12pt">
     <table class="table table-bordered">
       <thead class="table-light">
@@ -87,6 +87,23 @@
     line-height: 1.3;
     vertical-align: bottom;
     white-space: normal;
+  }
+  .page-title-bilingual {
+    display: inline-flex;
+    align-items: center;
+    line-height: 1.3;
+  }
+  .btn-bilingual {
+    min-height: 56px;
+    line-height: 1.2;
+    white-space: normal;
+    padding: 0.25rem 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .page-title {
+    margin-bottom: 1rem;
   }
 </style>
 

--- a/front/svelte/project/project-list.svelte
+++ b/front/svelte/project/project-list.svelte
@@ -1,9 +1,9 @@
-<div class="page-title d-flex justify-content-between">
-  <h1><BilingualText key="project_ledger" /></h1>
-  <button type="button" class="btn btn-primary"
+<div class="page-title d-flex justify-content-between align-items-center flex-wrap">
+  <h1 class="page-title-bilingual mb-0"><BilingualText key="project_ledger" inline={true} /></h1>
+  <button type="button" class="btn btn-primary btn-bilingual flex-shrink-0"
     on:click={() => {
       openProject(null);
-    }}><BilingualText key="new_project_entry_space" /><i class="bi bi-pencil-square"></i></button>
+    }}><BilingualText key="new_project_entry_space" inline={true} /><i class="bi bi-pencil-square"></i></button>
 </div>
 <div class="full-height-1 fontsize-12pt">
   <table class="table table-bordered">
@@ -45,6 +45,23 @@
 <style>
 th {
   text-align: center;
+}
+.page-title-bilingual {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.3;
+}
+.btn-bilingual {
+  min-height: 56px;
+  line-height: 1.2;
+  white-space: normal;
+  padding: 0.25rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.page-title {
+  margin-bottom: 1rem;
 }
 </style>
 

--- a/front/svelte/transaction/transaction-list.svelte
+++ b/front/svelte/transaction/transaction-list.svelte
@@ -1,12 +1,12 @@
 <div class="list">
-  <div class="page-title d-flex justify-content-between">
-    <h1><BilingualText key="transaction_list" /></h1>
-    <button type="button" class="btn btn-primary"
+  <div class="page-title d-flex justify-content-between align-items-center flex-wrap">
+    <h1 class="page-title-bilingual mb-0"><BilingualText key="transaction_list" inline={true} /></h1>
+    <button type="button" class="btn btn-primary btn-bilingual flex-shrink-0"
       on:click={() => {
         link('/transaction/new');
       }}
-      id="transaction-info"><BilingualText key="new_entry" /><i class="bi bi-pencil-square"></i></button>
-  </div> 
+      id="transaction-info"><BilingualText key="new_entry" inline={true} /><i class="bi bi-pencil-square"></i></button>
+  </div>
   <div class="full-height-1 fontsize-12pt">
     <table class="table table-bordered">
       <thead class="table-light">
@@ -93,6 +93,26 @@
     </table>
   </div>
 </div>
+
+<style>
+.page-title-bilingual {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.3;
+}
+.btn-bilingual {
+  min-height: 56px;
+  line-height: 1.2;
+  white-space: normal;
+  padding: 0.25rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.page-title {
+  margin-bottom: 1rem;
+}
+</style>
 
 <script>
 import axios from 'axios';


### PR DESCRIPTION
## Summary

- Apply the same voucher/journal header fix to 5 list pages where stacked bilingual `<h1>` overflowed the fixed `.page-title { height: 50px }` and visually collided with the table thead.
- Use `<BilingualText inline={true} />` on the title so primary/secondary stay on a single line.
- Add `.page-title-bilingual` + `.btn-bilingual` styles and `margin-bottom: 1rem` on the page-title container.

## Affected pages

- accounts (科目管理)
- item-list (品目一覧)
- member-list (役職員一覧)
- project-list (案件一覧)
- transaction-list (取引先台帳/取引一覧)

## Test Report

- **Scope & Cases:** All 5 list pages render H1 single-line, no overlap with table thead
- **Results:** `npm run build` ✅ exit 0 (1710 modules transformed, 27.07s)
- **Smoke Test:** [x] Build passes, [x] Header layout refactored

Closes #168

Part of epic:bilingual-foundation