### PR TITLE
fix(#186): enrich account API and show bilingual ledger selections

### DIFF
--- a/front/svelte/bank-ledger/bank-ledger.svelte
+++ b/front/svelte/bank-ledger/bank-ledger.svelte
@@ -35,14 +35,14 @@
           on:click|preventDefault={() => {
             openBank(bank.subAccountCode);
           }}>
-          {bank.name}
+          <BilingualText primary={bank.name} secondary={bank.nameVi} inline={true} />
         </button>
         {:else}
         <button type="button" class="btn btn-outline-info"
           on:click|preventDefault={() => {
             openBank(bank.subAccountCode);
           }}>
-          {bank.name}
+          <BilingualText primary={bank.name} secondary={bank.nameVi} inline={true} />
         </button>
         {/if}
       </li>
@@ -201,6 +201,7 @@ import {ledgerLines} from '../../../libs/ledger';
 import {setAccounts} from '../../javascripts/cross-slip';
 import CrossSlipModal from '../cross-slip/cross-slip-modal.svelte';
 import BilingualText from '../components/bilingual-text.svelte';
+import {languagePair} from '../../javascripts/bilingual.js';
 import {DateString} from '../../../libs/utils.js';
 import {currentPage} from '../../javascripts/router.js';
 
@@ -274,9 +275,18 @@ afterUpdate(() => {
   }
 })
 
