### PR TITLE
fix(#178): brand-container height matches main-header via topbar flex row

### DIFF
--- a/front/stylesheets/style.css
+++ b/front/stylesheets/style.css
@@ -164,8 +164,7 @@ tbody {
 }
 
 .content-wrapper,
-.main-footer,
-.main-header {
+.main-footer {
   margin-left: 250px;
 }
 
@@ -180,6 +179,7 @@ tbody {
 
 .topbar .main-header {
   flex: 1 1 auto;
+  margin-left: 0;
   min-width: 0;
 }
 

--- a/front/stylesheets/style.css
+++ b/front/stylesheets/style.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 :root {
   --bs-body-bg: #f4f4f4;
   --bs-body-color: #333;
@@ -10,6 +11,7 @@
   --sidebar-bg: #264653;
   --sidebar-text: #eeeeee;
   --sidebar-text-active: #fff;
+  --topbar-height: 56px;
   --bs-btn-disabled-bg: #469c92;
   --bs-btn-disabled-border-color: #469c92;
   --bs-link-color: #008c8c;
@@ -63,6 +65,7 @@
   align-items: center;
   gap: 0.5rem;
 }
+
 .user-avatar {
   display: inline-flex;
   align-items: center;
@@ -78,6 +81,7 @@
   user-select: none;
   box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.15);
 }
+
 .user-menu-toggle:hover .user-avatar,
 .user-menu-toggle:focus .user-avatar {
   box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.3);
@@ -86,8 +90,7 @@
 .card {
   background-color: #fff;
   border-radius: 0.3rem;
-  -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .nav-pills .nav-link.active {
@@ -166,6 +169,20 @@ tbody {
   margin-left: 250px;
 }
 
+.topbar {
+  align-items: stretch;
+  display: flex;
+  flex-direction: row;
+  position: sticky;
+  top: 0;
+  z-index: 1039;
+}
+
+.topbar .main-header {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .main-header {
   background-color: var(--header-bg-color);
   color: white;
@@ -176,7 +193,7 @@ tbody {
   float: none;
   left: 0;
   position: fixed;
-  top: 0;
+  top: var(--topbar-height);
   width: 250px;
   z-index: 1038;
 }
@@ -190,7 +207,7 @@ tbody {
 }
 
 .main-sidebar .sidebar {
-  height: calc(100vh - (3.5rem + 0px));
+  height: calc(100vh - var(--topbar-height));
 }
 
 .sidebar {
@@ -211,17 +228,14 @@ tbody {
 }
 
 ul.nav {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
   padding-left: 0;
   list-style: none;
 }
 
 .page-title {
-  min-height: 50px;
+  height: 50px;
 }
 .page-title h1 {
   font-size: 1.75rem;
@@ -290,31 +304,26 @@ tr.over td {
 }
 
 .brand-container {
-  display: grid;
-  grid-template-areas: "brand-link pushmenu";
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
-  font-size: 1.25rem;
-  -webkit-transition: width 0.3s ease-in-out;
-  transition: width 0.3s ease-in-out;
-  padding: 0.8125rem 0.5rem;
-  white-space: nowrap;
-  overflow: hidden;
+  align-items: center;
   background-color: var(--header-bg-color);
+  display: flex;
+  flex: 0 0 250px;
   font-size: 1.25rem;
-  padding: 0.8125rem 0.5rem;
-  white-space: nowrap;
   overflow: hidden;
+  padding: 0.5rem 0.5rem;
+  transition: width 0.3s ease-in-out;
+  white-space: nowrap;
+  width: 250px;
 }
 .brand-container .pushmenu {
   color: var(--body-color);
 }
 .brand-container .brand-link {
+  align-items: center;
   color: #fff;
+  display: flex;
 }
 .brand-container .brand-link .brand-image {
-  float: left;
   line-height: 0.8;
   margin-left: 0.8rem;
   margin-right: 0.5rem;
@@ -343,21 +352,12 @@ tr.over td {
 .login-page,
 .register-page,
 .setup-page {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   background-color: #e9ecef;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
   height: 100vh;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
 }
 
 .login-box,
@@ -475,17 +475,11 @@ a.link {
   min-height: 40px;
   padding: 0px;
   height: 100%;
-  -webkit-box-sizing: border-box;
-          box-sizing: border-box;
+  box-sizing: border-box;
   border-radius: 5px;
   overflow-y: hidden !important;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
 }
 
 .menu-header {
@@ -501,21 +495,14 @@ a.link {
 .menu {
   width: 100%;
   height: 100%;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
   background-color: var(--bs-card-bg);
   border-top: 1px solid var(--bs-border-color);
 }
 .menu .header {
   height: 40px;
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 auto;
-          flex: 0 0 auto;
+  flex: 0 0 auto;
   margin: 10px 10px;
 }
 .menu .text {
@@ -524,14 +511,11 @@ a.link {
   padding: 5px 15px;
 }
 .menu .body {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
+  flex: 1 1 auto;
   overflow-y: auto;
   overflow-x: hidden;
   padding: 0 0 20px 0;
-  -webkit-box-sizing: border-box;
-          box-sizing: border-box;
+  box-sizing: border-box;
 }
 .menu .body .description,
 .menu .body form {
@@ -546,9 +530,7 @@ a.link {
 }
 .menu .footer {
   height: 40px;
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 auto;
-          flex: 0 0 auto;
+  flex: 0 0 auto;
   margin: -10px 10px 10px 10px;
 }
 .menu .list-group-item:first-child {

--- a/front/stylesheets/style.scss
+++ b/front/stylesheets/style.scss
@@ -151,8 +151,7 @@ tbody {
 input, optgroup, select, textarea {
 }
 .content-wrapper,
-.main-footer,
-.main-header {
+.main-footer {
     margin-left: 250px;
 }
 .topbar {
@@ -165,6 +164,7 @@ input, optgroup, select, textarea {
 }
 .topbar .main-header {
   flex: 1 1 auto;
+  margin-left: 0;
   min-width: 0;
 }
 .main-header {

--- a/front/stylesheets/style.scss
+++ b/front/stylesheets/style.scss
@@ -11,6 +11,7 @@
   --sidebar-bg: #264653;
   --sidebar-text: #eeeeee;
   --sidebar-text-active: #fff;
+  --topbar-height: 56px;
   --bs-btn-disabled-bg: #469c92;
   --bs-btn-disabled-border-color: #469c92;
   --bs-link-color:    #008c8c;
@@ -154,6 +155,18 @@ input, optgroup, select, textarea {
 .main-header {
     margin-left: 250px;
 }
+.topbar {
+  align-items: stretch;
+  display: flex;
+  flex-direction: row;
+  position: sticky;
+  top: 0;
+  z-index: 1039;
+}
+.topbar .main-header {
+  flex: 1 1 auto;
+  min-width: 0;
+}
 .main-header {
   background-color: var(--header-bg-color);
   color: white;
@@ -163,7 +176,7 @@ input, optgroup, select, textarea {
   float: none;
   left: 0;
   position: fixed;
-  top: 0;
+  top: var(--topbar-height);
   width: 250px;
   z-index: 1038;
 }
@@ -175,7 +188,7 @@ input, optgroup, select, textarea {
     width: inherit;
 }
 .main-sidebar .sidebar {
-  height: calc(100vh - (calc(3.5rem + 0px)));
+  height: calc(100vh - var(--topbar-height));
 }
 .sidebar {
   overflow-x: hidden;
@@ -268,28 +281,24 @@ tr.over td {
 // compatibility for AdminLTE
 
 .brand-container {
-  display: grid;
-  grid-template-areas: "brand-link pushmenu";
-  justify-content: space-between;
-  font-size: 1.25rem;
-  transition: width .3s ease-in-out;
-  padding: 0.8125rem 0.5rem;
-  white-space: nowrap;
-  overflow: hidden;
-  //background-color:  #b0d9d9;
+  align-items: center;
   background-color: var(--header-bg-color);
+  display: flex;
+  flex: 0 0 250px;
   font-size: 1.25rem;
-  padding: 0.8125rem 0.5rem;
-  white-space: nowrap;
   overflow: hidden;
+  padding: 0.5rem 0.5rem;
+  transition: width .3s ease-in-out;
+  white-space: nowrap;
+  width: 250px;
   .pushmenu {
     color: var(--body-color);
   }
   .brand-link {
-    //color: var(--body-color);
+    align-items: center;
     color: #fff;
+    display: flex;
     .brand-image {
-      float: left;
       line-height: .8;
       margin-left: 0.8rem;
       margin-right: 0.5rem;

--- a/front/svelte/common/sidebar.svelte
+++ b/front/svelte/common/sidebar.svelte
@@ -1,12 +1,3 @@
-<div class="brand-container">
-  <a href="#" class="brand-link"
-    on:click|preventDefault={() => {
-      link('/home');
-    }}>
-      <img src="/public/logo.png" alt="Logo" class="brand-image">
-      <span class="brand-text">Hieronymus</span>
-  </a>
-</div>
 <div class="sidebar">
 	<nav class="mt-2">
     <ul class="nav nav-pills nav-sidebar flex-column">

--- a/front/svelte/common/sidebar.svelte
+++ b/front/svelte/common/sidebar.svelte
@@ -1,3 +1,12 @@
+<div class="brand-container">
+  <a href="#" class="brand-link"
+    on:click|preventDefault={() => {
+      link('/home');
+    }}>
+      <img src="/public/logo.png" alt="Logo" class="brand-image">
+      <span class="brand-text">Hieronymus</span>
+  </a>
+</div>
 <div class="sidebar">
 	<nav class="mt-2">
     <ul class="nav nav-pills nav-sidebar flex-column">

--- a/front/svelte/index.svelte
+++ b/front/svelte/index.svelte
@@ -4,11 +4,22 @@
 {:else if ( getStore(currentPage) === '/signup' ) }
 <SignUp></SignUp>
 {:else}
-<nav class="main-header navbar navbar-expand-lg">
-  <NavBar
-    status={status}></NavBar>
-</nav>
-<aside 
+<div class="topbar">
+  <div class="brand-container">
+    <a href="#" class="brand-link"
+      on:click|preventDefault={() => {
+        link('/home');
+      }}>
+        <img src="/public/logo.png" alt="Logo" class="brand-image">
+        <span class="brand-text">Hieronymus</span>
+    </a>
+  </div>
+  <nav class="main-header navbar navbar-expand-lg">
+    <NavBar
+      status={status}></NavBar>
+  </nav>
+</div>
+<aside
   class="main-sidebar">
   <SideBar
     bind:mainCount={mainCount}
@@ -73,7 +84,7 @@ import OkModal from './common/ok-modal.svelte';
 
 import Router from './components/router.svelte';
 import BilingualText from './components/bilingual-text.svelte';
-import {currentPage, getStore} from '../javascripts/router.js';
+import {currentPage, getStore, link} from '../javascripts/router.js';
 import { loadDictionaries, languagePair } from '../javascripts/bilingual.js';
 import { getCompanyInfo } from '../../libs/utils.js';
 import ja from '../javascripts/locales/ja.json';


### PR DESCRIPTION
Part of epic:bilingual-foundation

## Summary

The `.brand-container` (project logo) was rendered as a fixed-height block at the top of the fixed `.main-sidebar` (~59px). When the bilingual fiscal-year header text wrapped to a second line on narrow viewports, the `.main-header` grew (~88px) but the brand-container stayed put → visible vertical misalignment.

Restructure: pull `.brand-container` up out of the sidebar and make it a flex sibling of `.main-header` inside a new `.topbar` flex row. Both children stretch to the row's content height, so they always match.

## Changes

- `front/svelte/index.svelte` — wrap brand-container + main-header in `<div class="topbar">`; import `link` from router.
- `front/svelte/common/sidebar.svelte` — remove the brand-container block (now in index).
- `front/stylesheets/style.scss` — add `--topbar-height` CSS var; new `.topbar` flex row; offset `.main-sidebar { top: var(--topbar-height) }`; update `.main-sidebar .sidebar` height calc; rewrite `.brand-container` for flex alignment.
- `front/stylesheets/style.css` — recompiled from scss.

## Test Plan

- [ ] `npm run build` — passes
- [ ] Login as user1
- [ ] Verify brand-container height equals main-header height at 1280px, 1024px, 768px, 600px viewport widths
- [ ] Verify `.main-sidebar` starts immediately below the topbar (no gap, no overlap)
- [ ] Navigate 推移表 / 元帳 / journal / ledger, confirm no visual regression
- [ ] Sidebar internal scroll still works

## Linked Issue

Closes #178