### PR TITLE
docs: E0-E3 initiative plans for 試算表 + シミュレーション

### DIFF
--- a/docs/stories/epics/E00-reporting-engine/initiative.md
+++ b/docs/stories/epics/E00-reporting-engine/initiative.md
@@ -1,0 +1,184 @@
+# E00 — Reporting Engine Foundation
+
+> Initiative notes. Shared artifact (committed). Mapped to git branch `epic/reporting-engine` and GitHub label `epic:reporting-engine`.
+
+Date: 2026-06-07
+Status: proposed
+Lane: high-risk (touches calculation core, multi-tenant closing, data integrity)
+
+## Goal
+
+Tạo một calculation engine duy nhất cho mọi báo cáo tài chính (試算表, simulated TB, comparison, ledger), đồng thời sửa quy trình đóng sổ đang hỏng sau khi lên multi-tenant. E0 là nền bắt buộc cho E1, E2, E3 — nếu không có E0, các epic sau sẽ đẻ logic riêng và actual ≠ simulated.
+
+## Why now
+
+- `libs/trial_balance.js`, `front/svelte/trial-balance/trial-balance.svelte:151`, `libs/ledger.js` đang tính balance theo 3 cách khác nhau. Frontend tính lại balance là rủi ro cao nhất.
+- `forms/closing.js:42` gọi `Accounts.all3(fy.term)` trong khi signature yêu cầu `(tenantId, term, languagePair)` → truyền nhầm tham số.
+- `routes/api.js:92` và `routes/home.js:11` gọi `closing(term)` thiếu `tenantId` → sẽ throw hoặc ghi sai tenant.
+- Không có engine chuẩn → E2 simulation sẽ tự viết calculator riêng, sinh bug so sánh.
+
+## Affected product docs (to be created in E0)
+
+- `docs/product/reporting/calculation-engine.md` — domain rules, mô hình balance, opening/movement/ending.
+- `docs/product/reporting/closing-process.md` — closing flow, BS carry-forward, PL reset, 繰越利益剰余金, multi-tenant guards.
+- `docs/product/reporting/warnings.md` — mã cảnh báo TB-W001..W010 (canonical list lấy từ BRD mục 10.9).
+
+## Scope
+
+**In scope:**
+- Một engine tính số dư/movement duy nhất, dùng được cho actual, simulated, ledger.
+- Closing đa tenant đúng, có confirm UI.
+- Xoá logic tính balance ở frontend (màn legacy `/trial-balance`).
+- Unit test cho engine: BS carry-forward, PL reset, debit=credit, hierarchy subtotal.
+
+**Out of scope:**
+- 3 report type 試算表 (E1).
+- Simulation (E2).
+- Forecast (E3).
+- Sửa UI màn `/trial-balance` cũ sang 3 tab (E1).
+
+## Architecture direction
+
+### Reporting engine (canonical)
+
+```text
+libs/reporting/balance-engine.js
+
+  balanceEngine({
+    tenantId,                // required
+    term,                    // required, FiscalYear.term
+    period: { from, to },    // inclusive day boundary
+    entrySources: [          // one or more async iterators of "movement lines"
+      { name: 'actual',    fetch: () => CrossSlipDetail[] },
+      { name: 'simulation', fetch: () => SimulationEntry[] }  // future
+    ],
+    options: {
+      includeUnapproved = false,
+      accountClassIds = null,
+      projectIds = null,
+      labelIds = null,
+      subAccount = true
+    }
+  }) → {
+    lines: [{
+      accountId, subAccountId|null,
+      code, name, nameVi, subCode, subName, subNameVi,
+      major, middle, minor, majorVi, middleVi, minorVi,
+      openingDebit, openingCredit, openingBalance,
+      movementDebit, movementCredit,
+      endingDebit, endingCredit, endingBalance
+    }],
+    warnings: [{ code, severity, message, ref }],
+    meta: { generatedAt, entrySourceNames, tenantId, term, period }
+  }
+```
+
+Key rules:
+- Opening lấy từ `AccountRemaining`/`SubAccountRemaining` (giữ pattern hiện tại). `field(code) >= 6` (revenue/expense) chỉ có movement ở kỳ hiện tại; opening từ term trước = 0.
+- Movement cộng dồn từ tất cả `entrySources`. Mỗi entry = 1 dòng Nợ/Có theo `account_code` + `sub_account_code`.
+- Ending tính theo `dc(code)` nature:
+  - D: `ending = opening + debit - credit`
+  - C: `ending = opening - debit + credit`
+- Subtotal theo `AccountClass` được tính trong consumer (UI/export), engine trả flat list.
+- Decimal an toàn: dùng `numeric()` helper đã có, tránh float. Mọi tổng phải có thể chạy `debitTotal === creditTotal` cho mọi period (sanity invariant).
+
+### Multi-tenant guards
+
+- Mọi query trong engine scope theo `tenantId`. Bắt buộc tham số, không default.
+- `AccountRemaining`/`SubAccountRemaining` đã có `tenantId` — chỉ cần truyền đúng.
+- Closing phải từ chối nếu thiếu `tenantId` (throw ở top-level guard, không để truyền nhầm vào `AccountId` chỗ `tenantId`).
+
+### Closing flow (fixed)
+
+```text
+POST /api/closing/:term          (existing endpoint, just fix params)
+  └─> requireTenant middleware
+        └─> closing(tenantId, term)
+              ├─> fiscalYear(tenantId, term)  // returns [fy, nfy]
+              ├─> balanceEngine(tenantId, fy.term, { from, to: fy.endDate }, { entrySources: [actual] })
+              ├─> net_income = Σ revenue accounts (field >= 6 && <= 9) credit - debit
+              ├─> 繰越利益剰余金 (5040000): ending = previous + net_income
+              └─> Closing: for each account/subaccount
+                    if field(code) < 6 (BS):  // 1,2,3,4,5
+                      AccountRemaining(nfy.term).{debit,credit,balance} = endingBalance
+                    else if field(code) >= 6 (PL):
+                      reset to 0 in nfy.term
+```
+
+Pl hard-coded special case `7020010` (期末商品棚卸高) — dc='C' override — must be preserved.
+
+### Closing confirm UI
+
+- Route mới: `GET /closing/:term/confirm` (Svelte form, server-rendered).
+- Trang hiển thị: term + tenant + cảnh báo "操作は取り消せません" (hành động không thể huỷ) + checklist:
+  - [ ] Tất cả CrossSlip trong term đã approved (đếm số unapproved).
+  - [ ] Tổng Debit = Tổng Credit của term (tính từ engine).
+  - [ ] `FiscalYear` kỳ kế tiếp chưa tồn tại hoặc đang trống.
+  - [ ] **PL precheck** (mục 0.3 đã chốt): nếu bất kỳ `AccountRemaining(nextTerm, plAccount)` đã có debit/credit ≠ 0, hiển thị **banner đỏ** "Kỳ kế tiếp đã có số dư PL — sẽ bị reset khi đóng sổ". Checkbox bắt buộc "Tôi đã hiểu và muốn tiếp tục" phải tick trước khi nút "Đóng sổ" enable. (Quyết định reset: admin role; role khác → 403.)
+- Nút "Đóng sổ" → POST `/api/closing/:term` (kèm cờ `plResetAcknowledged=true` để server không reject).
+- Sau khi đóng sổ xong: chuyển `/reports/trial-balance?term=<nfy>` với banner "Đã đóng sổ term X".
+- Audit: ghi bảng **`AuditEvent`** (bảng mới — mục 0.4 đã chốt) với `action='closing', term, tenantId, actorId, payload={plResetAcknowledged, totalsSnapshot, warnings}`.
+
+## Risk classification
+
+Risk flags (theo `docs/FEATURE_INTAKE.md`):
+- **Data model** — sửa schema tham chiếu, không migration mới.
+- **Public contracts** — `api_trial_balance.js`, `api_ledger.js`, `api/closing/:term` response shape.
+- **Existing behavior** — đụng calculation core, frontend.
+- **Multi-domain** — closing, trial balance, ledger.
+- **Audit/security** — closing = destructive, cần audit log.
+- **Auth** — phải gắn `is_authenticated` + `requireTenant`.
+
+Hard gates: Data loss risk, Authorization, Audit/security.
+→ **Lane: high-risk**. Mỗi issue phải dùng `docs/templates/high-risk-story/` folder (execplan/overview/design/validation).
+
+## Candidate stories (issues)
+
+| # | Title | Lane | Depends on | Notes |
+|---|---|---|---|---|
+| 0.1 | `libs/reporting/balance-engine.js` core + unit tests | high-risk | — | Foundation. Engine đơn nguồn, không phụ thuộc Express/Svelte. |
+| 0.2 | Wire engine vào `routes/api_trial_balance.js`, xoá frontend re-compute | high-risk | 0.1 | Màn legacy vẫn dùng được, balance chỉ từ server. |
+| 0.3 | Sửa `forms/closing.js` cho đa tenant | high-risk | 0.1 | Sửa call sites, dùng engine, verify carry-forward. |
+| 0.4 | Closing confirm UI + audit log | high-risk | 0.3 | Svelte form, checklist, button "Đóng sổ". |
+| 0.5 | Reconciliation test: engine ending == ledger sums | high-risk | 0.1, 0.2 | Mocha, chạy 2 cách rồi assert bằng nhau cho 10 accounts + 5 sub-accounts cố định. |
+
+Không tạo `SimulationEntry` hay model mới ở E0. Engine chỉ chấp nhận `entrySources` là contract.
+
+## Validation ladder
+
+- **Unit:** mocha test `test/reporting/balance-engine.test.js`. Cases:
+  - Account D-nature: ending = opening + debit - credit.
+  - Account C-nature: ending = opening - debit + credit.
+  - `7020010` override: dù dc=702 → dc=C, balance theo C-nature.
+  - Revenue/expense: opening=0 kể cả khi kỳ trước có số dư (sau closing).
+  - `entrySources` nhiều nguồn: totalDebit = totalCredit.
+  - Subtotal: Σ endingBalance con = endingBalance parent (engine trả flat, test consumer).
+  - Decimal safety: amount lớn + phép cộng nhiều lần không lệch.
+- **Integration:** closing một term mẫu, đọc `AccountRemaining` kỳ sau khớp ending kỳ trước cho BS; PL kỳ sau = 0.
+- **Reconciliation:** engine ending == `ledgerLines(...).sums.balance` (cho cùng account/subaccount/period).
+- **E2E:** `npm start`, mở `/closing/2024/confirm`, đóng sổ, `/trial-balance` kỳ sau hiển thị số dư mới.
+- **Smoke:** `npm run build` + `npm test` pass.
+
+## Exit criteria
+
+E0 done khi tất cả:
+- [ ] `balance-engine.js` tồn tại, có unit test, có JSDoc.
+- [ ] Frontend `trial-balance.svelte` không còn `numeric + dc()` re-compute; chỉ render.
+- [ ] `closing.js` nhận `(tenantId, term)`, throw rõ ràng nếu thiếu.
+- [ ] `/closing/:term/confirm` hoạt động với checklist + audit log.
+- [ ] Reconciliation test pass.
+- [ ] Test Report đăng lên GitHub issue của từng story; trace ghi vào `harness.db` key theo issue number.
+- [ ] PR `epic/reporting-engine` → `main` merge sạch, không có vấn đề reopen.
+
+## Open decisions (đã chốt 2026-06-07)
+
+1. **0.1** `entrySources` = **array of fetchers** `[{name, fetch}]`. Engine log từng nguồn qua `meta.entrySourceNames` để audit/debug simulation về sau.
+2. **0.3** Closing confirm UI: nếu `AccountRemaining(nextTerm, plAccount)` đã có debit/credit ≠ 0 thì **warning đỏ**, admin phải confirm thêm 1 lần trước khi reset.
+3. **0.4** Audit log dùng **bảng mới `AuditEvent`** (không dùng `MonthlyLog`). Volume simulation/E2 sẽ cao, cần schema chuyên dụng. E2/E3 sẽ dùng chung.
+4. **0.5** Reconciliation test: **fix 10 accounts + 5 sub-accounts** đại diện (BS D, BS C, PL, edge case `7020010`, có sub-account). Không random để debug dễ. Phase 2 sẽ thêm property-based test.
+
+## Follow-up (out of E0 nhưng cần nhắc)
+
+- Sau E0, mọi epic downstream (E1/E2/E3) bắt buộc dùng engine. CI sẽ có rule (lint hoặc test) cấm import `AccountRemaining.findAll`/`CrossSlipDetail.findAll` trực tiếp ở route/UI — phải qua engine. Có thể thêm ở E1 PR.
+- Khi E2 đến, `entrySources` contract đã có sẵn, chỉ thêm `simulation` source.
+- Khi E3 đến, `SimulationAssumption` là wrapper sinh `SimulationEntry` — engine không cần đổi.

