### PR TITLE
fix(#172): journal form — overflow, date picker, bilingual contrast, outside-click close

### DIFF
--- a/front/stylesheets/style.css
+++ b/front/stylesheets/style.css
@@ -44,20 +44,16 @@
   color: var(--bs-table-color) !important;
 }
 
-/* BilingualText — secondary line color is context-aware.
-   Default (light bg): #666 stays subordinate. On dark teal surfaces
-   (sidebar, table th), lighten to maintain ≥4.5:1 contrast on #264653. */
+/* BilingualText — secondary line tracks its parent's text color via
+   `inherit` + reduced opacity. This keeps it subordinate yet legible on
+   ANY surface: dark text on light backgrounds, light text on dark
+   surfaces (sidebar, table th, colored buttons). No per-surface overrides
+   needed — the secondary line always matches whatever color the parent
+   element uses. */
 .bilingual-secondary,
 .bilingual-sep {
-  color: #666;
-}
-.sidebar .bilingual-secondary,
-.sidebar .bilingual-sep {
-  color: #b8c5ca;
-}
-.table th .bilingual-secondary,
-.table th .bilingual-sep {
-  color: #cfe2e8;
+  color: inherit;
+  opacity: 0.7;
 }
 
 /* User menu avatar — circular placeholder showing first letter of user name.

--- a/front/stylesheets/style.scss
+++ b/front/stylesheets/style.scss
@@ -44,20 +44,16 @@
   }
 }
 
-/* BilingualText — secondary line color is context-aware.
-   Default (light bg): #666 stays subordinate. On dark teal surfaces
-   (sidebar, table th), lighten to maintain ≥4.5:1 contrast on #264653. */
+/* BilingualText — secondary line tracks its parent's text color via
+   `inherit` + reduced opacity. This keeps it subordinate yet legible on
+   ANY surface: dark text on light backgrounds, light text on dark
+   surfaces (sidebar, table th, colored buttons). No per-surface overrides
+   needed — the secondary line always matches whatever color the parent
+   element uses. */
 .bilingual-secondary,
 .bilingual-sep {
-  color: #666;
-}
-.sidebar .bilingual-secondary,
-.sidebar .bilingual-sep {
-  color: #b8c5ca;
-}
-.table th .bilingual-secondary,
-.table th .bilingual-sep {
-  color: #cfe2e8;
+  color: inherit;
+  opacity: 0.7;
 }
 
 /* User menu avatar — circular placeholder showing first letter of user name.

--- a/front/svelte/accounts/account-modal.svelte
+++ b/front/svelte/accounts/account-modal.svelte
@@ -1,4 +1,4 @@
-<div class="modal" id="account-modal" tabindex="-1" data-bs-backdrop="static">
+<div class="modal" id="account-modal" tabindex="-1">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">

--- a/front/svelte/common/profile-modal.svelte
+++ b/front/svelte/common/profile-modal.svelte
@@ -1,4 +1,4 @@
-<div class="modal" bind:this={modalEl} tabindex="-1" data-bs-backdrop="static">
+<div class="modal" bind:this={modalEl} tabindex="-1">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/front/svelte/cross-slip/cross-slip-modal.svelte
+++ b/front/svelte/cross-slip/cross-slip-modal.svelte
@@ -1,4 +1,4 @@
-<div class="modal" id={ id ? id : "cross-slip-modal"} tabindex="-1" data-bs-backdrop="static">
+<div class="modal" id={ id ? id : "cross-slip-modal"} tabindex="-1">
   <div class="modal-dialog modal-xl">
     <div class="modal-content">
       <div class="modal-header">
@@ -123,19 +123,26 @@ export let popUp;
 export let id;
 
 let modal;
+let modalEl;
+let disposed = false;
 let vouchers;
 let ok = true;
 let errorMessages = [];
 let taxRules = [];
 
-const clean_popup = () => {
+// Single teardown path. Triggered by Bootstrap's `hidden.bs.modal`,
+// which fires for BOTH the X/Save buttons (via modal.hide()) and a
+// backdrop click — so clicking outside the form now disposes it
+// cleanly and keeps `popUp` in sync with the parent.
+const teardown = () => {
+  if (disposed) return;
+  disposed = true;
   dispatch('close');
   popUp = false;
-  modal.hide();
-  modal.dispose();
   vouchers = undefined;
   errorMessages = [];
   ok = true;
+  modal.dispose();
 }
 const onDragStart = (event) => {
   event.dataTransfer.dropEffect = 'link';
@@ -156,7 +163,9 @@ onMount(async () => {
   const result = await axios.get(`/api/tax-rule?type=active&date=${date}`);
   taxRules = result.data.values;
   console.log(taxRules);
-  modal = new Modal(document.getElementById('cross-slip-modal'));
+  modalEl = document.getElementById(id ? id : 'cross-slip-modal');
+  modalEl.addEventListener('hidden.bs.modal', teardown);
+  modal = new Modal(modalEl);
   modal.show();
 });
 beforeUpdate(() => {
@@ -244,7 +253,7 @@ const save = (event) => {
 };
 
 const close_ = (event) => {
-  clean_popup();
+  modal.hide();
 };
 
 const delete_ = (event) => {
@@ -258,7 +267,7 @@ const delete_ = (event) => {
         no: slip.no
       }
     }).then((result) => {
-      clean_popup();
+      modal.hide();
     });
   } catch(e) {
     console.log(e);

--- a/front/svelte/cross-slip/cross-slip.svelte
+++ b/front/svelte/cross-slip/cross-slip.svelte
@@ -3,24 +3,16 @@
     <div class="col-5">
       <div class="input-group date-group">
         <span class="badge bg-secondary year-badge">
-          <input type="text" autocomplete="off" class="number year-input" name="year"
-            id="slip-year" size="4" maxlength="5" disabled="disabled"
-            bind:value={slip.year}>
+          <span class="year-input">{slip.year || ''}</span>
         </span>
         <span class="input-group-text stacked-label">
           <BilingualText key="year" stacked={false} inline={true} />
         </span>
-        <input type="text" autocomplete="off" class="number" name="month"
-          id="slip-month" size="4" maxlength="3"
-          bind:value={slip.month}>
-        <span class="input-group-text stacked-label">
-          <BilingualText key="month" stacked={false} inline={true} />
-        </span>
-        <input type="text" autocomplete="off" class="number" name="day" id="slip-day" size="4" maxlength="3"
-            bind:value={slip.day}>
-        <span class="input-group-text stacked-label">
-          <BilingualText key="day" stacked={false} inline={true} />
-        </span>
+        <input type="date" class="form-control date-picker"
+          id="slip-date"
+          min={minDate} max={maxDate}
+          value={slipDate}
+          on:change={onDateChange}>
         {#if slip.no}
         <span class="input-group-text">No. {slip.no}</span>
         {/if}
@@ -49,12 +41,12 @@
   <div class="row">
     <table class="table table-striped table-bordered">
       <thead class="table-light">
-        <th><BilingualText key="debit_account" /></th>
+        <th class="col-account"><BilingualText key="debit_account" /></th>
         <th class="col-amount"><BilingualText key="amount" /></th>
         <th><BilingualText key="application" /></th>
-        <th><BilingualText key="credit_account" /></th>
+        <th class="col-account"><BilingualText key="credit_account" /></th>
         <th class="col-amount"><BilingualText key="amount" /></th>
-        <th>
+        <th class="col-action">
         </th>
       </thead>
       <tbody id="cross-slip">
@@ -174,7 +166,7 @@
               on:focusout={makeTaxLine}>
             {/if}
           </td>
-          <td style="width:130px;">
+          <td class="col-action">
             {#if (slip.approvedAt) }
             {#if ( ( line.debitVoucherId !== null ) || ( line.creditVoucherId !== null ))}
             <Icon icon="fa:file"></Icon>
@@ -234,9 +226,10 @@
    All rules use > or descendant selectors of .crossslip so
    they cannot leak to other pages. */
 
