### PR TITLE
chore(#191): update harness framework

### DIFF
--- a/docs/stories/backlog.md
+++ b/docs/stories/backlog.md
@@ -10,4 +10,5 @@ the work is selected or when a product decision needs a durable place to land.
 
 | Epic | Description | Status |
 | --- | --- | --- |
-| TBD | Add candidate epics after spec intake | unsliced |
+| bilingual-foundation (#89) | Simultaneous bilingual display (Việt–Nhật): Translations DB, locales, BilingualText, preference API, UI migration | **completed** — merged to `main` via PR #190 (2026-06-06); 41 issues closed |
+| TBD | Next initiative after spec intake | unsliced |

--- a/scripts/schema/002-story-verify.sql
+++ b/scripts/schema/002-story-verify.sql
@@ -1,0 +1,9 @@
+-- Harness v0 schema - migration 002
+-- Story-level mechanical verification.
+
+ALTER TABLE story ADD COLUMN verify_command TEXT;
+ALTER TABLE story ADD COLUMN last_verified_at TEXT;
+ALTER TABLE story ADD COLUMN last_verified_result TEXT
+    CHECK(last_verified_result IN ('pass','fail') OR last_verified_result IS NULL);
+
+INSERT INTO schema_version (version) VALUES (2);


### PR DESCRIPTION
Closes #191

### Summary

- Add Harness schema migration 002 for story verification fields.
- Update Harness backlog to mark bilingual foundation completed.

### Verification

- `scripts/bin/harness-cli.exe --version` -> `harness-cli 0.1.8`
- `scripts/bin/harness-cli.exe migrate`
- `scripts/bin/harness-cli.exe query matrix`