### PR TITLE
fix(#170): global .page-title min-height — bilingual h1 overflow on 7 list pages

### DIFF
--- a/front/stylesheets/style.css
+++ b/front/stylesheets/style.css
@@ -235,7 +235,10 @@ ul.nav {
 }
 
 .page-title {
-  height: 50px;
+  min-height: 50px;
+  height: auto;
+  flex-wrap: wrap;
+  row-gap: 0.25rem;
 }
 .page-title h1 {
   font-size: 1.75rem;

--- a/front/stylesheets/style.scss
+++ b/front/stylesheets/style.scss
@@ -217,10 +217,13 @@ ul.nav {
   list-style: none;
 }
 .page-title {
-  height:50px;
+  min-height: 50px;
+  height: auto;
+  flex-wrap: wrap;
+  row-gap: 0.25rem;
   h1 {
     font-size: 1.75rem;
-    margin:6px;
+    margin: 6px;
   }
   input[type="text"] {
     font-size:1.75rem;


### PR DESCRIPTION
Part of epic:bilingual-foundation