### PR TITLE
fix(#174): bilingual account/class names on account management page

### DIFF
--- a/front/svelte/accounts/accounts-list.svelte
+++ b/front/svelte/accounts/accounts-list.svelte
@@ -18,14 +18,14 @@
     {#each lines as line}
     <tr>
       <td>
-        {line.majorName}
+        {#if line.majorName}<span class="bi-pair"><span class="bi-primary">{line.majorName}</span>{#if line.majorNameVi}<span class="bi-sep"> / </span><span class="bi-secondary">{line.majorNameVi}</span>{/if}</span>{/if}
       </td>
       <td>
-        {line.middleName}
+        {#if line.middleName}<span class="bi-pair"><span class="bi-primary">{line.middleName}</span>{#if line.middleNameVi}<span class="bi-sep"> / </span><span class="bi-secondary">{line.middleNameVi}</span>{/if}</span>{/if}
       </td>
       <td>
         {#if (line.minorName != '')}
-        {line.minorName}
+        <span class="bi-pair"><span class="bi-primary">{line.minorName}</span>{#if line.minorNameVi}<span class="bi-sep"> / </span><span class="bi-secondary">{line.minorNameVi}</span>{/if}</span>
         {/if}
       </td>
       <td>
@@ -34,7 +34,7 @@
           on:click={() => {
             editAccount(line.code);
           }}>
-          {line.accountName}
+          <span class="bi-pair"><span class="bi-primary">{line.accountName}</span>{#if line.accountNameVi}<span class="bi-sep"> / </span><span class="bi-secondary">{line.accountNameVi}</span>{/if}</span>
         </button>
         {:else}
         <button type="button" class="btn btn-primary btn-sm"
@@ -57,7 +57,7 @@
           on:click={() => {
             editSubAccount(line.code, line.subCode);
           }}>
-          {line.subAccountName}
+          <span class="bi-pair"><span class="bi-primary">{line.subAccountName}</span>{#if line.subAccountNameVi}<span class="bi-sep"> / </span><span class="bi-secondary">{line.subAccountNameVi}</span>{/if}</span>
         </button>
         {:else}
         <button type="button" class="btn btn-primary btn-sm"
@@ -92,6 +92,18 @@
 <style>
 th {
 	text-align: center;
+}
+.bi-pair {
+	display: inline;
+}
+.bi-primary {
+	font-weight: 600;
+}
+.bi-secondary {
+	font-size: 0.85em;
+}
+.bi-sep {
+	opacity: 0.5;
 }
 </style>
 

--- a/front/svelte/accounts/accounts.svelte
+++ b/front/svelte/accounts/accounts.svelte
@@ -44,6 +44,7 @@ import {parseParams, buildParam} from '../../javascripts/params.js';
 import { currentPage } from '../../javascripts/router.js';
 
 import BilingualText from '../components/bilingual-text.svelte';
+import { languagePair } from '../../javascripts/bilingual.js';
 export let status;
 
 let accounts;
@@ -66,18 +67,24 @@ const ready = () => {
     };
     if ( last_account.major_name != account.major_name ) {
       new_line.majorName = account.major_name;
+      new_line.majorNameVi = account.major_nameVi || '';
     } else {
       new_line.majorName = '';
+      new_line.majorNameVi = '';
     }
     if ( last_account.middle_name != account.middle_name ) {
       new_line.middleName = account.middle_name;
+      new_line.middleNameVi = account.middle_nameVi || '';
     } else {
       new_line.middleName = '';
+      new_line.middleNameVi = '';
     }
     if ( last_account.minor_name != account.minor_name ) {
       new_line.minorName = account.minor_name;
+      new_line.minorNameVi = account.minor_nameVi || '';
     } else {
       new_line.minorName = '';
+      new_line.minorNameVi = '';
     }
     if		(( new_line.major_name != '') ||
          ( new_line.middle_name != '' ) ||
@@ -90,7 +97,9 @@ const ready = () => {
         middleName: '',
         minorName: '',
         accountName: account.name,
+        accountNameVi: account.nameVi || '',
         subAccountName: '',
+        subAccountNameVi: '',
         taxClass: ( account.subAccounts && account.subAccounts.length > 0 ) ? 0 : account.taxClass,
         key: account.key ? account.key : '',
         debit: account.debit ? numeric(account.debit) : 0,
@@ -107,7 +116,9 @@ const ready = () => {
             middleName: '',
             minorName: '',
             accountName: '',
+            accountNameVi: '',
             subAccountName: sub.name,
+            subAccountNameVi: sub.nameVi || '',
             taxClass: sub.taxClass,
             key: sub.key,
             debit: sub.debit ? numeric(sub.debit) : 0,
@@ -125,7 +136,8 @@ const ready = () => {
 
 
 const	updateAccounts = () => {
-  axios.get(`/api/accounts4/${status.fy.term}`).then((result) => {
+  const lp = encodeURIComponent(JSON.stringify($languagePair));
+  axios.get(`/api/accounts4/${status.fy.term}?languagePair=${lp}`).then((result) => {
     accounts = result.data;
     //console.log('accounts', accounts);
     setAccounts(accounts);

--- a/libs/accounts.js
+++ b/libs/accounts.js
@@ -329,6 +329,7 @@ export default class {
   ],
   });
   if (languagePair) {
+    await enrichBilingual('AccountClass', accountClasses, languagePair);
     const allAccs = accountClasses.flatMap(acl => acl.accounts || []);
     if (allAccs.length > 0) {
       await enrichBilingual('Account', allAccs, languagePair);
@@ -346,6 +347,9 @@ export default class {
   major_name: acl.major,
   middle_name: acl.middle,
   minor_name: acl.minor,
+  major_nameVi: acl.getDataValue('majorVi') || '',
+  middle_nameVi: acl.getDataValue('middleVi') || '',
+  minor_nameVi: acl.getDataValue('minorVi') || '',
   acl_id: acl.id,
   acl_code: make_klass(acl.field, acl.adding)
   });
@@ -391,6 +395,9 @@ export default class {
   major_name: acl.major,
   middle_name: acl.middle,
   minor_name: acl.minor,
+  major_nameVi: acl.getDataValue('majorVi') || '',
+  middle_nameVi: acl.getDataValue('middleVi') || '',
+  minor_nameVi: acl.getDataValue('minorVi') || '',
   acl_id: acl.id,
   acl_code: make_klass(acl.field, acl.adding),
   key: acc.key,
@@ -418,6 +425,9 @@ export default class {
   major_name: acl.major,
   middle_name: acl.middle,
   minor_name: acl.minor,
+  major_nameVi: acl.getDataValue('majorVi') || '',
+  middle_nameVi: acl.getDataValue('middleVi') || '',
+  minor_nameVi: acl.getDataValue('minorVi') || '',
   acl_id: acl.id,
   acl_code: make_klass(acl.field, acl.adding),
   key: acc.key,


### PR DESCRIPTION
Part of epic:bilingual-foundation.

Fixes the account management page data rows showing Japanese-only for account/class names. See #174 for full root-cause and test report.

## What
- `libs/accounts.js` (`all4`): enrich AccountClass + emit `major/middle/minor_nameVi`
- `accounts.svelte`: send `languagePair` query param; thread Vi fields through `ready()`
- `accounts-list.svelte`: render `ja / vi` inline (matches trial-balance #151 pattern)

## Test
- `npm run build` ✅
- 13 pre-existing test failures are env-only (signup needs live PostgreSQL), not touched by this change