+const lpQuery = () => {
+  const pair = $languagePair;
+  return `?languagePair=${encodeURIComponent(JSON.stringify(pair))}`;
+}
+
+$: if ($languagePair && accountCode) {
+  updateAccount();
+}
+
 const updateAccount = () => {
   if	( accountCode )	{
-    axios.get(`/api/account/${accountCode}`).then((result) => {
+    axios.get(`/api/account/${accountCode}${lpQuery()}`).then((result) => {
       bank_list = result.data;
     });
   } else {

--- a/front/svelte/changes/changes.svelte
+++ b/front/svelte/changes/changes.svelte
@@ -2,7 +2,7 @@
   <div class="d-flex align-items-center">
     <h1 class="page-title-bilingual mb-0"><BilingualText key="changes" inline={true} /></h1>
     {#if account}
-      <h2 class="ms-3 mb-0 fs-4">{account.name}</h2>
+      <h2 class="ms-3 mb-0 fs-4"><BilingualText primary={account.name} secondary={account.nameVi} inline={true} /></h2>
     {/if}
   </div>
 </div>
@@ -95,7 +95,7 @@ import {setAccounts, findAccount, findSubAccountByCode} from '../../javascripts/
 import parse_account_code from '../../../libs/parse_account_code';
 import {currentPage, link} from '../../javascripts/router.js';
 import BilingualText from '../components/bilingual-text.svelte';
-import { bi } from '../../javascripts/bilingual.js';
+import { bi, languagePair } from '../../javascripts/bilingual.js';
 import { get } from 'svelte/store';
 
 import {
@@ -189,6 +189,15 @@ const accountSelect = (code) => {
   link(href);
 }
 
+const lpQuery = () => {
+  const pair = get(languagePair);
+  return `?languagePair=${encodeURIComponent(JSON.stringify(pair))}`;
+}
+
+$: if ($languagePair && accountCode) {
+  changeAccount(false);
+}
+
 const termChange = () => {
   console.log({allYears})
   if ( sameMonth )	{
@@ -199,7 +208,7 @@ const termChange = () => {
 
 const changeAccount = (update) => {
   if (!accountCode) return;
-  axios.get(`/api/account/${accountCode}`).then((result) => {
+  axios.get(`/api/account/${accountCode}${lpQuery()}`).then((result) => {
     account = result.data;
     console.log('account', account);
     remaining = {};

--- a/front/svelte/ledger/ledger.svelte
+++ b/front/svelte/ledger/ledger.svelte
@@ -16,7 +16,7 @@
       	code: account.accountCode
     	})
     }}>
-    { account ? account.name : ''}
+    <BilingualText primary={account.name} secondary={account.nameVi} inline={true} />
   </button>
   {/if}
   <div>
@@ -169,6 +169,10 @@ const _link = (event) => {
 const lpQuery = () => {
   const pair = $languagePair;
   return `?languagePair=${encodeURIComponent(JSON.stringify(pair))}`;
+}
+
+$: if ($languagePair && accountCode) {
+  update(false);
 }
 
 const accountSelect = (code) => {

--- a/libs/bilingual-helper.js
+++ b/libs/bilingual-helper.js
@@ -81,4 +81,48 @@ export async function enrichBilingual(tableName, records, languagePair) {
   return records;
 }
 
-export default { enrichBilingual, TRANSLATION_MAP };
+/**
+ * Capitalize language code for enriched field suffix (e.g. 'vi' -> 'Vi').
+ * @param {string|undefined} language
+ * @returns {string}
+ */
+export function secondaryFieldSuffix(language) {
+  return language ? language.charAt(0).toUpperCase() + language.slice(1) : '';
+}
+
+/**
+ * Read enriched secondary name from a Sequelize instance.
+ * @param {object} rec
+ * @param {{ secondary?: string }|null|undefined} languagePair
+ * @returns {string}
+ */
+export function getEnrichedName(rec, languagePair) {
+  const suffix = secondaryFieldSuffix(languagePair?.secondary);
+  if (!suffix) return '';
+  const getter = rec.getDataValue;
+  return (typeof getter === 'function' ? getter.call(rec, `name${suffix}`) : rec[`name${suffix}`]) || '';
+}
+
+/**
+ * Shape Account + SubAccounts JSON with stable nameVi for the wire format.
+ * @param {object} account - Sequelize Account instance with subAccounts
+ * @param {{ secondary?: string }|null|undefined} languagePair
+ * @returns {object}
+ */
+export function shapeAccountBilingual(account, languagePair) {
+  const json = account.toJSON();
+  json.nameVi = getEnrichedName(account, languagePair);
+  json.subAccounts = (account.subAccounts || []).map((sub) => ({
+    ...sub.toJSON(),
+    nameVi: getEnrichedName(sub, languagePair),
+  }));
+  return json;
+}
+
+export default {
+  enrichBilingual,
+  TRANSLATION_MAP,
+  secondaryFieldSuffix,
+  getEnrichedName,
+  shapeAccountBilingual
+};

--- a/migrations/20260606120000-seed-payroll-subaccount-translations.cjs
+++ b/migrations/20260606120000-seed-payroll-subaccount-translations.cjs
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * Issue #186 — Seed payroll sub-account name translations
+ *
+ * Sub-accounts under 預り金 (源泉所得税, 健康保険料, 厚生年金保険料, 住民税)
+ * were missing from Translation seeds, causing ja-only display in ledger tabs.
+ *
+ * Also seeds 雇用保険料 and 介護保険料 as common siblings.
+ */
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    const now = new Date();
+
+    const nameMap = {
+      '源泉所得税':     ['Thuế TNCN khấu trừ tại nguồn', 'Withholding income tax'],
+      '健康保険料':     ['Phí bảo hiểm y tế',             'Health insurance premium'],
+      '厚生年金保険料': ['Phí bảo hiểm lương hưu',        'Employees\' pension insurance premium'],
+      '住民税':         ['Thuế cư trú',                    'Resident tax'],
+      '雇用保険料':     ['Phí bảo hiểm thất nghiệp',      'Employment insurance premium'],
+      '介護保険料':     ['Phí bảo hiểm chăm sóc dài hạn', 'Long-term care insurance premium']
+    };
+
+    const records = [];
+    for (const [ja, [vi, en]] of Object.entries(nameMap)) {
+      records.push({
+        tableName: 'Account', recordKey: `name:${ja}`, field: 'name',
+        language: 'vi', value: vi, tenantId: null, createdAt: now, updatedAt: now
+      });
+      records.push({
+        tableName: 'Account', recordKey: `name:${ja}`, field: 'name',
+        language: 'en', value: en, tenantId: null, createdAt: now, updatedAt: now
+      });
+      records.push({
+        tableName: 'SubAccount', recordKey: `name:${ja}`, field: 'name',
+        language: 'vi', value: vi, tenantId: null, createdAt: now, updatedAt: now
+      });
+      records.push({
+        tableName: 'SubAccount', recordKey: `name:${ja}`, field: 'name',
+        language: 'en', value: en, tenantId: null, createdAt: now, updatedAt: now
+      });
+    }
+
+    if (records.length > 0) {
+      await queryInterface.bulkInsert('Translations', records);
+    }
+  },
+
+  async down(queryInterface) {
+    const jaNames = [
+      '源泉所得税', '健康保険料', '厚生年金保険料', '住民税',
+      '雇用保険料', '介護保険料'
+    ];
+    await queryInterface.bulkDelete('Translations', {
+      tenantId: null,
+      tableName: ['Account', 'SubAccount'],
+      field: 'name',
+      recordKey: jaNames.map((n) => `name:${n}`)
+    });
+  }
+};

--- a/routes/api_account.js
+++ b/routes/api_account.js
@@ -1,12 +1,13 @@
 import models from '../models/index.js';
 const Op = models.Sequelize.Op;
 import Accounts from '../libs/accounts.js';
-import { enrichBilingual } from '../libs/bilingual-helper.js';
+import { enrichBilingual, shapeAccountBilingual } from '../libs/bilingual-helper.js';
 
 export default {
   get: async (req, res, next) => {
     const tenantId = req.currentTenantId;
     let account_code = req.params.code;
+    const lp = req.query.languagePair ? JSON.parse(req.query.languagePair) : req.session?.languagePair;
 
     let account = await models.Account.findOne({
       where: {
@@ -24,7 +25,13 @@ export default {
     if (!account) {
       return res.status(404).json({ error: `Account not found: ${account_code}` });
     }
-    res.json(account);
+    if (lp) {
+      await enrichBilingual('Account', [account], lp);
+      if (account.subAccounts?.length) {
+        await enrichBilingual('SubAccount', account.subAccounts, lp);
+      }
+    }
+    res.json(shapeAccountBilingual(account, lp));
   },
   get_class: (req, res, next) => {
     const tenantId = req.currentTenantId;

--- a/test/bilingual-helper.test.mjs
+++ b/test/bilingual-helper.test.mjs
@@ -11,7 +11,13 @@ import { strict as assert } from 'node:assert';
 import bilingualHelper from '../libs/bilingual-helper.js';
 import mockModels from '../models/index.js';
 
-const { enrichBilingual, TRANSLATION_MAP } = bilingualHelper;
+const {
+  enrichBilingual,
+  TRANSLATION_MAP,
+  secondaryFieldSuffix,
+  getEnrichedName,
+  shapeAccountBilingual
+} = bilingualHelper;
 
 
 // ---------------------------------------------------------------------------
@@ -232,5 +238,96 @@ describe('enrichBilingual — enrichment', function () {
       assert.strictEqual(records[0].middle, 'B', 'original middle unchanged');
       assert.strictEqual(records[0].minor, 'C', 'original minor unchanged');
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// secondaryFieldSuffix / getEnrichedName / shapeAccountBilingual
+// ---------------------------------------------------------------------------
+
+describe('secondaryFieldSuffix', function () {
+
+  it('capitalizes language code', function () {
+    assert.strictEqual(secondaryFieldSuffix('vi'), 'Vi');
+    assert.strictEqual(secondaryFieldSuffix('en'), 'En');
+  });
+
+  it('returns empty string for falsy input', function () {
+    assert.strictEqual(secondaryFieldSuffix(undefined), '');
+    assert.strictEqual(secondaryFieldSuffix(''), '');
+  });
+});
+
+describe('getEnrichedName', function () {
+
+  it('reads nameVi when secondary is vi', function () {
+    const rec = mockRecord({ name: '預り金', nameVi: 'Tiền giữ hộ' });
+    assert.strictEqual(getEnrichedName(rec, { primary: 'ja', secondary: 'vi' }), 'Tiền giữ hộ');
+  });
+
+  it('reads nameEn when secondary is en', function () {
+    const rec = mockRecord({ name: '預り金', nameEn: 'Deposits received' });
+    assert.strictEqual(getEnrichedName(rec, { primary: 'ja', secondary: 'en' }), 'Deposits received');
+  });
+
+  it('returns empty string when no enriched field exists', function () {
+    const rec = mockRecord({ name: '預り金' });
+    assert.strictEqual(getEnrichedName(rec, { primary: 'ja', secondary: 'vi' }), '');
+  });
+});
+
+describe('shapeAccountBilingual', function () {
+
+  function mockAccountInstance(props, subAccounts = []) {
+    const data = { ...props, subAccounts };
+    return new Proxy(data, {
+      get(target, prop) {
+        if (prop === 'setDataValue') return (key, value) => { target[key] = value; };
+        if (prop === 'toJSON') return () => {
+          const { subAccounts: subs, ...rest } = target;
+          return { ...rest };
+        };
+        if (prop === 'getDataValue') return (key) => target[key];
+        return target[prop];
+      },
+      set(target, prop, value) {
+        target[prop] = value;
+        return true;
+      },
+      has(target, prop) { return prop in target; },
+      ownKeys(target) { return Reflect.ownKeys(target); },
+      getOwnPropertyDescriptor(target, prop) {
+        return Object.getOwnPropertyDescriptor(target, prop);
+      },
+    });
+  }
+
+  function mockSubInstance(props) {
+    return mockRecord(props);
+  }
+
+  it('maps account and sub-account enriched names to nameVi', function () {
+    const subs = [
+      mockSubInstance({ id: 1, name: '源泉所得税', nameVi: 'Thuế TNCN khấu trừ tại nguồn', subAccountCode: 1 }),
+      mockSubInstance({ id: 2, name: '住民税', nameVi: 'Thuế cư trú', subAccountCode: 2 }),
+    ];
+    const account = mockAccountInstance(
+      { id: 10, name: '預り金', nameVi: 'Tiền giữ hộ', accountCode: '2010000' },
+      subs
+    );
+
+    const shaped = shapeAccountBilingual(account, { primary: 'ja', secondary: 'vi' });
+
+    assert.strictEqual(shaped.name, '預り金');
+    assert.strictEqual(shaped.nameVi, 'Tiền giữ hộ');
+    assert.strictEqual(shaped.subAccounts.length, 2);
+    assert.strictEqual(shaped.subAccounts[0].nameVi, 'Thuế TNCN khấu trừ tại nguồn');
+    assert.strictEqual(shaped.subAccounts[1].nameVi, 'Thuế cư trú');
+  });
+
+  it('returns empty nameVi when languagePair has no secondary', function () {
+    const account = mockAccountInstance({ name: '預り金', accountCode: '2010000' }, []);
+    const shaped = shapeAccountBilingual(account, { primary: 'ja' });
+    assert.strictEqual(shaped.nameVi, '');
   });
 });


### PR DESCRIPTION
Part of epic:bilingual-foundation

## Summary
- Enrich GET /api/account/:code with bilingual translations
- Seed payroll sub-account name translations
- Wire BilingualText on ledger, changes, and bank-ledger pages

Closes #186