### PR TITLE
feat(#176): store languagePair on User instead of (user, tenant)

### DIFF
--- a/front/svelte/login/login.svelte
+++ b/front/svelte/login/login.svelte
@@ -5,6 +5,9 @@
     </div>
     <div class="card">
       <div class="card-body login-card-body">
+        <div class="d-flex justify-content-end mb-2">
+          <LanguagePairSelector save={false} />
+        </div>
         <p class="fs-4 text-center "><BilingualText key="login" /></p>
         <p class="text-{msg_type} text-center">{message}</p>
         <div class="mb-3">
@@ -36,7 +39,9 @@
 import {onMount, beforeUpdate, afterUpdate, createEventDispatcher} from 'svelte';
 import axios from 'axios';
 import BilingualText from '../components/bilingual-text.svelte';
-import { bi } from '../../javascripts/bilingual.js';
+import { bi, languagePair } from '../../javascripts/bilingual.js';
+import { get } from 'svelte/store';
+import LanguagePairSelector from '../widgets/language-pair-selector.svelte';
 export let current;
 
 let user_name = '';
@@ -68,7 +73,8 @@ const Login = async () => {
   try {
     const response = await axios.post('/api/user/login', {
       user_name,
-      password
+      password,
+      languagePair: get(languagePair)
     });
 
     console.log('result', response.data);

--- a/front/svelte/login/signup.svelte
+++ b/front/svelte/login/signup.svelte
@@ -5,6 +5,9 @@
     </div>
     <div class="card">
       <div class="card-body login-card-body">
+        <div class="d-flex justify-content-end mb-2">
+          <LanguagePairSelector save={false} />
+        </div>
         <p class="fs-4 text-center"><BilingualText key="signup_heading" /></p>
         
         {#if successMessage}
@@ -235,6 +238,7 @@ import {get} from 'svelte/store';
 import { link } from '../../javascripts/router.js';
 import BilingualText from '../components/bilingual-text.svelte';
 import { bi, _b } from '../../javascripts/bilingual.js';
+import LanguagePairSelector from '../widgets/language-pair-selector.svelte';
 
 // Option text can't host a component; build "primary / secondary" strings reactively.
 $: biFn = $bi;

--- a/front/svelte/widgets/language-pair-selector.svelte
+++ b/front/svelte/widgets/language-pair-selector.svelte
@@ -6,7 +6,11 @@
   (primary, secondary) tuples so each option's display is independent of
   the current $languagePair.
 
-  Props: none (reads/writes languagePair store + calls API)
+  Props:
+    save — when true (default), persist the pick to the user via
+           PUT /api/user/language-pair. Set false on outer pages
+           (login/signup) where there is no authenticated user yet:
+           the pick only updates the client store for immediate display.
 -->
 <div class="d-flex align-items-center" style="font-size:0.85rem; padding: 0 0.5rem;">
   <select class="form-select form-select-sm" style="width:auto; min-width:120px;" bind:value={selectedPair} title={currentLabel}>
@@ -22,6 +26,10 @@
   import ja from '../../javascripts/locales/ja.json';
   import vi from '../../javascripts/locales/vi.json';
   import en from '../../javascripts/locales/en.json';
+
+  // When false, only update the client store (no API persist).
+  // Used by outer pages (login/signup) where no user session exists yet.
+  export let save = true;
 
   const DICT = { ja, vi, en };
 
@@ -84,8 +92,10 @@
     const [primary, secondary] = selectedPair.split(',');
     const newPair = { primary, secondary };
     languagePair.set(newPair);
-    axios.put('/api/user/language-pair', newPair).catch((e) => {
-      console.log('Failed to persist language pair', e);
-    });
+    if (save) {
+      axios.put('/api/user/language-pair', newPair).catch((e) => {
+        console.log('Failed to persist language pair', e);
+      });
+    }
   }
 </script>

--- a/libs/bootstrap.js
+++ b/libs/bootstrap.js
@@ -54,8 +54,7 @@ export async function bootstrapTenantMember(user, t) {
     {
       slug,
       name: `${user.legalName}さんの組織`,
-      status: 'active',
-      settings: { languagePair: { primary: 'ja', secondary: 'vi' } }
+      status: 'active'
     },
     { transaction: t }
   );

--- a/migrations/20260605000000-move-language-pair-to-user.cjs
+++ b/migrations/20260605000000-move-language-pair-to-user.cjs
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * Move languagePair storage from (user, tenant) level to USER level.
+ *
+ * Rationale: language is a property of the person, not the company. A tenant
+ * with multi-national staff should not impose one language; and the same
+ * person across two tenants should keep one language. So the preference
+ * belongs on Users, independent of any tenant.
+ *
+ * up:   add Users.languagePair (JSONB, nullable), migrate any existing
+ *       TenantMember preference onto its user (first non-null wins), then
+ *       drop TenantMembers.languagePair.
+ * down: re-add TenantMembers.languagePair and copy the user value back onto
+ *       every active membership, then drop Users.languagePair.
+ */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Users', 'languagePair', {
+      type: Sequelize.JSONB,
+      allowNull: true,
+      defaultValue: null,
+      comment: 'User-level language pair preference. Null = system default {ja,vi}. e.g. {"primary":"ja","secondary":"vi"}'
+    });
+
+    // Migrate existing per-membership preference onto the user.
+    // For users with several memberships carrying a pair, the lowest member id wins.
+    await queryInterface.sequelize.query(`
+      UPDATE "Users" u
+      SET "languagePair" = sub."languagePair"
+      FROM (
+        SELECT DISTINCT ON ("userId") "userId", "languagePair"
+        FROM "TenantMembers"
+        WHERE "languagePair" IS NOT NULL AND "userId" IS NOT NULL
+        ORDER BY "userId", "id" ASC
+      ) sub
+      WHERE u."id" = sub."userId";
+    `);
+
+    await queryInterface.removeColumn('TenantMembers', 'languagePair');
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.addColumn('TenantMembers', 'languagePair', {
+      type: Sequelize.JSONB,
+      allowNull: true,
+      defaultValue: null,
+      comment: 'User-level language pair override. Null = inherit tenant default. e.g. {"primary":"ja","secondary":"vi"}'
+    });
+
+    // Copy user preference back onto active memberships.
+    await queryInterface.sequelize.query(`
+      UPDATE "TenantMembers" m
+      SET "languagePair" = u."languagePair"
+      FROM "Users" u
+      WHERE m."userId" = u."id" AND u."languagePair" IS NOT NULL;
+    `);
+
+    await queryInterface.removeColumn('Users', 'languagePair');
+  }
+};