-/* (A) Muted secondary text: increase contrast inside this form */
+/* (A) Secondary text: inherit parent color (legible on dark th and
+   light cells alike); keep it smaller/subordinate. Color handled
+   globally in style.css via inherit + opacity. */
 :global(.crossslip .bilingual-secondary) {
-  color: var(--bs-gray-700);
   font-size: 0.85em;
   line-height: 1.3;
 }
@@ -295,6 +288,47 @@
   width: 150px;
   min-width: 150px;
 }
+/* Fixed-layout column sizing: give account + action columns explicit
+   widths so the Note/application column absorbs the remaining space. */
+:global(.crossslip .col-account) {
+  width: 18%;
+}
+:global(.crossslip .col-action) {
+  width: 110px;
+}
+
+/* (F) Overflow containment (issue #1): the form used fixed `size=`
+   character widths on inputs, which forced the table wider than the
+   modal and overflowed. Make the table fill the modal and let every
+   field shrink to its cell instead of its `size` attribute. */
+:global(.crossslip table) {
+  width: 100%;
+  table-layout: fixed;
+}
+:global(.crossslip td input[type="text"]),
+:global(.crossslip td .search-input),
+:global(.crossslip td .form-control),
+:global(.crossslip td select) {
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+/* Flex rows inside the Note/application cell: allow children to shrink
+   below their content/`size` width so nothing pushes past the cell. */
+:global(.crossslip .application) {
+  gap: 0.25rem;
+}
+:global(.crossslip .application > *) {
+  min-width: 0;
+}
+:global(.crossslip .application > input) {
+  flex: 1 1 auto;
+}
+/* Date picker fills remaining width of the compact date group */
+:global(.crossslip .date-picker) {
+  flex: 1 1 auto;
+  min-width: 0;
+}
 </style>
 
 <script>
@@ -302,7 +336,7 @@ import axios from 'axios';
 import Icon from '@iconify/svelte';
 
 import {findTaxClass} from '../../javascripts/cross-slip';
-import {numeric, getCompanyInfo} from '../../../libs/utils';
+import {numeric, getCompanyInfo, DateString} from '../../../libs/utils';
 import {onMount, beforeUpdate, afterUpdate, createEventDispatcher} from 'svelte';
 import Account from './account.svelte';
 import {field} from '../../../libs/parse_account_code';
@@ -319,6 +353,27 @@ let projects = [];
 let showProject = false;
 
 $: slip.year = slip.month < ( fy.startDate.getMonth() + 1 ) ? fy.endDate.getFullYear() : fy.startDate.getFullYear();
+
+// Date picker (issue #2): single native date input bounded to the
+// fiscal-year range. Year stays auto-derived (above) and shown in the
+// badge; picking a date writes back month/day.
+const pad2 = (n) => ('0' + n).slice(-2);
+$: minDate = fy.startDate ? DateString(fy.startDate) : undefined;
+$: maxDate = fy.endDate ? DateString(fy.endDate) : undefined;
+$: slipDate = ( slip.year && slip.month && slip.day )
+  ? `${slip.year}-${pad2(slip.month)}-${pad2(slip.day)}`
+  : '';
+const onDateChange = (event) => {
+  const v = event.target.value; // YYYY-MM-DD
+  if ( !v ) {
+    slip.day = undefined;
+    return;
+  }
+  const [y, m, d] = v.split('-').map((n) => parseInt(n, 10));
+  slip.month = m;
+  slip.day = d;
+  slip = slip;
+};
 
 onMount(async () => {
   try {


### PR DESCRIPTION
Part of epic:bilingual-foundation. Closes the 4 cross-slip (Journal Detail Entry) form defects in #172.

## What
- **#1 Overflow:** inputs used fixed `size=` char widths that pushed the table past `modal-xl`. Now responsive (`width:100%`, `min-width:0`, `box-sizing`) + `table-layout:fixed` with explicit account/action column widths so Note absorbs slack.
- **#2 Date:** replaced 3 loose text inputs (year-disabled/month/day) with one native `type=date` bounded to the fiscal-year range; year auto-derived, shown in badge.
- **#3 Contrast (systemic):** `.bilingual-secondary/.bilingual-sep` → `color:inherit; opacity:0.7`, replacing fixed gray + per-surface overrides. Legible on dark teal th and Voucher/Save buttons. Dropped the cross-slip scoped gray override.
- **#4 Outside-click close (systemic):** removed `data-bs-backdrop="static"` on cross-slip / account / profile modals; cross-slip now runs one idempotent `teardown()` via `hidden.bs.modal` so backdrop click and X/Save dispose cleanly. `ok-modal` left static (confirmation).

## Tested
- `npm run build` ✅ (no errors; pre-existing chunk-size warning only)
- Live UI smoke test deferred — app needs PostgreSQL + server, unavailable in this env

## Files
`cross-slip.svelte`, `cross-slip-modal.svelte`, `account-modal.svelte`, `profile-modal.svelte`, `style.css`, `style.scss`