--- a/docs/stories/epics/E01-trial-balance/initiative.md
+++ b/docs/stories/epics/E01-trial-balance/initiative.md
@@ -1,0 +1,207 @@
+# E01 — Trial Balance Foundation
+
+> Initiative notes. Shared artifact (committed). Mapped to git branch `epic/trial-balance` and GitHub label `epic:trial-balance`.
+
+Date: 2026-06-07
+Status: proposed
+Lane: high-risk (touches public contract `api/trial-balance/*`, financial reporting, multi-tenant data isolation)
+
+## Goal
+
+Xây dựng màn hình 試算表 mới với 3 report type (残高/合計/合計残高), hierarchy đầy đủ tới 補助科目, drill-down xuống ledger và journal, cảnh báo bất thường, và export Excel. Dựa trên reporting engine đã có ở E0. Tạo màn mới `/reports/trial-balance` (3 tab); giữ màn legacy `/trial-balance` cho tới khi E1.10 mới gỡ.
+
+## Why now
+
+- `api_trial_balance.js` hiện chỉ trả về `lines` ở dạng balance. Chưa hỗ trợ 合計/合計残高, chưa filter phong phú, chưa drill-down, chưa export.
+- `front/svelte/trial-balance/trial-balance.svelte:151` đang tính lại balance ở frontend — sẽ được gỡ ở E1.10.
+- Kế toán nội bộ + 税理士 cần xem 試算表 đầy đủ + 比較 để đối chiếu.
+- E2 simulation cần cùng bề mặt báo cáo với actual — phải có E1 trước mới có gì để overlay.
+
+## Affected product docs (to be created/updated)
+
+- `docs/product/reporting/trial-balance-reports.md` — định nghĩa 3 report type, columns, subtotals.
+- `docs/product/reporting/hierarchy.md` — 大/中/小/勘定/補助 và cách engine trả subtotal.
+- `docs/product/reporting/warnings.md` — TB-W001..W010 (canonical, từ BRD mục 10.9; E0 tạo file, E1 implement).
+- `docs/product/reporting/bilingual-display.md` — JP/VI/bilingual mode, fallback rule, export language.
+- `docs/product/reporting/export-spec.md` — Excel template cho 試算表, file name pattern.
+
+## Scope
+
+**In scope:**
+- 3 report type: 残高試算表, 合計試算表, 合計残高試算表.
+- Hierarchy 5 cấp (大/中/小/勘定/補助科目) với subtotal + expand/collapse.
+- Bilingual JP/VI/bilingual mode cho account name + report header.
+- Drill-down row → ledger (`api_ledger.js` đã có) → journal detail.
+- Warnings TB-W001, W002, W005 (debit≠credit, unapproved tồn tại, cash/bank âm). W003/W004/W006-W010 ở E2/E3 hoặc phase sau.
+- Excel export với số liệu + filter + language mode trong header.
+- Filter: term, month, account class, hide-zero, language.
+- Màn mới `/reports/trial-balance` 3 tab; màn legacy `/trial-balance` giữ nguyên, có banner "sẽ gỡ ở E1.10".
+
+**Out of scope:**
+- Comparison view (TB-010) — E2 nếu cần, hoặc phase 2.
+- Monthly trend, project/label filter — phase 2.
+- PDF export — phase 2 (đã có `forms/trial-balance` + `libs/print.js`).
+- Formula engine, simulation — E2.
+
+## Architecture direction
+
+### New route prefix
+
+`/reports/trial-balance` — Svelte view mới. Legacy vẫn ở `/trial-balance`. Hai URL hoạt động song song cho tới E1.10.
+
+### API changes (additive, không phá legacy)
+
+Mở rộng `routes/api_trial_balance.js`:
+
+```
+GET /api/trial-balance?reportType=balance|movement|combined
+                          &term=<int>
+                          &month=YYYY-MM[&end=true]   // optional
+                          &languagePair=<json>        // existing
+                          &accountClassIds=<csv>      // new
+                          &hideZero=<bool>            // new
+                          &includeUnapproved=<bool>   // new, default false
+```
+
+Response mới (versioned qua field `version: 2`):
+
+```json
+{
+  "version": 2,
+  "meta": {
+    "tenantId", "term", "reportType", "period": { "from", "to" },
+    "languageMode", "generatedAt", "warnings": [{ "code", "severity", "message" }],
+    "totals": { "openingDebit", "openingCredit", "movementDebit", "movementCredit", "endingDebit", "endingCredit" }
+  },
+  "lines": [
+    {
+      "type": "subtotal" | "account" | "subAccount",
+      "aclCode"?, "major", "middle", "minor", "majorVi", "middleVi", "minorVi",
+      "accountId"?, "code"?, "name", "nameVi",
+      "subAccountId"?, "subCode"?, "subName"?, "subNameVi"?,
+      "openingDebit", "openingCredit", "movementDebit", "movementCredit",
+      "endingDebit", "endingCredit",
+      "balance": <signed by dc()>,
+      "warningCodes": ["TB-W001"...]
+    }
+  ]
+}
+```
+
+Legacy response chỉ trả `lines` (mảng phẳng) — giữ nguyên endpoint cũ để màn legacy không vỡ.
+
+### Subtotal & hierarchy
+
+- Engine trả flat (E0 đã chốt).
+- Consumer (UI helper + export) build subtotal dọc theo `major → middle → minor` và chèn `type:'subtotal'` rows.
+- Subtotal = Σ dòng con (chỉ `type:'account'`/`type:'subAccount'`).
+- Subtotal cho `endingDebit`/`endingCredit`: theo dc-nature của từng account con, không gộp vào 1 cột (giữ nguyên tắc kế toán).
+
+### Warnings
+
+| Code | Severity | Rule | Engine action |
+|---|---|---|---|
+| TB-W001 | critical | Σ movementDebit ≠ Σ movementCredit cho period | Top banner, chặn export nếu strict mode |
+| TB-W002 | high | Có `CrossSlip` term hiện tại có `approvedAt IS NULL` | Banner + link tới danh sách unapproved |
+| TB-W005 | medium | `普通預金` (hoặc cash/bank theo config) có endingDebit < 0 | Highlight row đỏ |
+
+Config: `lib/reporting/warning-rules.js` — array rule, mỗi rule có `id, severity, evaluate(lines, meta) → messages[]`. Phase 1 hard-code 3 rule; phase sau expose config.
+
+### Drill-down
+
+- Component Svelte: `<TrialBalanceDrillDown>` mở **modal** (mục 1.5 đã chốt). Tái dùng pattern modal hiện có (`front/svelte/cross-slip/cross-slip-modal.svelte`, `front/svelte/common/ok-modal.svelte`). Phase sau detect viewport rộng → chuyển panel.
+- Click row `account` → gọi `api_ledger.js?accountCode=<>&from=<>&to=<>` (đã có, tận dụng).
+- Click row `subAccount` → truyền thêm `subAccountCode=`.
+- Trong panel drill-down: button "Mở ledger đầy đủ" → `/ledger/{accountCode}?from=&to=`.
+- Phase 1 chưa drill tới journal/voucher ở TB; link "Xem chứng từ" ở ledger row.
+
+### Bilingual display
+
+- `languagePair` đã có từ epic bilingual-foundation. Reuse `enrichBilingual` pattern.
+- Modes: `ja`, `vi`, `ja-vi`, `vi-ja`. Engine nhận `languagePair`; trả `{name, nameVi, major, middle, minor, majorVi, middleVi, minorVi}` cho mỗi line. UI ghép theo mode.
+- Fallback: thiếu `nameVi` → dùng `name`; thiếu `name` → `code`.
+- Export: thêm 1 row header với `言語: {mode}` (label dùng `BilingualText`).
+
+### Excel export
+
+- Tái dùng pattern `exceljs` từ `libs/parse_accounts.js` + `front/svelte/project/project-summary.svelte`.
+- File: `libs/reporting/tb-export.js` (server-side) — function `exportTrialBalance(workbook, response) → buffer`.
+- Sheet `試算表_<reportType>`:
+  - Row 1-3: tenant, term, period, language mode, generatedAt.
+  - Row 4: column header (bilingual theo mode).
+  - Row 5+: data (subtotal + account + subAccount theo thứ tự).
+  - Row cuối: totals.
+  - Sheet `Warnings`: nếu có.
+- Number format: `#,##0;[Red]-#,##0` (theo BRD mục 10.11).
+- File name: `trial_balance_{tenantCode}_{term}_{YYYYMMDDHHmm}.xlsx`.
+- API: `GET /api/trial-balance/export?...` trả `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` với `Content-Disposition`.
+
+## Risk classification
+
+Risk flags:
+- **Public contracts** — `api/trial-balance/*` thêm `version: 2`, query params mới, route mới `/export`.
+- **Data model** — không migration (chỉ thêm field response).
+- **Existing behavior** — frontend mới không được vỡ legacy.
+- **Multi-domain** — UI + API + export.
+- **Authorization** — chỉ role accounting mới xem. Reuse `requireTenant` + check role hiện có.
+
+Hard gates: Public contracts (response shape thay đổi).
+→ **Lane: high-risk**. Mỗi issue dùng `docs/templates/high-risk-story/` folder.
+
+## Candidate stories (issues)
+
+| # | Title | Lane | Depends on | Notes |
+|---|---|---|---|---|
+| 1.1 | API v2: 3 report type, filter, totals, warnings | high-risk | E0.1, E0.2 | Backbone của E1. |
+| 1.2 | Subtotal builder consumer (helper, dùng chung cho UI + export) | normal | 1.1 | Library-only, không UI. |
+| 1.3 | View mới `/reports/trial-balance` — 3 tab (残高/合計/合計残高) | high-risk | 1.1, 1.2 | Bilingual header, filter bar. |
+| 1.4 | Hierarchy 5 cấp + expand/collapse + 補助科目 rows | high-risk | 1.2, 1.3 | Click expand/collapse, indent. |
+| 1.5 | Drill-down row → ledger (modal) | normal | 1.3, ledger đã có | Sub-account truyền cả `subAccountCode`. |
+| 1.6 | Warnings panel (TB-W001, W002, W005) | normal | 1.1 | Banner + highlight row. |
+| 1.7 | Excel export server-side | high-risk | 1.1, 1.2, 1.6 | API `/api/trial-balance/export`. |
+| 1.8 | Filter UI: term/month/account class/hide-zero/language | normal | 1.3 | Reset, hiển thị filter đang áp dụng. |
+| 1.9 | Bilingual mode selector + fallback test | normal | 1.3 | Mode ja/vi/ja-vi/vi-ja. |
+| 1.10 | Gỡ màn legacy `/trial-balance` + redirect sang `/reports/trial-balance` | normal | 1.3 | Sau khi màn mới stable. Remove `front/svelte/trial-balance/` (không xoá lib `trial_balance.js` — vẫn dùng bởi E0). |
+| 1.11 | Reconciliation test E2E: API v2 ending == ledger sums == UI render | high-risk | 1.3, 1.4, 1.5, 1.6, 1.7 | Mocha, mocha-headless, screenshot. |
+
+## Validation ladder
+
+- **Unit (mocha):**
+  - `libs/reporting/tb-subtotal.test.js` — subtotal = Σ con cho mọi level.
+  - `libs/reporting/tb-export.test.js` — workbook có đúng sheet, header, totals.
+  - `libs/reporting/warning-rules.test.js` — W001 catch mismatch, W005 catch cash âm.
+- **Integration:**
+  - `test/integration/trial-balance-v2.test.js` — 3 report type, filter, language.
+  - Drill-down: API drill gọi đúng ledger endpoint với cùng filter.
+- **E2E (manual via `npm start` + headless):**
+  - Mở `/reports/trial-balance`, chọn report type, xem hierarchy, expand/collapse, drill-down, export.
+  - Dùng `chrome-devtools` MCP để chụp 3 tab.
+- **Reconciliation:**
+  - `Σ movementDebit(trial balance v2) === Σ movementDebit(ledger sums)` cho 5 accounts random.
+  - `endingBalance(v2) === endingBalance(closing.js nfy)` cho 5 BS accounts.
+- **Smoke:** `npm run build` + `npm test` pass.
+
+## Exit criteria
+
+E1 done khi tất cả:
+- [ ] API v2 trả đúng 3 report type, filter, warnings, totals, bilingual data.
+- [ ] View `/reports/trial-balance` hoạt động với 3 tab, hierarchy 5 cấp, drill-down, export.
+- [ ] 3 warning rule chạy đúng trong mọi scenario test.
+- [ ] Excel file mở được, số liệu khớp UI, header theo language mode.
+- [ ] Reconciliation test pass cho ≥ 5 accounts.
+- [ ] Màn legacy vẫn chạy (E1.10 chưa thực hiện).
+- [ ] Test Report đăng lên từng issue; trace ghi `harness.db`.
+
+## Open decisions (đã chốt 2026-06-07)
+
+1. **1.1** API v2 = **cùng endpoint `/api/trial-balance` + field `version` trong response** (`?version=2` → shape mới; không có → legacy). Handler branch theo version cho tới khi E1.10 gỡ legacy. E2 simulation gọi cùng endpoint với extra `entrySources`.
+2. **1.5** Drill-down = **modal** ở phase 1 (ít đụng layout). Có thể detect viewport rộng → chuyển panel ở phase sau.
+3. **1.6** W001 (debit≠credit) **không chặn export** ở phase 1: chỉ banner đỏ + ghi warning vào file Excel. Chặn = phase 2 sau user feedback.
+4. **1.7** Excel sinh **server-side** (`libs/reporting/tb-export.js`, `exceljs` đã có). Cùng data source với API v2, tránh tái lặp lỗi "frontend tự tính" mà E0 vừa gỡ.
+5. **1.9** Bilingual mode **không persist** ở phase 1 (chỉ session/URL). Persist vào user preference để dành E2 khi comparison cần sticky.
+
+## Follow-up
+
+- E2 sẽ gọi cùng API v2 với `entrySources` mở rộng → engine trả `endingBalance = actual + simulation`. Cùng subtotal builder, cùng export, cùng warnings (thêm "SIMULATION" badge trong header).
+- E1.10 gỡ legacy đặt ở cuối E1 vì cần màn mới ổn trước.
+- TB-006 (comparison view) và TB-007 (advanced filters: project/label) — phase 2, không thuộc E1.

