### PR TITLE
fix(#184): thead.table-light th renders white instead of dark teal — affects 25 input forms

### DIFF
--- a/front/stylesheets/style.css
+++ b/front/stylesheets/style.css
@@ -37,8 +37,8 @@
 .table > :not(caption) > * > td {
   background-color: #fff;
 }
-table.table th,
-.table th {
+.table > :not(caption) > th,
+.table > :not(caption) > * > th {
   background-color: #264653;
   color: #fff;
 }
@@ -57,6 +57,13 @@ table.table th,
 .bilingual-sep {
   color: inherit;
   opacity: 0.7;
+}
+.table > :not(caption) > th .bilingual-secondary,
+.table > :not(caption) > th .bilingual-sep,
+.table > :not(caption) > * > th .bilingual-secondary,
+.table > :not(caption) > * > th .bilingual-sep {
+  color: #b8c5c9;
+  opacity: 1;
 }
 
 /* User menu avatar — circular placeholder showing first letter of user name.

--- a/front/stylesheets/style.css
+++ b/front/stylesheets/style.css
@@ -34,9 +34,10 @@
   background-color: #fff;
   border-radius: 0.3rem;
 }
-.table > :not(caption) > * > * {
+.table > :not(caption) > * > td {
   background-color: #fff;
 }
+table.table th,
 .table th {
   background-color: #264653;
   color: #fff;

--- a/front/stylesheets/style.scss
+++ b/front/stylesheets/style.scss
@@ -32,9 +32,13 @@
 .table {
   background-color: #fff;
   border-radius: 0.3rem;
-  &>:not(caption)>*>*  {
+  // Restrict white-cell override to td; th needs the dark teal below (#184).
+  &>:not(caption)>*>td  {
       background-color: #fff;
   }
+  // Specificity (0,1,2) beats Bootstrap's `.table>:not(caption)>*>*` (0,1,1)
+  // so the dark teal header holds even when <thead class="table-light"> (#184).
+  table.table th,
   th {
     background-color: #264653;
     color: #fff;

--- a/front/stylesheets/style.scss
+++ b/front/stylesheets/style.scss
@@ -36,10 +36,15 @@
   &>:not(caption)>*>td  {
       background-color: #fff;
   }
-  // Specificity (0,1,2) beats Bootstrap's `.table>:not(caption)>*>*` (0,1,1)
-  // so the dark teal header holds even when <thead class="table-light"> (#184).
-  table.table th,
-  th {
+  // Match Bootstrap's own cell selector structure (`.table>:not(caption)>*>*`)
+  // but target `th` instead of the trailing `*`. Specificity (0,1,2) beats
+  // Bootstrap's (0,1,1) so the dark teal header holds even when
+  // <thead class="table-light"> — which would otherwise set --bs-table-bg to
+  // #f8f9fa and show white "boxes" with black text inside the dark teal row
+  // (#184).
+  // Direct `th` in thead/tbody (legacy markup) and `tr > th` (valid markup).
+  &>:not(caption)>th,
+  &>:not(caption)>*>th {
     background-color: #264653;
     color: #fff;
   }
@@ -59,6 +64,16 @@
 .bilingual-sep {
   color: inherit;
   opacity: 0.7;
+}
+/* On the dark teal table header, the secondary language line needs a
+   muted shade that is darker than the primary white but still legible
+   on the dark background — matches the reference style (#184). */
+.table > :not(caption) > th .bilingual-secondary,
+.table > :not(caption) > th .bilingual-sep,
+.table > :not(caption) > * > th .bilingual-secondary,
+.table > :not(caption) > * > th .bilingual-sep {
+  color: #b8c5c9;
+  opacity: 1;
 }
 
 /* User menu avatar — circular placeholder showing first letter of user name.

--- a/front/svelte/cross-slip/cross-slip-modal.svelte
+++ b/front/svelte/cross-slip/cross-slip-modal.svelte
@@ -26,21 +26,23 @@
         {#if (vouchers)}
         <table class="table table-striped table-bordered">
           <thead class="table-light">
-            <th style="width:20px;">
+            <tr>
+              <th scope="col" style="width:20px;">
 
-            </th>
-            <th style="width:100px;">
-              <BilingualText key="kind" />
-            </th>
-            <th style="width:200px;">
-              <BilingualText key="counterparty" />
-            </th>
-            <th style="width:100px;">
-              <BilingualText key="amount" />
-            </th>
-            <th>
-              <BilingualText key="description" />
-            </th>
+              </th>
+              <th scope="col" style="width:100px;">
+                <BilingualText key="kind" />
+              </th>
+              <th scope="col" style="width:200px;">
+                <BilingualText key="counterparty" />
+              </th>
+              <th scope="col" style="width:100px;">
+                <BilingualText key="amount" />
+              </th>
+              <th scope="col">
+                <BilingualText key="description" />
+              </th>
+            </tr>
           </thead>
           <tbody>
             {#each vouchers as line}

--- a/front/svelte/cross-slip/cross-slip.svelte
+++ b/front/svelte/cross-slip/cross-slip.svelte
@@ -41,13 +41,15 @@
   <div class="row">
     <table class="table table-striped table-bordered">
       <thead class="table-light">
-        <th class="col-account"><BilingualText key="debit_account" /></th>
-        <th class="col-amount"><BilingualText key="amount" /></th>
-        <th><BilingualText key="application" /></th>
-        <th class="col-account"><BilingualText key="credit_account" /></th>
-        <th class="col-amount"><BilingualText key="amount" /></th>
-        <th class="col-action">
-        </th>
+        <tr>
+          <th scope="col" class="col-account"><BilingualText key="debit_account" /></th>
+          <th scope="col" class="col-amount"><BilingualText key="amount" /></th>
+          <th scope="col"><BilingualText key="application" /></th>
+          <th scope="col" class="col-account"><BilingualText key="credit_account" /></th>
+          <th scope="col" class="col-amount"><BilingualText key="amount" /></th>
+          <th scope="col" class="col-action">
+          </th>
+        </tr>
       </thead>
       <tbody id="cross-slip">
         {#if slip}


### PR DESCRIPTION
Part of epic:bilingual-foundation

Fix CSS specificity để `<th>` trong `<thead class="table-light">` giữ nền dark teal `#264653` thay vì nền trắng Bootstrap. Bug xảy ra ở 25 file (cross-slip, journal, account, member, item, project, task, transaction, voucher, ledger, bank-ledger, changes, term, backup, approve, project-summary, project-labels, trial-balance, spreadsheet, …) — fix CSS gốc áp dụng cho tất cả cùng lúc.

Closes #184

#### Test Report

- `npm run build` ✅ (28.98s)
- `npm test` ✅ (69 passing)
- JSDOM computed style: `thead.table-light th` → `rgb(38,70,83)` + `rgb(255,255,255)` ✅; `tbody td` → `rgb(255,255,255)` ✅
- Production server (port 3010) serve CSS rule mới (curl verified)