--- a/models/tenantmember.js
+++ b/models/tenantmember.js
@@ -162,14 +162,6 @@ export default (sequelize, DataTypes) => {
       defaultValue: false
     },
 
-    // Language pair preference (user override)
-    languagePair: {
-      type: DataTypes.JSONB,
-      allowNull: true,
-      defaultValue: null,
-      comment: 'User-level language pair override. Null = inherit tenant default. e.g. {"primary":"ja","secondary":"vi"}'
-    },
-
     // Tenant-internal identity & display
     tradingName: {
       type: DataTypes.STRING,

--- a/models/user.js
+++ b/models/user.js
@@ -115,6 +115,14 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: true,
       comment: '電話'
+    },
+
+    // Bilingual display preference (user-level, tenant-independent)
+    languagePair: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      defaultValue: null,
+      comment: 'User-level language pair preference. Null = system default {ja,vi}. e.g. {"primary":"ja","secondary":"vi"}'
     }
   }, {
     sequelize,

--- a/routes/api.js
+++ b/routes/api.js
@@ -45,8 +45,8 @@ router.delete('/admin/backup/:date', is_authenticated, requireTenant, admin.dele
 router.get('/user', is_authenticated, user.get);
 router.get('/user/tenants', is_authenticated, user.tenants);
 router.get('/user/session-status', is_authenticated, user.sessionStatus);
-router.get('/user/language-pair', is_authenticated, requireTenant, user.languagePair);
-router.put('/user/language-pair', is_authenticated, requireTenant, user.updateLanguagePair);
+router.get('/user/language-pair', is_authenticated, user.languagePair);
+router.put('/user/language-pair', is_authenticated, user.updateLanguagePair);
 router.post('/user/select-tenant', is_authenticated, user.selectTenant);
 router.post('/user/tenant', is_authenticated, user.createTenant);
 router.post('/tenant', is_authenticated, user.createTenant);

--- a/routes/api_user.js
+++ b/routes/api_user.js
@@ -333,8 +333,28 @@ export default {
           } else {
             req.session.user = user.user;
 
+            // First-login default: seed the user's language preference from the
+            // pair they picked on the outer (login) page, but only if they have
+            // none yet. Never overrides an existing preference.
             try {
-              // Fetch all active tenant memberships
+              const picked = req.body.languagePair;
+              if (picked && picked.primary && picked.secondary &&
+                  ['ja', 'vi', 'en'].includes(picked.primary) &&
+                  ['ja', 'vi', 'en'].includes(picked.secondary) &&
+                  picked.primary !== picked.secondary) {
+                const dbUser = await models.User.findByPk(user.user.id);
+                if (dbUser && !dbUser.languagePair) {
+                  dbUser.languagePair = { primary: picked.primary, secondary: picked.secondary };
+                  await dbUser.save();
+                  req.session.languagePair = dbUser.languagePair;
+                }
+              }
+            } catch (lpErr) {
+              // Non-fatal: language seeding must not block login.
+              console.log('login languagePair seed error', lpErr);
+            }
+
+            try {
               const memberships = await models.TenantMember.findAll({
                 where: { 
                   userId: user.user.id, 
@@ -702,27 +722,14 @@ export default {
     try {
       const systemDefault = { primary: 'ja', secondary: 'vi' };
 
-      // 1. Try TenantMember override
-      if (req.currentTenantId) {
-        const membership = await models.TenantMember.findOne({
-          where: { userId: req.session.user.id, tenantId: req.currentTenantId, status: 'active' }
-        });
-        if (membership && membership.languagePair) {
-          req.session.languagePair = membership.languagePair;
-          return res.json({ result: 'OK', languagePair: membership.languagePair, source: 'member' });
-        }
+      // Language preference is user-level and tenant-independent.
+      const user = await models.User.findByPk(req.session.user.id);
+      if (user && user.languagePair) {
+        req.session.languagePair = user.languagePair;
+        return res.json({ result: 'OK', languagePair: user.languagePair, source: 'user' });
       }
 
-      // 2. Try Tenant default
-      if (req.currentTenantId) {
-        const tenant = await models.Tenant.findByPk(req.currentTenantId);
-        if (tenant && tenant.settings && tenant.settings.languagePair) {
-          req.session.languagePair = tenant.settings.languagePair;
-          return res.json({ result: 'OK', languagePair: tenant.settings.languagePair, source: 'tenant' });
-        }
-      }
-
-      // 3. System fallback
+      // System fallback (user has no preference yet).
       req.session.languagePair = systemDefault;
       return res.json({ result: 'OK', languagePair: systemDefault, source: 'system' });
     } catch (err) {
@@ -734,9 +741,6 @@ export default {
     if (!req.session || !req.session.user) {
       return res.status(401).json({ result: 'NG', message: '認証されていません。' });
     }
-    if (!req.currentTenantId) {
-      return res.status(403).json({ result: 'NG', message: 'テナントが選択されていません。' });
-    }
 
     const { primary, secondary } = req.body;
     if (!primary || !secondary || !['ja', 'vi', 'en'].includes(primary) || !['ja', 'vi', 'en'].includes(secondary)) {
@@ -747,18 +751,16 @@ export default {
     }
 
     try {
-      const membership = await models.TenantMember.findOne({
-        where: { userId: req.session.user.id, tenantId: req.currentTenantId, status: 'active' }
-      });
-      if (!membership) {
-        return res.status(404).json({ result: 'NG', message: 'メンバーシップが見つかりません。' });
+      const user = await models.User.findByPk(req.session.user.id);
+      if (!user) {
+        return res.status(404).json({ result: 'NG', message: 'ユーザーが見つかりません。' });
       }
 
-      membership.languagePair = { primary, secondary };
-      await membership.save();
+      user.languagePair = { primary, secondary };
+      await user.save();
 
-      req.session.languagePair = membership.languagePair;
-      res.json({ result: 'OK', languagePair: membership.languagePair });
+      req.session.languagePair = user.languagePair;
+      res.json({ result: 'OK', languagePair: user.languagePair });
     } catch (err) {
       console.error('updateLanguagePair error', err);
       res.status(500).json({ result: 'NG', message: '言語設定の更新に失敗しました。' });

--- a/test/bilingual-integration.test.mjs
+++ b/test/bilingual-integration.test.mjs
@@ -88,7 +88,7 @@ describe('Language Pair API (#89)', function () {
     assert.equal(res.body.result, 'OK');
     assert.equal(res.body.languagePair.primary, 'ja');
     assert.equal(res.body.languagePair.secondary, 'en');
-    assert.equal(res.body.source, 'member');
+    assert.equal(res.body.source, 'user');
   });
 
   it('PUT rejects same language for primary and secondary', async function () {
@@ -110,6 +110,69 @@ describe('Language Pair API (#89)', function () {
   it('language-pair requires authentication (302 redirect without login)', async function () {
     const res = await request(app).get('/api/user/language-pair').expect(302);
     assert.ok(res.headers.location, 'should redirect to login');
+  });
+});
+
+describe('Language Pair — first-login default init (#176)', function () {
+  this.timeout(30000);
+
+  it('login with languagePair seeds a brand-new user preference', async function () {
+    const user = makeUser('seed');
+    const agent = request.agent(app);
+
+    await agent
+      .post('/api/user/signup')
+      .send({
+        user_name: user.name,
+        password: user.password,
+        legalName: user.legalName,
+        email: user.email
+      })
+      .expect('Content-Type', /json/);
+
+    // Login carrying the pair picked on the outer (login) page.
+    const loginRes = await agent
+      .post('/api/user/login')
+      .send({ user_name: user.name, password: user.password, languagePair: { primary: 'vi', secondary: 'en' } })
+      .expect(200);
+    assert.equal(loginRes.body.result, 'OK');
+
+    // The seeded preference is now the user's own.
+    const res = await agent.get('/api/user/language-pair').expect(200);
+    assert.equal(res.body.languagePair.primary, 'vi');
+    assert.equal(res.body.languagePair.secondary, 'en');
+    assert.equal(res.body.source, 'user');
+  });
+
+  it('login languagePair does NOT override an existing user preference', async function () {
+    const user = makeUser('noov');
+    const agent = request.agent(app);
+
+    await agent
+      .post('/api/user/signup')
+      .send({
+        user_name: user.name,
+        password: user.password,
+        legalName: user.legalName,
+        email: user.email
+      })
+      .expect('Content-Type', /json/);
+
+    // First login seeds vi-en.
+    await agent
+      .post('/api/user/login')
+      .send({ user_name: user.name, password: user.password, languagePair: { primary: 'vi', secondary: 'en' } })
+      .expect(200);
+
+    // Second login carries a different pair — must be ignored (preference already set).
+    await agent
+      .post('/api/user/login')
+      .send({ user_name: user.name, password: user.password, languagePair: { primary: 'ja', secondary: 'en' } })
+      .expect(200);
+
+    const res = await agent.get('/api/user/language-pair').expect(200);
+    assert.equal(res.body.languagePair.primary, 'vi');
+    assert.equal(res.body.languagePair.secondary, 'en');
   });
 });
 


### PR DESCRIPTION
Part of epic:bilingual-foundation. Closes part of #176.

Moves bilingual language-pair preference from the (user, tenant) layer to the USER layer; adds no-save selector on login/signup with first-login default seeding. See #176 for full summary and Test Report.

- `Users.languagePair` added; `TenantMembers.languagePair` dropped (reversible migration)
- resolver/updater rewritten to user-level; `requireTenant` removed from language-pair routes
- login seeds preference from outer-page pick only when user has none
- build ✅, 69 tests passing (+2 new), migration up/down/up clean