### PR TITLE
fix(#170): list-page title overlap + uneven header spacing

### DIFF
--- a/front/stylesheets/style.css
+++ b/front/stylesheets/style.css
@@ -225,7 +225,7 @@ ul.nav {
 }
 
 .page-title {
-  height: 50px;
+  min-height: 50px;
 }
 .page-title h1 {
   font-size: 1.75rem;

--- a/front/svelte/accounts/accounts.svelte
+++ b/front/svelte/accounts/accounts.svelte
@@ -1,13 +1,15 @@
-<div class="page-title d-flex justify-content-between align-items-center flex-wrap">
-  <h1 class="page-title-bilingual mb-0"><BilingualText key="account_management2" inline={true} /></h1>
-</div>
-<div class="full-height-1 fontsize-12pt">
-  <AccountsList
-    status={status}
-    lines={lines}
-    accounts={accounts}
-    on:open={openAccount}>
-  </AccountsList>
+<div class="list">
+  <div class="page-title d-flex justify-content-between align-items-center flex-wrap">
+    <h1 class="page-title-bilingual mb-0"><BilingualText key="account_management2" inline={true} /></h1>
+  </div>
+  <div class="full-height-1 fontsize-12pt">
+    <AccountsList
+      status={status}
+      lines={lines}
+      accounts={accounts}
+      on:open={openAccount}>
+    </AccountsList>
+  </div>
 </div>
 
 <AccountModal

--- a/front/svelte/company/company-list.svelte
+++ b/front/svelte/company/company-list.svelte
@@ -1,12 +1,13 @@
-<div class="page-title d-flex justify-content-between">
-  <h1><BilingualText key="company_ledger" /></h1>
-  <button type="button" class="btn btn-primary"
-    on:click={() => {
-      openCompany(null);
-    }}><BilingualText key="company_entry_space" /><i class="bi bi-pencil-square"></i></button>
-</div>
-<div class="full-height-1 fontsize-12pt">
-  <table class="table table-bordered">
+<div class="list">
+  <div class="page-title d-flex justify-content-between align-items-center flex-wrap">
+    <h1 class="page-title-bilingual mb-0"><BilingualText key="company_ledger" inline={true} /></h1>
+    <button type="button" class="btn btn-primary btn-bilingual flex-shrink-0"
+      on:click={() => {
+        openCompany(null);
+      }}><BilingualText key="company_entry_space" inline={true} /><i class="bi bi-pencil-square"></i></button>
+  </div>
+  <div class="full-height-1 fontsize-12pt">
+    <table class="table table-bordered">
     <thead class="table-light">
       <tr>
         <th scope="col" style="width: 200px;"><BilingualText key="name" /></th>
@@ -75,10 +76,28 @@
       {/each}
     </tbody>
   </table>
+  </div>
 </div>
 <style>
 th {
   text-align: center;
+}
+.page-title-bilingual {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.3;
+}
+.btn-bilingual {
+  min-height: 56px;
+  line-height: 1.2;
+  white-space: normal;
+  padding: 0.25rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.page-title {
+  margin-bottom: 1rem;
 }
 </style>
 

--- a/front/svelte/item/item-list.svelte
+++ b/front/svelte/item/item-list.svelte
@@ -1,13 +1,14 @@
-<div class="page-title d-flex justify-content-between align-items-center flex-wrap">
-  <h1 class="page-title-bilingual mb-0"><BilingualText key="item_list" inline={true} /></h1>
-  <button type="button" class="btn btn-primary btn-bilingual flex-shrink-0"
-    on:click={() => {
-      openItem(null);
-    }}
-    id="item-info"><BilingualText key="item_entry_space" inline={true} /><i class="bi bi-pencil-square"></i></button>
-</div>
-<div class="full-height-1 fontsize-12pt">
-  <table class="table table-bordered">
+<div class="list">
+  <div class="page-title d-flex justify-content-between align-items-center flex-wrap">
+    <h1 class="page-title-bilingual mb-0"><BilingualText key="item_list" inline={true} /></h1>
+    <button type="button" class="btn btn-primary btn-bilingual flex-shrink-0"
+      on:click={() => {
+        openItem(null);
+      }}
+      id="item-info"><BilingualText key="item_entry_space" inline={true} /><i class="bi bi-pencil-square"></i></button>
+  </div>
+  <div class="full-height-1 fontsize-12pt">
+    <table class="table table-bordered">
     <thead class="table-light">
       <tr>
         <th scope="col" style="width: 150px;"><BilingualText key="class_name" /></th>
@@ -96,6 +97,7 @@
       {/each}
     </tbody>
   </table>
+  </div>
 </div>
 
 <style>

--- a/front/svelte/project/project-list.svelte
+++ b/front/svelte/project/project-list.svelte
@@ -1,12 +1,13 @@
-<div class="page-title d-flex justify-content-between align-items-center flex-wrap">
-  <h1 class="page-title-bilingual mb-0"><BilingualText key="project_ledger" inline={true} /></h1>
-  <button type="button" class="btn btn-primary btn-bilingual flex-shrink-0"
-    on:click={() => {
-      openProject(null);
-    }}><BilingualText key="new_project_entry_space" inline={true} /><i class="bi bi-pencil-square"></i></button>
-</div>
-<div class="full-height-1 fontsize-12pt">
-  <table class="table table-bordered">
+<div class="list">
+  <div class="page-title d-flex justify-content-between align-items-center flex-wrap">
+    <h1 class="page-title-bilingual mb-0"><BilingualText key="project_ledger" inline={true} /></h1>
+    <button type="button" class="btn btn-primary btn-bilingual flex-shrink-0"
+      on:click={() => {
+        openProject(null);
+      }}><BilingualText key="new_project_entry_space" inline={true} /><i class="bi bi-pencil-square"></i></button>
+  </div>
+  <div class="full-height-1 fontsize-12pt">
+    <table class="table table-bordered">
     <thead class="table-light">
       <tr>
         <th scope="col" style="width: 200px;"><BilingualText key="project_name_dup" /></th>
@@ -41,6 +42,7 @@
       {/each}
     </tbody>
   </table>
+  </div>
 </div>
 <style>
 th {

--- a/front/svelte/task/task-list.svelte
+++ b/front/svelte/task/task-list.svelte
@@ -1,11 +1,11 @@
 <div class="list">
-  <div class="page-title d-flex justify-content-between">
-    <h1 class="fs-3"><BilingualText key="project_list" /></h1>
-    <button type="button" class="btn btn-primary"
+  <div class="page-title d-flex justify-content-between align-items-center flex-wrap">
+    <h1 class="page-title-bilingual mb-0"><BilingualText key="project_list" inline={true} /></h1>
+    <button type="button" class="btn btn-primary btn-bilingual flex-shrink-0"
     on:click={() => {
       link('/task/new');
     }}
-    id="task-info"><BilingualText key="new_entry" /><i class="bi bi-pencil-square"></i></button>
+    id="task-info"><BilingualText key="new_entry" inline={true} /><i class="bi bi-pencil-square"></i></button>
   </div>
   <div class="full-height-1 fontsize-12pt">
     <table class="table table-bordered">
@@ -77,6 +77,26 @@
     </table>
   </div>
 </div>
+
+<style>
+.page-title-bilingual {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.3;
+}
+.btn-bilingual {
+  min-height: 56px;
+  line-height: 1.2;
+  white-space: normal;
+  padding: 0.25rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.page-title {
+  margin-bottom: 1rem;
+}
+</style>
 
 <script>
 import axios from 'axios';


### PR DESCRIPTION
Part of epic:bilingual-foundation. Supersedes the insufficient fixes in #166/#168.

## What
- **Title overlap:** `.page-title` `height: 50px` → `min-height: 50px`. The 2-line bilingual title (~66px) was clipped by the fixed height and bled onto the table/month-selector. `inline={true}` (added in #166/#168) only toggles inline-flex vs flex — it does not collapse the lines, so the overlap survived. Titles stay 2-line (primary top, secondary bottom).
- **Uneven header→title spacing:** wrapped accounts/company/item/project in `<div class="list">` so all 8 list pages share `.list { padding-top: 20px }` (previously bare `.page-title` pages had 0px gap).
- **company/task:** never touched by #166/#168 — brought up to the shared `inline` + `page-title-bilingual`/`btn-bilingual` pattern.

## Files
`front/stylesheets/style.css`, `accounts/accounts.svelte`, `company/company-list.svelte`, `item/item-list.svelte`, `project/project-list.svelte`, `task/task-list.svelte`

## Test
- `npm run build` ✅ (no errors)
- Visual smoke test ✅ — reviewer confirmed titles no longer overlap, header→title gap even across all pages, 2-line bilingual titles consistent.