### PR TITLE
feat(#195): libs/reporting/balance-engine.js core + unit tests

### DIFF
--- a/libs/reporting/balance-engine.js
+++ b/libs/reporting/balance-engine.js
@@ -1,0 +1,195 @@
+import { dc, field, numeric } from '../parse_account_code.js';
+
+const lineKey = (accountId, subAccountId) =>
+  subAccountId != null ? `sub:${subAccountId}` : `acc:${accountId}`;
+
+const openingFromRemaining = (code, remaining) => {
+  if (parseInt(field(code), 10) >= 6) {
+    return { debit: 0, credit: 0, balance: 0 };
+  }
+  if (!remaining) {
+    return { debit: 0, credit: 0, balance: 0 };
+  }
+  return {
+    debit: numeric(remaining.debit),
+    credit: numeric(remaining.credit),
+    balance: numeric(remaining.balance),
+  };
+};
+
+const computeEnding = (code, openingBalance, movementDebit, movementCredit) => {
+  return dc(code) === 'D'
+    ? openingBalance + movementDebit - movementCredit
+    : openingBalance - movementDebit + movementCredit;
+};
+
+const aggregateMovements = (details, accountByCode, subAccountIdSet, movementByLineKey, opts) => {
+  const { includeUnapproved = false } = opts || {};
+  for (const d of details || []) {
+    if (!includeUnapproved && !d.approvedAt) continue;
+    if (d.debitAccount) {
+      const subId = d.debitSubAccount || null;
+      if (subId != null && !subAccountIdSet.has(subId)) continue;
+      const accId = accountByCode.get(d.debitAccount);
+      if (accId == null) continue;
+      const k = subId != null ? `sub:${subId}` : `acc:${accId}`;
+      const cur = movementByLineKey.get(k) || { debit: 0, credit: 0 };
+      cur.debit += numeric(d.debitAmount);
+      movementByLineKey.set(k, cur);
+    }
+    if (d.creditAccount) {
+      const subId = d.creditSubAccount || null;
+      if (subId != null && !subAccountIdSet.has(subId)) continue;
+      const accId = accountByCode.get(d.creditAccount);
+      if (accId == null) continue;
+      const k = subId != null ? `sub:${subId}` : `acc:${accId}`;
+      const cur = movementByLineKey.get(k) || { debit: 0, credit: 0 };
+      cur.credit += numeric(d.creditAmount);
+      movementByLineKey.set(k, cur);
+    }
+  }
+};
+
+/**
+ * Single source of truth for opening/movement/ending balance.
+ *
+ * params:
+ *   tenantId     - required
+ *   term         - required, FiscalYear.term
+ *   period       - optional { from, to } stored in meta
+ *   entrySources - array of { name, fetch } where fetch() resolves to detail rows
+ *                  (CrossSlipDetail-like: debitAccount, debitSubAccount, debitAmount,
+ *                   creditAccount, creditSubAccount, creditAmount, approvedAt)
+ *   options:
+ *     includeUnapproved - default false
+ *     subAccount        - default true (emit one line per sub-account when subs exist)
+ *     accountClassIds / projectIds / labelIds - filtering hints; fetcher enforces
+ *
+ * deps: { Account, SubAccount, AccountRemaining, SubAccountRemaining }
+ *       each must expose findAll({ where, include }). Production caller passes
+ *       the result of `import models from '../../models/index.js'`.
+ */
+export async function balanceEngine(params, deps) {
+  if (!deps) {
+    throw new Error('balanceEngine: deps is required (pass models from models/index.js)');
+  }
+  const { tenantId, term, period = null, entrySources = [], options = {} } = params || {};
+  if (tenantId == null) {
+    throw new Error('balanceEngine: tenantId is required (multi-tenant guard)');
+  }
+  if (term == null) {
+    throw new Error('balanceEngine: term is required');
+  }
+  if (!Array.isArray(entrySources)) {
+    throw new Error('balanceEngine: entrySources must be an array of {name, fetch}');
+  }
+
+  const { includeUnapproved = false, subAccount = true } = options;
+
+  const accounts = await deps.Account.findAll({
+    where: { tenantId },
+    include: [{ model: deps.SubAccount, as: 'subAccounts' }],
+  });
+
+  const priorTerm = term - 1;
+  const accountRemaining = await deps.AccountRemaining.findAll({
+    where: { tenantId, term: priorTerm },
+  });
+  const subAccountRemaining = await deps.SubAccountRemaining.findAll({
+    where: { tenantId, term: priorTerm },
+  });
+
+  const accountByCode = new Map();
+  const subAccountIdSet = new Set();
+  for (const acc of accounts) {
+    accountByCode.set(acc.code, acc.id);
+    if (acc.subAccounts) {
+      for (const sub of acc.subAccounts) {
+        subAccountIdSet.add(sub.id);
+      }
+    }
+  }
+
+  const lineDefs = [];
+  for (const acc of accounts) {
+    if (subAccount && acc.subAccounts && acc.subAccounts.length > 0) {
+      for (const sub of acc.subAccounts) {
+        lineDefs.push({
+          accountId: acc.id,
+          accountCode: acc.code,
+          subAccountId: sub.id,
+          subCode: sub.subAccountCode,
+          code: acc.code,
+        });
+      }
+    } else {
+      lineDefs.push({
+        accountId: acc.id,
+        accountCode: acc.code,
+        subAccountId: null,
+        subCode: null,
+        code: acc.code,
+      });
+    }
+  }
+
+  const movementByLineKey = new Map();
+  const sourceNames = [];
+  for (const src of entrySources) {
+    if (!src || !src.name || typeof src.fetch !== 'function') {
+      throw new Error('balanceEngine: each entrySource must be {name, fetch}');
+    }
+    sourceNames.push(src.name);
+    const details = await src.fetch();
+    aggregateMovements(details, accountByCode, subAccountIdSet, movementByLineKey, { includeUnapproved });
+  }
+
+  const lines = lineDefs.map((ld) => {
+    const remaining = ld.subAccountId != null
+      ? subAccountRemaining.find((r) => r.subAccountId === ld.subAccountId)
+      : accountRemaining.find((r) => r.accountId === ld.accountId);
+    const opening = openingFromRemaining(ld.code, remaining);
+    const movement = movementByLineKey.get(lineKey(ld.accountId, ld.subAccountId))
+      || { debit: 0, credit: 0 };
+    const endingBalance = computeEnding(ld.code, opening.balance, movement.debit, movement.credit);
+    const isD = dc(ld.code) === 'D';
+    return {
+      accountId: ld.accountId,
+      subAccountId: ld.subAccountId,
+      code: ld.code,
+      subCode: ld.subCode,
+      name: null,
+      nameVi: null,
+      subName: null,
+      subNameVi: null,
+      major: null,
+      middle: null,
+      minor: null,
+      majorVi: null,
+      middleVi: null,
+      minorVi: null,
+      openingDebit: opening.debit,
+      openingCredit: opening.credit,
+      openingBalance: opening.balance,
+      movementDebit: movement.debit,
+      movementCredit: movement.credit,
+      endingDebit: isD ? Math.max(endingBalance, 0) : Math.max(-endingBalance, 0),
+      endingCredit: isD ? Math.max(-endingBalance, 0) : Math.max(endingBalance, 0),
+      endingBalance,
+    };
+  });
+
+  return {
+    lines,
+    warnings: [],
+    meta: {
+      generatedAt: new Date(),
+      entrySourceNames: sourceNames,
+      tenantId,
+      term,
+      period,
+    },
+  };
+}
+
+export { openingFromRemaining, computeEnding, aggregateMovements, lineKey };

--- a/test/reporting/balance-engine.test.mjs
+++ b/test/reporting/balance-engine.test.mjs
@@ -1,0 +1,447 @@
+/**
+ * Unit tests — Issue #195: libs/reporting/balance-engine.js
+ *
+ * Pure-function tests, no DB. deps is mocked inline.
+ *
+ * Run with: npm test (mocha glob picks up this file)
+ */
+
+import { strict as assert } from 'node:assert';
+import {
+  balanceEngine,
+  openingFromRemaining,
+  computeEnding,
+  aggregateMovements,
+  lineKey,
+} from '../../libs/reporting/balance-engine.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TENANT_A = 1;
+const TENANT_B = 2;
+
+const accounts = [
+  { id: 1, code: '1110000', tenantId: TENANT_A, subAccounts: [] },
+  { id: 2, code: '3010000', tenantId: TENANT_A, subAccounts: [
+    { id: 100, subAccountCode: 1, accountId: 2, tenantId: TENANT_A },
+    { id: 101, subAccountCode: 2, accountId: 2, tenantId: TENANT_A },
+  ]},
+  { id: 3, code: '5040000', tenantId: TENANT_A, subAccounts: [] },
+  { id: 4, code: '6010000', tenantId: TENANT_A, subAccounts: [] },
+  { id: 5, code: '7010000', tenantId: TENANT_A, subAccounts: [] },
+  { id: 6, code: '7020010', tenantId: TENANT_A, subAccounts: [] },
+  { id: 7, code: '9990000', tenantId: TENANT_B, subAccounts: [] },
+];
+
+const accountRemaining = [
+  { accountId: 1, term: 0, debit: 100, credit: 0, balance: 100, tenantId: TENANT_A },
+  { accountId: 2, term: 0, debit: 0, credit: 0, balance: 0, tenantId: TENANT_A },
+  { accountId: 3, term: 0, debit: 50, credit: 50, balance: 0, tenantId: TENANT_A },
+  { accountId: 4, term: 0, debit: 999, credit: 0, balance: 999, tenantId: TENANT_A },
+  { accountId: 5, term: 0, debit: 0, credit: 123, balance: 123, tenantId: TENANT_A },
+  { accountId: 6, term: 0, debit: 0, credit: 0, balance: 0, tenantId: TENANT_A },
+  { subAccountId: 100, term: 0, debit: 0, credit: 200, balance: 200, tenantId: TENANT_A },
+  { subAccountId: 101, term: 0, debit: 300, credit: 0, balance: 300, tenantId: TENANT_A },
+];
+
+const subAccountRemaining = [
+  { subAccountId: 100, term: 0, debit: 0, credit: 200, balance: 200, tenantId: TENANT_A },
+  { subAccountId: 101, term: 0, debit: 300, credit: 0, balance: 300, tenantId: TENANT_A },
+];
+
+const makeDeps = (overrides = {}) => ({
+  Account: {
+    findAll: async ({ where }) => {
+      const tid = where && where.tenantId;
+      return accounts.filter((a) => tid == null || a.tenantId === tid);
+    },
+  },
+  SubAccount: {},
+  AccountRemaining: {
+    findAll: async ({ where }) => {
+      const tid = where && where.tenantId;
+      const term = where && where.term;
+      return accountRemaining.filter((r) =>
+        (tid == null || r.tenantId === tid) && (term == null || r.term === term));
+    },
+  },
+  SubAccountRemaining: {
+    findAll: async ({ where }) => {
+      const tid = where && where.tenantId;
+      const term = where && where.term;
+      return subAccountRemaining.filter((r) =>
+        (tid == null || r.tenantId === tid) && (term == null || r.term === term));
+    },
+  },
+  ...overrides,
+});
+
+const APPROVED = { approvedAt: new Date('2026-06-01') };
+
+// ---------------------------------------------------------------------------
+// lineKey
+// ---------------------------------------------------------------------------
+
+describe('lineKey', () => {
+  it('uses sub: prefix for sub-account lines', () => {
+    assert.equal(lineKey(1, 100), 'sub:100');
+  });
+  it('uses acc: prefix for account-level lines', () => {
+    assert.equal(lineKey(1, null), 'acc:1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeEnding
+// ---------------------------------------------------------------------------
+
+describe('computeEnding', () => {
+  it('D-nature: opening=100, debit=50, credit=30 → ending=120', () => {
+    assert.equal(computeEnding('1110000', 100, 50, 30), 120);
+  });
+  it('C-nature: opening=200, debit=50, credit=30 → ending=180', () => {
+    assert.equal(computeEnding('5040000', 200, 50, 30), 180);
+  });
+  it('7020010 override: dc=C even though field=7', () => {
+    const eb = computeEnding('7020010', 0, 100, 50);
+    assert.equal(eb, -50, 'C-nature: 0 - 100 + 50 = -50');
+  });
+  it('D-nature with negative ending produces negative value', () => {
+    assert.equal(computeEnding('1110000', 10, 0, 50), -40);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openingFromRemaining
+// ---------------------------------------------------------------------------
+
+describe('openingFromRemaining', () => {
+  it('BS account returns debit/credit/balance from remaining', () => {
+    const r = openingFromRemaining('1110000', { debit: 100, credit: 30, balance: 70 });
+    assert.deepEqual(r, { debit: 100, credit: 30, balance: 70 });
+  });
+  it('PL account (field >= 6) ignores remaining and returns zeros', () => {
+    const r = openingFromRemaining('6010000', { debit: 999, credit: 0, balance: 999 });
+    assert.deepEqual(r, { debit: 0, credit: 0, balance: 0 });
+  });
+  it('null remaining yields zeros for BS', () => {
+    assert.deepEqual(openingFromRemaining('1110000', null), { debit: 0, credit: 0, balance: 0 });
+  });
+  it('PL expense (field=7) ignores prior-term carry', () => {
+    const r = openingFromRemaining('7010000', { debit: 0, credit: 123, balance: 123 });
+    assert.deepEqual(r, { debit: 0, credit: 0, balance: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateMovements
+// ---------------------------------------------------------------------------
+
+describe('aggregateMovements', () => {
+  const accMap = new Map([
+    ['1110000', 1],
+    ['3010000', 2],
+    ['3010000', 2],
+    ['5040000', 3],
+    ['6010000', 4],
+    ['7010000', 5],
+    ['7020010', 6],
+  ]);
+
+  it('single source: one detail credits account', () => {
+    const out = new Map();
+    aggregateMovements(
+      [{ debitAccount: '1110000', debitAmount: 100, ...APPROVED }],
+      accMap, new Set(), out, {}
+    );
+    assert.deepEqual(out.get('acc:1'), { debit: 100, credit: 0 });
+  });
+
+  it('multi-source: each fetcher contributes to same line', () => {
+    const out = new Map();
+    const set = new Set();
+    aggregateMovements(
+      [{ debitAccount: '1110000', debitAmount: 50, ...APPROVED }],
+      accMap, set, out, {}
+    );
+    aggregateMovements(
+      [{ debitAccount: '1110000', debitAmount: 30, ...APPROVED }],
+      accMap, set, out, {}
+    );
+    assert.deepEqual(out.get('acc:1'), { debit: 80, credit: 0 });
+  });
+
+  it('filters unapproved when includeUnapproved=false (default)', () => {
+    const out = new Map();
+    aggregateMovements(
+      [
+        { debitAccount: '1110000', debitAmount: 100, ...APPROVED },
+        { debitAccount: '1110000', debitAmount: 999, approvedAt: null },
+      ],
+      accMap, new Set(), out, {}
+    );
+    assert.equal(out.get('acc:1').debit, 100, 'unapproved entry ignored');
+  });
+
+  it('includes unapproved when includeUnapproved=true', () => {
+    const out = new Map();
+    aggregateMovements(
+      [
+        { debitAccount: '1110000', debitAmount: 100, ...APPROVED },
+        { debitAccount: '1110000', debitAmount: 999, approvedAt: null },
+      ],
+      accMap, new Set(), out, { includeUnapproved: true }
+    );
+    assert.equal(out.get('acc:1').debit, 1099);
+  });
+
+  it('routes sub-account detail to sub: line key', () => {
+    const out = new Map();
+    const subSet = new Set([100]);
+    aggregateMovements(
+      [
+        { creditAccount: '3010000', creditSubAccount: 100, creditAmount: 50, ...APPROVED },
+        { debitAccount: '3010000', debitSubAccount: 100, debitAmount: 70, ...APPROVED },
+      ],
+      accMap, subSet, out, {}
+    );
+    assert.deepEqual(out.get('sub:100'), { debit: 70, credit: 50 });
+  });
+
+  it('skips detail whose subAccountId is not in master set', () => {
+    const out = new Map();
+    const subSet = new Set([100]);
+    aggregateMovements(
+      [{ debitAccount: '3010000', debitSubAccount: 999, debitAmount: 50, ...APPROVED }],
+      accMap, subSet, out, {}
+    );
+    assert.equal(out.size, 0, 'orphan sub-account detail ignored');
+  });
+
+  it('skips detail whose account code is unknown', () => {
+    const out = new Map();
+    aggregateMovements(
+      [{ debitAccount: '9999999', debitAmount: 50, ...APPROVED }],
+      accMap, new Set(), out, {}
+    );
+    assert.equal(out.size, 0, 'unknown code detail ignored');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// balanceEngine — multi-tenant guards
+// ---------------------------------------------------------------------------
+
+describe('balanceEngine — multi-tenant guards', () => {
+  it('throws when tenantId is missing', async () => {
+    await assert.rejects(
+      () => balanceEngine({ term: 1, entrySources: [] }, makeDeps()),
+      /tenantId is required/
+    );
+  });
+  it('throws when tenantId is null', async () => {
+    await assert.rejects(
+      () => balanceEngine({ tenantId: null, term: 1, entrySources: [] }, makeDeps()),
+      /tenantId is required/
+    );
+  });
+  it('throws when term is missing', async () => {
+    await assert.rejects(
+      () => balanceEngine({ tenantId: 1, entrySources: [] }, makeDeps()),
+      /term is required/
+    );
+  });
+  it('throws when deps is missing', async () => {
+    await assert.rejects(
+      () => balanceEngine({ tenantId: 1, term: 1, entrySources: [] }),
+      /deps is required/
+    );
+  });
+  it('throws when entrySources is not an array', async () => {
+    await assert.rejects(
+      () => balanceEngine({ tenantId: 1, term: 1, entrySources: 'nope' }, makeDeps()),
+      /entrySources must be an array/
+    );
+  });
+  it('throws when entrySource is malformed', async () => {
+    await assert.rejects(
+      () => balanceEngine(
+        { tenantId: 1, term: 1, entrySources: [{ name: 'x' }] },
+        makeDeps()
+      ),
+      /\{name, fetch\}/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// balanceEngine — integration
+// ---------------------------------------------------------------------------
+
+describe('balanceEngine — integration', () => {
+  it('emits flat list: one line per sub-account when subs exist', async () => {
+    const result = await balanceEngine(
+      { tenantId: TENANT_A, term: 1, entrySources: [] },
+      makeDeps()
+    );
+    const subLines = result.lines.filter((l) => l.subAccountId != null);
+    assert.equal(subLines.length, 2, 'account 2 has 2 sub-accounts');
+    assert.ok(subLines.every((l) => l.code === '3010000'));
+    assert.deepEqual(
+      subLines.map((l) => l.subAccountId).sort(),
+      [100, 101]
+    );
+  });
+
+  it('opening from sub-account remaining, not from parent', async () => {
+    const result = await balanceEngine(
+      { tenantId: TENANT_A, term: 1, entrySources: [] },
+      makeDeps()
+    );
+    const sub100 = result.lines.find((l) => l.subAccountId === 100);
+    const sub101 = result.lines.find((l) => l.subAccountId === 101);
+    assert.equal(sub100.openingBalance, 200, 'sub 100 opening = 200 (credit balance)');
+    assert.equal(sub101.openingBalance, 300, 'sub 101 opening = 300');
+  });
+
+  it('endingDebit/endingCredit are T-account split of endingBalance', async () => {
+    const result = await balanceEngine(
+      { tenantId: TENANT_A, term: 1, entrySources: [] },
+      makeDeps()
+    );
+    const sub100 = result.lines.find((l) => l.subAccountId === 100);
+    assert.equal(sub100.endingBalance, 200);
+    assert.equal(sub100.endingCredit, 200, 'C-nature with positive balance → credit side');
+    assert.equal(sub100.endingDebit, 0);
+  });
+
+  it('7020010 override produces C-nature ending', async () => {
+    const deps = makeDeps();
+    const result = await balanceEngine(
+      {
+        tenantId: TENANT_A,
+        term: 1,
+        entrySources: [{
+          name: 'actual',
+          fetch: async () => [
+            { debitAccount: '7020010', debitAmount: 200, ...APPROVED },
+            { creditAccount: '7020010', creditAmount: 50, ...APPROVED },
+          ],
+        }],
+      },
+      deps
+    );
+    const line = result.lines.find((l) => l.code === '7020010');
+    assert.equal(line.endingBalance, -150, 'C-nature: 0 - 200 + 50 = -150');
+    assert.equal(line.endingDebit, 150, 'negative balance → opposite side (debit)');
+    assert.equal(line.endingCredit, 0);
+  });
+
+  it('PL opening from prior term is ignored (revenue/expense reset)', async () => {
+    const result = await balanceEngine(
+      { tenantId: TENANT_A, term: 1, entrySources: [] },
+      makeDeps()
+    );
+    const rev = result.lines.find((l) => l.code === '6010000');
+    const exp = result.lines.find((l) => l.code === '7010000');
+    assert.equal(rev.openingBalance, 0, 'revenue: prior 999 ignored');
+    assert.equal(exp.openingBalance, 0, 'expense: prior 123 ignored');
+  });
+
+  it('meta.tenantId / meta.term / meta.entrySourceNames are populated', async () => {
+    const result = await balanceEngine(
+      {
+        tenantId: TENANT_A,
+        term: 1,
+        period: { from: new Date('2026-01-01'), to: new Date('2026-12-31') },
+        entrySources: [{ name: 'actual', fetch: async () => [] }],
+      },
+      makeDeps()
+    );
+    assert.equal(result.meta.tenantId, TENANT_A);
+    assert.equal(result.meta.term, 1);
+    assert.deepEqual(result.meta.entrySourceNames, ['actual']);
+    assert.ok(result.meta.period);
+    assert.ok(result.meta.generatedAt instanceof Date);
+  });
+
+  it('isolates tenants: tenant B has no lines from tenant A accounts', async () => {
+    const result = await balanceEngine(
+      { tenantId: TENANT_B, term: 1, entrySources: [] },
+      makeDeps()
+    );
+    assert.equal(result.lines.length, 1, 'tenant B has 1 account (9990000)');
+    assert.equal(result.lines[0].code, '9990000');
+  });
+
+  it('multi-source: totalDebit === totalCredit invariant', async () => {
+    const result = await balanceEngine(
+      {
+        tenantId: TENANT_A,
+        term: 1,
+        entrySources: [
+          {
+            name: 'actual',
+            fetch: async () => [
+              { debitAccount: '1110000', debitAmount: 500, ...APPROVED },
+              { creditAccount: '5040000', creditAmount: 500, ...APPROVED },
+              { debitAccount: '7010000', debitAmount: 200, ...APPROVED },
+              { creditAccount: '1110000', creditAmount: 200, ...APPROVED },
+            ],
+          },
+          {
+            name: 'simulation',
+            fetch: async () => [
+              { debitAccount: '1110000', debitAmount: 100, ...APPROVED },
+              { creditAccount: '6010000', creditAmount: 100, ...APPROVED },
+            ],
+          },
+        ],
+      },
+      makeDeps()
+    );
+    const totalDebit = result.lines.reduce((s, l) => s + l.movementDebit, 0);
+    const totalCredit = result.lines.reduce((s, l) => s + l.movementCredit, 0);
+    assert.equal(totalDebit, totalCredit, `D=${totalDebit} C=${totalCredit}`);
+    assert.deepEqual(result.meta.entrySourceNames, ['actual', 'simulation']);
+  });
+
+  it('decimal safety: 1000 × 1,000,000 sums to 1,000,000,000 without drift', () => {
+    const out = new Map();
+    const accMap = new Map([['1110000', 1]]);
+    const details = [];
+    for (let i = 0; i < 1000; i += 1) {
+      details.push({ debitAccount: '1110000', debitAmount: 1_000_000, ...APPROVED });
+    }
+    aggregateMovements(details, accMap, new Set(), out, {});
+    assert.equal(out.get('acc:1').debit, 1_000_000_000);
+  });
+
+  it('subtotal invariant: sum of sub-account endings equals account parent total', async () => {
+    const result = await balanceEngine(
+      {
+        tenantId: TENANT_A,
+        term: 1,
+        entrySources: [{
+          name: 'actual',
+          fetch: async () => [
+            { creditAccount: '3010000', creditSubAccount: 100, creditAmount: 30, ...APPROVED },
+            { debitAccount: '3010000', debitSubAccount: 101, debitAmount: 40, ...APPROVED },
+          ],
+        }],
+      },
+      makeDeps()
+    );
+    const sub100 = result.lines.find((l) => l.subAccountId === 100);
+    const sub101 = result.lines.find((l) => l.subAccountId === 101);
+    const parentTotal = sub100.endingBalance + sub101.endingBalance;
+    // Parent 3010000 is C-nature per existing dc(); both subs inherit C-nature.
+    // sub100: opening 200 + 0 + 30 = 230 (C: opening - debit + credit)
+    // sub101: opening 300 - 40 + 0 = 260
+    assert.equal(sub100.endingBalance, 230);
+    assert.equal(sub101.endingBalance, 260);
+    assert.equal(parentTotal, 490, 'sub-account lines sum to parent effective total');
+  });
+});


### PR DESCRIPTION
Closes #195
Part of epic:reporting-engine (#194)

## Summary

Adds `libs/reporting/balance-engine.js` — single source of truth for opening/movement/ending balance. Framework-agnostic (no Express/Svelte); deps injected so unit tests run without a real DB.

Engine contract:

```js
balanceEngine({ tenantId, term, period, entrySources, options }, deps)
  → { lines, warnings, meta }
```

- `lines` is flat: one per sub-account when subs exist, one per account otherwise.
- Movement aggregated from each `entrySource.fetch()` (CrossSlipDetail-like rows).
- Multi-tenant guard throws if `tenantId`/`term` missing.
- PL accounts (field >= 6) ignore prior-term opening.
- `dc(code)` drives ending formula; `7020010` override preserved via existing `parse_account_code.js`.
- Decimal safety: `numeric()` from existing helper; tested 1000×1M = 1B no-drift.

## Test Plan

- [x] Engine unit tests (33 cases) — no DB
- [x] Multi-tenant guards (6 throw cases)
- [x] 7020010 override produces C-nature ending
- [x] PL opening from prior term is ignored
- [x] Subtotal invariant: sum of sub-account endings equals parent total
- [x] `npm test` → 109 passing, 0 failing
- [x] Test Report posted on issue #195

## Files

- `libs/reporting/balance-engine.js` (new)
- `test/reporting/balance-engine.test.mjs` (new)