--- a/docs/stories/epics/E02-simulation/initiative.md
+++ b/docs/stories/epics/E02-simulation/initiative.md
@@ -1,0 +1,280 @@
+# E02 — Simulation MVP (Manual Journal)
+
+> Initiative notes. Shared artifact (committed). Mapped to git branch `epic/simulation` and GitHub label `epic:simulation`.
+
+Date: 2026-06-07
+Status: proposed
+Lane: high-risk (new domain, multi-tenant data isolation, public contract mới, đụng độ xác suất với actual data)
+
+## Goal
+
+Cho phép tạo scenario simulation chứa virtual journal entries (mirror `CrossSlipDetail`), xem simulated 試算表 và actual-vs-simulated comparison, hỗ trợ clone/archive/lock, và export Excel với badge rõ ràng "không phải dữ liệu kế toán chính thức". Tận dụng reporting engine (E0) và trial balance view (E1) — không viết calculation riêng.
+
+## Why now
+
+- E0 đã chốt `entrySources` contract cho phép inject virtual entries.
+- E1 đã có API v2 + UI + export — simulation chỉ thêm nguồn dữ liệu + tab "Simulation" trong cùng view.
+- Người dùng (chủ DN, kế toán) cần dự phóng trước khi quyết định tuyển người / tăng giá / cắt chi phí. Hiện không có công cụ nào trong app.
+- Đã có BRD ở `new_feature_brainstorm_result.md` (mục 11.1–11.10) — simulation MVP scope đã chốt ở BRD mục 22.2 (manual journal trước, forecast sau).
+
+## Affected product docs (to be created/updated)
+
+- `docs/product/simulation/concepts.md` — scenario, virtual entry, actual vs simulation, lock state, badge rule.
+- `docs/product/simulation/data-model.md` — `SimulationScenario`, `SimulationEntry` schema + tenant scoping.
+- `docs/product/simulation/permissions.md` — ai tạo/clone/lock/export được gì.
+- `docs/product/simulation/ui-flow.md` — list / detail / TB tab / comparison tab.
+- Update `docs/product/reporting/warnings.md` — thêm SIM-W001..W005 (TB-W001 ngữ cảnh simulation).
+
+## Scope
+
+**In scope (BRD mục 22.2):**
+- Scenario CRUD (tạo, sửa ở draft, clone, archive, lock).
+- Virtual journal entries: cân bằng Nợ/Có, amount > 0, debit≠credit, có memo/project/label/sub-account.
+- Simulated 試算表: gọi engine với `entrySources = [actual, simulation]`, dùng cùng subtotal builder + export từ E1.
+- Actual vs simulated comparison (TB-007 trong BRD): cột actual / adjustment / simulated / difference / difference%.
+- Clone scenario tạo bản độc lập.
+- Lock scenario: không sửa entries/assumptions/period; clone ra draft mới.
+- Excel export scenario với header ghi rõ "SIMULATION - NOT OFFICIAL ACCOUNTING REPORT" + lock timestamp nếu có.
+- Tenant isolation + role-based permission.
+
+**Out of scope (E2):**
+- Recurring assumptions (SIM-003) — E3.
+- Revenue growth / expense growth / cash projection (SIM-004/005/006) — E3.
+- `SimulationAssumption` table — chưa cần; E2 chỉ lưu `SimulationEntry` raw.
+- Tax estimate (SIM optional) — phase sau.
+- Convert simulation → actual journal — **KHÔNG** trong MVP, BRD Open Q #8 đã cảnh báo "tránh tai nạn kế toán".
+- Multi-scenario compare (best/base/worst) — phase sau.
+- Budget integration — phase sau.
+
+## Architecture direction
+
+### Data model
+
+**`SimulationScenario`** (mới):
+
+| Field | Type | Note |
+|---|---|---|
+| id | INT PK | |
+| tenantId | INT NOT NULL | index, FK |
+| name | STRING(200) NOT NULL | |
+| description | TEXT | nullable |
+| baseTerm | INT NOT NULL | term chứa actual data dùng làm nền |
+| basePeriodFrom | DATE NOT NULL | thường = fy.startDate |
+| basePeriodTo | DATE NOT NULL | mặc định = fy.endDate |
+| simPeriodFrom | DATE NOT NULL | ≥ basePeriodTo+1 |
+| simPeriodTo | DATE NOT NULL | > simPeriodFrom |
+| status | ENUM('draft','locked','archived') DEFAULT 'draft' | |
+| ownerId | INT NOT NULL | FK user |
+| visibility | ENUM('private','shared') DEFAULT 'private' | |
+| lockedAt | DATE | nullable |
+| lockedBy | INT | FK user, nullable |
+| createdAt, updatedAt | TIMESTAMP | |
+
+Indexes: `(tenantId, status)`, `(tenantId, ownerId)`.
+
+**`SimulationEntry`** (mới, mirror `CrossSlipDetail` không có approved):
+
+| Field | Type | Note |
+|---|---|---|
+| id | INT PK | |
+| tenantId | INT NOT NULL | |
+| scenarioId | INT NOT NULL | FK, index |
+| date | DATE NOT NULL | trong [simPeriodFrom, simPeriodTo] |
+| debitAccount | STRING(20) NOT NULL | FK accountCode |
+| debitSubAccount | INT | FK subAccount, nullable |
+| debitAmount | DECIMAL(12) NOT NULL | > 0 |
+| creditAccount | STRING(20) NOT NULL | |
+| creditSubAccount | INT | nullable |
+| creditAmount | DECIMAL(12) NOT NULL | > 0 |
+| taxRuleId | INT | nullable, FK |
+| projectId | INT | nullable, FK |
+| labelId | INT | nullable, FK |
+| memo | STRING(500) | |
+| sourceType | ENUM('manual') DEFAULT 'manual' | E3 sẽ thêm 'recurring' |
+| createdAt, updatedAt | TIMESTAMP | |
+
+Constraint: `debitAmount > 0`, `creditAmount > 0`, `debitAmount = creditAmount` (validate ở app layer), `debitAccount ≠ creditAccount`. KHÔNG có `approvedAt` (BR-SIM-001).
+
+**Không tạo `SimulationAssumption`** ở E2 — E3 sẽ thêm.
+
+### Routes / API
+
+```
+# Scenario CRUD
+GET    /api/simulation/scenarios                  list
+POST   /api/simulation/scenarios                  create
+GET    /api/simulation/scenarios/:id              detail (with entries)
+PATCH  /api/simulation/scenarios/:id              update (draft only)
+POST   /api/simulation/scenarios/:id/clone        clone → new draft
+POST   /api/simulation/scenarios/:id/lock         lock
+POST   /api/simulation/scenarios/:id/archive      archive
+POST   /api/simulation/scenarios/:id/unlock       unlock (admin only)
+
+# Virtual entries
+GET    /api/simulation/scenarios/:id/entries
+POST   /api/simulation/scenarios/:id/entries
+PATCH  /api/simulation/scenarios/:id/entries/:eid
+DELETE /api/simulation/scenarios/:id/entries/:eid
+
+# Reports
+GET    /api/simulation/scenarios/:id/trial-balance?reportType=...&month=...&languagePair=...
+GET    /api/simulation/scenarios/:id/comparison?reportType=...&month=...&languagePair=...
+GET    /api/simulation/scenarios/:id/export?type=trial-balance|comparison|full
+```
+
+Reports **không tạo engine riêng** — gọi lại `balanceEngine()` của E0 với `entrySources` mở rộng.
+
+### Engine contract (E0 + E2)
+
+```js
+balanceEngine({
+  tenantId, term, period,
+  entrySources: [
+    { name: 'actual',     fetch: () => CrossSlipDetail (approved) },
+    { name: 'simulation', fetch: () => SimulationEntry, scenarioId }
+  ],
+  options: { reportType, includeUnapproved: false, ... }
+})
+// Output.lines[i].endingBalance = actual + simulation adjustment
+// Output.meta.entrySourceNames = ['actual','simulation']
+```
+
+Engine không biết gì về "scenario" — nó chỉ nhận thêm 1 nguồn. Service layer (`simulation/trial-balance.js`) tạo fetcher từ `SimulationEntry`.
+
+### UI
+
+Màn `/reports/trial-balance` từ E1 thêm 1 dropdown **"Mode"**: `Actual | Simulation`.
+
+- Khi chọn `Simulation`:
+  - Dropdown phụ chọn scenario (chỉ draft/locked, không archived).
+  - Banner đỏ: "SIMULATION - NOT OFFICIAL ACCOUNTING REPORT" + tên scenario.
+  - Warning list có thêm SIM-W001 (simulation total không cân: gần như không thể vì validate ở entry layer, nhưng vẫn check), SIM-W002 (scenario lock bị bỏ qua bởi admin: cảnh báo trước khi xem).
+  - Export: ghi rõ "Simulation: <name>, Status: <draft|locked>, Not for tax filing".
+
+**Màn mới** `/simulation/scenarios` (list + create button) và `/simulation/scenarios/:id` (detail với tabs: Assumptions (placeholder cho E3), Entries, Trial Balance, Comparison, Export).
+
+### Comparison report (SIM-007)
+
+API trả:
+
+```json
+{
+  "meta": { "scenarioId", "term", "period", "languageMode", "generatedAt" },
+  "lines": [{
+    "type": "subtotal|account|subAccount",
+    "code", "name", "nameVi", ...,
+    "actual": { "movementDebit", "movementCredit", "endingBalance" },
+    "adjustment": { "movementDebit", "movementCredit", "endingBalance" },
+    "simulated": { "movementDebit", "movementCredit", "endingBalance" },
+    "difference": "simulated.endingBalance - actual.endingBalance",
+    "differencePct": "..."
+  }],
+  "totals": { ... },
+  "warnings": [...]
+}
+```
+
+Logic: chạy engine 2 lần (chỉ actual; actual+simulation) rồi diff. Cùng subtotal builder. Reuse export từ E1 với thêm sheet "Comparison".
+
+### Permission
+
+Roles (mở rộng từ hệ thống hiện tại, BRD mục 14.1):
+
+| Role | E2 quyền |
+|---|---|
+| Admin | Full |
+| Accountant | Create / edit / clone / lock (own + shared) / export |
+| Manager | Create / edit own scenario; view shared; clone |
+| Viewer | View shared scenario only |
+| 税理士 | View shared scenario + export (no create) |
+
+Implement: thêm 1 permission string `simulation:create`, `simulation:lock`, `simulation:export`. Reuse `is_authenticated` + `requireTenant` middleware. Authorize ở route layer; UI ẩn nút theo permission.
+
+**Lưu ý:** Phase 1 chỉ phân biệt `canCreate` / `canView` / `canExport`. Quyền chi tiết hơn (vd salary simulation riêng) để phase sau.
+
+### Audit
+
+- Mỗi thay đổi scenario (create/update/clone/lock/archive/entry CRUD) ghi bảng **`AuditEvent`** (bảng dùng chung tạo ở E0.4 — mục 2.13 đã chốt) với `action='simulation:<verb>'`, `entityType='SimulationScenario'|'SimulationEntry'`, `entityId`, `tenantId`, `actorId`, payload gọn (chỉ id + diff, không lưu toàn bộ entry).
+- `AuditEvent` cần index phụ `(entityType, entityId)` để query nhanh theo scenarioId. Nếu E0 chưa thêm index này, E2.13 bổ sung migration.
+
+## Risk classification
+
+Risk flags:
+- **Data model** — 2 bảng mới + migration.
+- **Auth/Authorization** — permission mới.
+- **Public contracts** — `/api/simulation/*` mới hoàn toàn.
+- **Cross-platform** — UI mới `/simulation/*`.
+- **Existing behavior** — mở rộng E0 engine contract (additive, không phá).
+- **Multi-domain** — simulation + reporting.
+- **Audit/security** — virtual entries KHÔNG được lẫn actual; tenant isolation; export có sensitive data.
+
+Hard gates: Authorization, Data isolation, Audit/security.
+→ **Lane: high-risk**. Mỗi issue dùng `docs/templates/high-risk-story/` folder.
+
+## Candidate stories (issues)
+
+| # | Title | Lane | Depends on | Notes |
+|---|---|---|---|---|
+| 2.1 | Migrations + models `SimulationScenario`, `SimulationEntry` | high-risk | — | Tenant-scoped, indexes, constraints. |
+| 2.2 | Scenario CRUD API + service layer | high-risk | 2.1 | Lock/clone/archive logic. |
+| 2.3 | Virtual entry CRUD API + balance validator (Nợ=Có) | high-risk | 2.1 | Reject nếu không cân, amount ≤ 0, debit=credit. |
+| 2.4 | Simulated TB API: gọi engine với 2 entrySources | high-risk | 2.2, 2.3, E0.1 | Reuse API v2 shape từ E1.1. |
+| 2.5 | Comparison API (SIM-007) | high-risk | 2.4 | Engine 2 lần + diff. |
+| 2.6 | Scenario list + create form UI (`/simulation/scenarios`) | normal | 2.2 | Bilingual. |
+| 2.7 | Scenario detail UI (`/simulation/scenarios/:id`) — 4 tabs (placeholder cho Assumptions) | high-risk | 2.6, 2.3, 2.4, 2.5 | Banner "SIMULATION - NOT OFFICIAL" trên header. |
+| 2.8 | Trial Balance tab: tích hợp vào view E1 với mode=Simulation | high-risk | 2.4, E1.3 | Dropdown scenario, banner đỏ. |
+| 2.9 | Comparison tab: render comparison data | high-risk | 2.5, 2.7 | Diff color: xanh = tăng, đỏ = giảm. |
+| 2.10 | Lock UI + clone UI | normal | 2.2 | Modal confirm cho lock. |
+| 2.11 | Excel export scenario (TB + comparison + entries) | high-risk | 2.4, 2.5 | Header có badge simulation, lock timestamp. |
+| 2.12 | Permission: `simulation:create/view/export` + middleware | high-risk | — | Audit cũng dùng. |
+| 2.13 | Audit log: ghi mọi thay đổi scenario/entry vào `AuditEvent` (bảng E0.4) | high-risk | 2.2, 2.3, 2.12, E0.4 | Dùng chung `AuditEvent`; thêm index `(entityType, entityId)` nếu thiếu. |
+| 2.14 | Tenant isolation test: scenario của tenant A không hiển thị/đọc được từ tenant B | high-risk | 2.2, 2.4 | Mocha, supertest chéo tenant. |
+| 2.15 | Reconciliation: simulated TB = actual TB + virtual entries (sum) | high-risk | 2.4 | Engine 2 lần verify diff. |
+
+## Validation ladder
+
+- **Unit (mocha):**
+  - `test/simulation/entry-validator.test.js` — Nợ=Có, amount>0, debit≠credit, date trong period.
+  - `test/simulation/scenario-state.test.js` — draft ↔ locked ↔ archived transition.
+  - `test/simulation/comparison-calc.test.js` — diff tính đúng với dataset fixture.
+- **Integration:**
+  - `test/integration/simulation-crud.test.js` — create → entry → simulated TB đúng.
+  - `test/integration/simulation-export.test.js` — file Excel có badge + lock ts.
+  - `test/integration/simulation-tenant-isolation.test.js` — 2 tenant, request chéo → 404/403.
+- **E2E (chrome-devtools MCP):**
+  - Tạo scenario, thêm 3 entries, mở TB mode=Simulation, chụp screenshot.
+  - Clone, lock, archive.
+  - Export, mở file Excel, xác nhận header.
+- **Reconciliation:**
+  - `simulated.endingBalance(account) = actual.endingBalance(account) + Σ virtual entries(account)`.
+  - `Σ simulated.movementDebit = Σ simulated.movementCredit` (luôn cân vì entry đã validate).
+- **Smoke:** `npm run build` + `npm test` pass.
+
+## Exit criteria
+
+E2 done khi tất cả:
+- [ ] 2 models + migrations + indexes đã merge.
+- [ ] Scenario CRUD + entry CRUD + clone/lock/archive chạy đúng, audit log đầy đủ.
+- [ ] Simulated TB = actual + virtual entries, drill-down có badge phân biệt.
+- [ ] Comparison hiển thị đúng actual / adjustment / simulated / diff.
+- [ ] Export có badge "SIMULATION - NOT OFFICIAL", file mở được, số liệu khớp UI.
+- [ ] Tenant isolation test pass.
+- [ ] Permission đúng theo role matrix.
+- [ ] Không có virtual entry nào lọt vào `api_ledger`/`api_trial-balance` (actual mode).
+- [ ] Test Report đăng lên từng issue; trace ghi `harness.db`.
+
+## Open decisions (đã chốt 2026-06-07)
+
+1. **2.1** `SimulationEntry` **không copy** `application1`/`application2` từ `CrossSlipDetail`. `memo` đủ cho simulation; thêm cột sau nếu cần (migration rẻ).
+2. **2.13** Audit dùng **bảng chung `AuditEvent`** (tạo ở E0.4) — không tạo `SimulationAudit` riêng. Query theo `(entityType, entityId)`. Nhất quán với closing audit, đỡ maintain 2 bảng.
+3. **2.6/2.7** Scenario list **có filter**: status, owner, date range. Bỏ search free-text ở phase 1.
+4. **2.8** Mode=Simulation **sticky per session** khi đổi account/tháng. Banner đỏ luôn hiện để không nhầm với actual.
+5. **2.12** Permission **hard-code trong `libs/auth/permissions.js`** (map role → `simulation:create/view/export`). Không tạo schema RBAC ở phase này.
+6. **2.14** Test chéo tenant chạy trên **test DB + Sequelize transaction rollback** (không stub). Isolation phải test thật tầng query.
+
+## Follow-up (sang E3)
+
+- E3 sẽ thêm `SimulationAssumption` table, recurring engine, revenue/expense growth, cash projection.
+- Simulation entry lúc đó có thêm `sourceType='recurring'`, E0 engine không cần đổi.
+- Có thể thêm 1 endpoint E2 làm nền: `GET /api/simulation/scenarios/:id/assumptions/preview` trả entries sẽ sinh ra (E3 dùng).
+- BRD Open Q #8 (convert simulation → actual journal) — **không làm** trong MVP. Nếu khách hàng yêu cầu, làm riêng epic sau với workflow approval rất rõ.

--- a/docs/stories/epics/E03-forecast/initiative.md
+++ b/docs/stories/epics/E03-forecast/initiative.md
@@ -1,0 +1,286 @@
+# E03 — Forecast Simulation
+
+> Initiative notes. Shared artifact (committed). Mapped to git branch `epic/forecast` and GitHub label `epic:forecast`.
+
+Date: 2026-06-07
+Status: proposed
+Lane: high-risk (sinh virtual entries hàng loạt tự động, cash projection, đụng độ probability cao với actual data)
+
+## Goal
+
+Mở rộng simulation từ manual journal (E2) sang dự phóng: recurring assumptions (lặp theo tháng/quý/năm), revenue growth, expense growth, và cash flow projection. Tận dụng E0 engine + E2 scenario/entry infrastructure. Tất cả assumption chỉ là wrapper sinh `SimulationEntry` — không tính toán riêng.
+
+## Why now
+
+- E2 đã có scenario + entry CRUD + simulated TB + comparison. Forecast chỉ thêm 1 nguồn entries tự sinh.
+- Người dùng (chủ DN, manager) cần hỏi "nếu tuyển thêm 2 người thì cash có âm không?" — manual quá cồng kềnh với 6-12 tháng.
+- BRD mục 11.3-11.6 đã chốt scope MVP forecast: recurring, revenue growth, expense simulation, cash projection.
+- BRD mục 22.2 đã chốt: chưa làm formula engine, headcount planning, tax simulation. Tôn trọng.
+
+## Affected product docs (to be created/updated)
+
+- `docs/product/simulation/assumptions.md` — recurring rule, growth rule, parameter schema.
+- `docs/product/simulation/cash-projection.md` — accrual vs cash, payment timing, monthly roll-forward.
+- `docs/product/simulation/warnings.md` — SIM-W010 (cash âm), SIM-W011 (recurring overlap), SIM-W012 (expense không tìm thấy counter account).
+
+## Scope
+
+**In scope (BRD mục 11.3-11.6, MVP):**
+- Recurring assumptions (SIM-003): monthly/quarterly/yearly, start/end month, day of month, optional increase rule.
+- Revenue growth simulation (SIM-004): percent / fixed / manual monthly / based on prior.
+- Expense simulation (SIM-005): fixed / variable / one-time / headcount-based.
+- Cash flow simulation (SIM-006): opening cash + cash in/out theo payment timing.
+- Simulated P/L (tổng hợp từ entries).
+- Preview generated entries trước khi lưu.
+- Warning: cash âm, recurring overlap (2 assumption trùng ngày + account).
+
+**Out of scope (E3):**
+- Formula engine / custom formula builder (BRD mục 11.10: "Phase sau"). Tôi cứng giữ rule: assumption chỉ sinh entry, không tính số phức tạp.
+- Tax simulation (BRD cảnh báo rủi ro cao, phase 5).
+- Loan repayment, headcount planning chi tiết — phase sau.
+- Monte Carlo / best-base-worst (BRD mục 11.5: "không bao giờ quay về").
+- Multi-scenario compare best/base/worst — phase sau.
+
+## Architecture direction
+
+### Data model
+
+**`SimulationAssumption`** (mới, đã để chỗ từ E2 design):
+
+| Field | Type | Note |
+|---|---|---|
+| id | INT PK | |
+| tenantId | INT NOT NULL | |
+| scenarioId | INT NOT NULL | FK, index |
+| type | ENUM('revenue_growth','expense_fixed','expense_pct_of_sales','expense_headcount','recurring') | mở rộng được |
+| name | STRING(200) | |
+| parameters | JSONB | schema đặc thù theo type — xem dưới |
+| startMonth | DATE | |
+| endMonth | DATE | |
+| status | ENUM('active','disabled') DEFAULT 'active' | |
+| generatedCount | INT DEFAULT 0 | số entry đã sinh, dùng cho sync/regen |
+| generatedHash | STRING(64) | hash params + period để detect thay đổi |
+| createdAt, updatedAt | TIMESTAMP | |
+
+Indexes: `(tenantId, scenarioId, type)`, `(scenarioId, status)`.
+
+**Không thêm bảng cho cash projection.** Cash flow = derived view: engine trả entries, 1 service `cashProjection(scenarioId, periodFrom, periodTo)` group theo tháng + apply payment timing. Cache lại (in-memory hoặc `MonthlyLog`) vì recompute mỗi lần mở tab sẽ tốn.
+
+### Assumption parameter schemas (JSONB)
+
+Mỗi `type` có schema riêng. Validate bằng JSON schema hoặc hand-rolled check. Cố gắng giữ mỗi schema ≤ 6 trường.
+
+```js
+// recurring (SIM-003)
+{
+  frequency: 'monthly'|'quarterly'|'yearly',
+  dayOfMonth: 1-31,                  // optional
+  debitAccount, debitSubAccount?,
+  creditAccount, creditSubAccount?,
+  amount,                            // > 0
+  taxRuleId?, projectId?, labelId?,
+  memo?,
+  increaseRule?: { type: 'percent'|'fixed', value }   // optional
+}
+
+// revenue_growth (SIM-004)
+{
+  revenueAccount,
+  counterAccount,                    // 売掛金 / 普通預金
+  growthType: 'percent'|'fixed'|'manual'|'avg_last_3m'|'last_month',
+  growthValue,                       // number or array (manual)
+  collectionTimingDays: 0|30|60|90,  // 0 = immediate cash
+  taxRuleId?,
+  projectId?
+}
+
+// expense_fixed (SIM-005)
+{
+  expenseAccount, counterAccount,
+  amountType: 'fixed'|'percent_of_sales'|'headcount',
+  amount?,                           // for fixed
+  percentOf?: 'sales'|'cogs',        // for percent_of_sales
+  // headcount (mục 3.5): 1 assumption → 2 entry (給与手当 + 法定福利費)
+  headcount?: {
+    count,
+    salaryPerMonth,
+    salaryAccount,                   // 給与手当
+    insuranceAccount,                // 法定福利費
+    insurancePct                     // % của (count × salaryPerMonth)
+  },
+  paymentTimingDays: 0|30|60,
+  taxRuleId?, projectId?
+}
+```
+
+### Generator service
+
+`libs/simulation/assumption-generator.js`:
+
+```js
+async function generateEntries(assumption, scenario) {
+  // Trả về SimulationEntry[] (chưa lưu DB).
+  // Phase 1: hiện thực cho recurring, revenue_growth, expense_fixed.
+  // expense_pct_of_sales, expense_headcount để phase 2.
+}
+
+async function preview(scenarioId) {
+  // Trả entries gộp từ TẤT CẢ assumption active, chưa commit.
+  // Dùng cho UI "Preview generated entries" trước khi Save.
+}
+
+async function regenerate(scenarioId) {
+  // Xoá entries có sourceType IN ('recurring','formula') rồi insert lại.
+  // Manual entries giữ nguyên.
+  // Hash để skip nếu params không đổi.
+}
+```
+
+Invariants:
+- Mỗi entry sinh ra phải cân Nợ=Có (validator E2.3 đã enforce).
+- Date trong `[simPeriodFrom, simPeriodTo]`.
+- Nếu `endMonth` vượt `simPeriodTo`, chỉ sinh tới `simPeriodTo`.
+- Ngày không tồn tại trong tháng (vd 31/2) → dùng ngày cuối tháng.
+- Recurring + recurring trùng `account + date + amount` → cảnh báo SIM-W011 (không chặn).
+
+### Cash projection
+
+> Phân loại cash / receivable / payable **derive từ `AccountClass.major/middle`** (mục 3.8 đã chốt) — KHÔNG từ số `field(code)`. Danh sách mapping chính xác chốt ở story 3.8 sau khi đọc seed `AccountClass` thực tế.
+
+```js
+async function cashProjection(scenarioId, periodFrom, periodTo) {
+  // 1. Opening cash = endingBalance(các account có AccountClass.middle = '現金及び預金' …) tại periodFrom-1.
+  //    Lấy từ engine actual + simulation entries tới periodFrom-1.
+  // 2. Lấy TẤT CẢ entries (manual + generated) trong [periodFrom, periodTo].
+  // 3. Với mỗi entry:
+  //    - accrual impact: vào tháng `entry.date` (group by month).
+  //    - cash impact: classify account qua AccountClass:
+  //        cash/bank   → immediate
+  //        receivable  → shift theo collectionTimingDays
+  //        payable     → shift theo paymentTimingDays
+  // 4. Trả [{ month, openingCash, cashIn, cashOut, netFlow, endingCash, accrualProfit }].
+}
+```
+
+Service trả cả accrual lẫn cash, để UI hiển thị 2 cột (theo BRD BR-SIM-007: "tách khỏi accrual profit").
+
+Cảnh báo SIM-W010: nếu `endingCash < 0` ở bất kỳ tháng nào → flag tháng đó đỏ.
+
+### API
+
+```
+# Assumptions CRUD
+GET    /api/simulation/scenarios/:id/assumptions
+POST   /api/simulation/scenarios/:id/assumptions
+PATCH  /api/simulation/scenarios/:id/assumptions/:aid
+DELETE /api/simulation/scenarios/:id/assumptions/:aid
+POST   /api/simulation/scenarios/:id/assumptions/:aid/preview     # entries sẽ sinh
+
+# Generator
+POST   /api/simulation/scenarios/:id/regenerate                    # xoá + insert lại entries từ assumption
+POST   /api/simulation/scenarios/:id/preview-all                   # tổng tất cả assumption
+
+# P/L
+GET    /api/simulation/scenarios/:id/pl?periodFrom=&periodTo=      # simulated P/L
+
+# Cash flow
+GET    /api/simulation/scenarios/:id/cash-flow?periodFrom=&periodTo=
+```
+
+### UI
+
+Scenario detail (E2.7) tab **Assumptions** thay placeholder bằng:
+- Bảng list assumption (type, name, period, status, generatedCount).
+- Button "+ Assumption" → wizard theo type (form dynamic theo JSONB schema).
+- Mỗi row có button "Preview" → modal hiển thị entries sẽ sinh (date, accounts, amount, memo).
+- Button "Regenerate all" trên header tab → xoá generated entries + insert lại.
+
+Tab **P/L** mới: bar chart thu/chi theo tháng + summary. Library: Svelte native SVG hoặc dùng 1 lib chart nhẹ (chưa có — chốt ở Open Q #5).
+
+Tab **Cash** mới: line chart cash balance 12 tháng, highlight tháng âm.
+
+Bilingual + badge "SIMULATION" từ E2 giữ nguyên.
+
+### Permission
+
+E2 đã có `simulation:create/view/export`. E3 chỉ thêm:
+- `simulation:regenerate` (admin/accountant) — trigger xoá + insert entries tự động.
+- Không cần permission mới cho assumption CRUD vì kế thừa `simulation:create`.
+
+## Risk classification
+
+Risk flags:
+- **Data model** — 1 bảng mới + JSONB (cẩn thận validation).
+- **Public contracts** — `/api/simulation/.../assumptions`, `/pl`, `/cash-flow`.
+- **Existing behavior** — generator xoá entries (dù chỉ generated) — phải backup trước khi xoá.
+- **Multi-domain** — UI + service + chart.
+- **Audit/security** — regenerate = destructive, audit log entry nào bị xoá.
+
+Hard gates: Audit/security, Public contract mới.
+→ **Lane: high-risk**.
+
+## Candidate stories (issues)
+
+| # | Title | Lane | Depends on | Notes |
+|---|---|---|---|---|
+| 3.1 | Migration + model `SimulationAssumption` | high-risk | E2.1 | JSONB parameters, indexes. |
+| 3.2 | Assumption CRUD API + JSON schema validate theo type | high-risk | 3.1 | 3 type phase 1: recurring, revenue_growth, expense_fixed. |
+| 3.3 | Generator service: sinh `SimulationEntry` từ recurring | high-risk | 3.1, E2.3 | Monthly/quarterly/yearly + day-of-month edge case. |
+| 3.4 | Generator: revenue_growth (percent/fixed/manual/avg/last) | high-risk | 3.3 | Collection timing tạo offset cash entry. |
+| 3.5 | Generator: expense_fixed (fixed/percent-of-sales/headcount) | high-risk | 3.3 | Headcount chỉ cần basic count × salary; phase 2 nếu muốn phức tạp hơn. |
+| 3.6 | Preview API (1 assumption hoặc all) | high-risk | 3.3, 3.4, 3.5 | Không ghi DB, chỉ trả danh sách. |
+| 3.7 | Regenerate API: xoá generated entries + insert lại, audit log | high-risk | 3.6, E2.13 | Manual entries giữ nguyên. |
+| 3.8 | Cash projection service + API | high-risk | 3.7 | Tách accrual vs cash theo payment timing. |
+| 3.9 | Simulated P/L API | high-risk | 3.7 | Group revenue/expense entries theo tháng. |
+| 3.10 | UI: tab Assumptions + wizard form theo type | high-risk | 3.2, 3.6 | Dynamic form dựa JSONB schema. |
+| 3.11 | UI: tab P/L + tab Cash (chart 12 tháng) | high-risk | 3.8, 3.9 | Native Svelte SVG (xem Open Q #5). |
+| 3.12 | Warning SIM-W010/W011/W012 | normal | 3.8, 3.6 | Highlight row đỏ, banner scenario. |
+| 3.13 | Permission `simulation:regenerate` | normal | E2.12 | 1 quyền mới. |
+| 3.14 | Reconciliation: regenerated entries sum = manual comparable | high-risk | 3.7 | Mocha, kiểm tra hash skip đúng. |
+
+## Validation ladder
+
+- **Unit (mocha):**
+  - `test/simulation/recurring-generator.test.js` — frequency monthly sinh đúng số entry, day-of-month 31/2 → ngày cuối tháng.
+  - `test/simulation/revenue-growth.test.js` — percent vs fixed vs avg_last_3m đúng.
+  - `test/simulation/expense-fixed.test.js` — fixed, percent-of-sales, headcount (count × salary).
+  - `test/simulation/cash-projection.test.js` — collection timing offset, accrual vs cash.
+  - `test/simulation/json-schema.test.js` — invalid JSONB bị reject.
+- **Integration:**
+  - Tạo scenario E2, thêm recurring, regenerate, kiểm tra entries xuất hiện trong simulated TB.
+  - Edit assumption → regenerate → entries cũ bị xoá + mới được insert + manual entries giữ.
+- **E2E (chrome-devtools MCP):**
+  - Tạo scenario "2026 H2 Hiring", thêm salary recurring 6 tháng, xem TB + cash projection, chụp.
+  - Đổi salary 500k → 700k, regenerate, chụp diff.
+- **Reconciliation:**
+  - Σ generated entries = Σ manual entries (nếu cùng params).
+  - Cash projection tháng cuối = opening + Σ cash in - Σ cash out.
+- **Smoke:** `npm run build` + `npm test` pass.
+
+## Exit criteria
+
+E3 done khi tất cả:
+- [ ] Assumption CRUD + 3 generator type hoạt động.
+- [ ] Preview + Regenerate đúng, manual entries không bị động vào.
+- [ ] Cash projection + simulated P/L khớp engine, cảnh báo cash âm.
+- [ ] UI wizard + 2 chart tab hoạt động, bilingual, badge simulation.
+- [ ] Audit log cover mọi thay đổi (assumption CRUD + regenerate).
+- [ ] Test Report đăng lên từng issue; trace ghi `harness.db`.
+
+## Open decisions (đã chốt 2026-06-07)
+
+1. **3.1** JSONB parameters validate bằng **Ajv** (thêm dep mới). Schema khai báo rõ ràng, tái dùng được khi số `type` phình ở phase sau.
+2. **3.5** Headcount expense: **1 assumption → 2 entry** (給与手当 + 法定福利費 = % của lương), khớp ví dụ BRD mục 24.1. % bảo hiểm là tham số trong `parameters.headcount`.
+3. **3.6** Preview **không cho edit** entry trực tiếp. Generated entries thuần từ assumption; muốn khác → sửa assumption hoặc clone thành manual entry.
+4. **3.7** Regenerate **không snapshot** phase 1. Chỉ xoá *generated* entries (manual giữ nguyên), audit log đủ forensic, có thể regenerate lại từ assumption bất cứ lúc nào.
+5. **3.11** Chart = **native Svelte SVG** (0 dep): 1 line chart cash + 1 bar chart P/L đơn giản. Không thêm chart.js/echarts.
+6. **3.8** Phân loại cash/receivable/payable **derive từ `AccountClass.major/middle`** (KHÔNG từ số `field(code)` thô). ⚠️ Đã verify: hệ thống phân loại BS/PL bằng `AccountClass` (資産/負債, 流動資産/流動負債...) trong `libs/init-financial-statement.js`, không phải bằng `field()` số. Mapping cụ thể (vd middle='現金及び預金' → cash; major='負債' + account chứa '売掛/未収' → receivable) cần **chốt danh sách chính xác ở story 3.8** sau khi đọc seed `AccountClass` thực tế của tenant. Không hard-code field number.
+7. **3.12** SIM-W011 (recurring overlap) = **warning low, không chặn**. Gộp duplicate hiển thị trong preview, user tự quyết (có thể là intent hợp lệ).
+
+## Follow-up (sang epic sau — phase 2)
+
+- Formula engine / custom expression (BRD mục 11.10).
+- Tax estimate (BRD mục 11.7).
+- Multi-scenario compare best/base/worst (BRD mục 11.5).
+- Convert simulation → actual journal với approval workflow (BRD Open Q #8) — cân nhắc kỹ trước khi làm.
+- Phase 2 reports: monthly trend, project/label filter ở trial balance (E1 mục TB-010/TB-007 advanced).


### PR DESCRIPTION
Planning artifacts only — no code changes, no issue gate required (docs).

## What
4 epic initiative notes mapping the BRD (`new_feature_brainstorm_result.md`) to executable epics, grounded in actual code:

- **E00 reporting-engine** — single balance engine + fix multi-tenant closing (currently broken: `forms/closing.js` passes wrong args post-multitenant)
- **E01 trial-balance** — 3 report types (残高/合計/合計残高), 5-level hierarchy w/ sub-account, drill-down, warnings, Excel export
- **E02 simulation** — scenario + virtual journal entries (manual MVP), simulated TB via engine overlay, actual-vs-sim comparison, lock/clone
- **E03 forecast** — recurring assumptions, revenue/expense growth, cash projection

## Decisions
All 22 open decisions resolved (see each file's 'Open decisions' section). Notable: shared `AuditEvent` table across E0/E2/E3; cash classification derives from `AccountClass` (verified, not raw field codes).

## Next
After merge: create `epic:reporting-engine` issue + sub-issues, then start E0.1 (balance engine core).