### PR TITLE
feat(#196): wire trial balance through balanceEngine, drop frontend re-compute

### DIFF
--- a/front/svelte/trial-balance/trial-balance.svelte
+++ b/front/svelte/trial-balance/trial-balance.svelte
@@ -80,7 +80,6 @@ import axios from 'axios';
 import {onMount} from 'svelte';
 import TrialBalanceList from './trial-balance-list.svelte';
 import {numeric} from '../../../libs/utils.js';
-import {dc} from '../../../libs/parse_account_code';
 import {currentPage, link} from '../../javascripts/router.js';
 
 import BilingualText from '../components/bilingual-text.svelte';
@@ -146,14 +145,9 @@ const updateLines = async () => {
       pickup: numeric(account.pickup),
       debit: numeric(account.debit),
       credit: numeric(account.credit),
+      balance: numeric(account.balance),
       code: account.code
     };
-    if ( dc(account.code) == 'D' ) {
-      new_line.balance = new_line.pickup + new_line.debit - new_line.credit;
-    } else {
-      new_line.balance = new_line.pickup - new_line.debit + new_line.credit;
-    }
-
     if ( last_account.middle_name != account.middle_name ) {
       _lines.push({
         name: `【${account.middle_name}】`,

--- a/libs/reporting/balance-engine.js
+++ b/libs/reporting/balance-engine.js
@@ -1,5 +1,7 @@
 import { dc, field, numeric } from '../parse_account_code.js';
 
+const codeOf = (acc) => (acc.accountCode != null ? acc.accountCode : acc.code);
+
 const lineKey = (accountId, subAccountId) =>
   subAccountId != null ? `sub:${subAccountId}` : `acc:${accountId}`;
 
@@ -24,29 +26,27 @@ const computeEnding = (code, openingBalance, movementDebit, movementCredit) => {
 };
 
 const aggregateMovements = (details, accountByCode, subAccountIdSet, movementByLineKey, opts) => {
-  const { includeUnapproved = false } = opts || {};
+  const { includeUnapproved = false, subAccount = true } = opts || {};
+  const route = (code, subRaw, d, amountField, side) => {
+    if (!code) return;
+    const accId = accountByCode.get(code);
+    if (accId == null) return;
+    const subId = subRaw || null;
+    let k;
+    if (subAccount && subId != null) {
+      if (!subAccountIdSet.has(subId)) return;
+      k = `sub:${subId}`;
+    } else {
+      k = `acc:${accId}`;
+    }
+    const cur = movementByLineKey.get(k) || { debit: 0, credit: 0 };
+    cur[side] += numeric(d[amountField]);
+    movementByLineKey.set(k, cur);
+  };
   for (const d of details || []) {
     if (!includeUnapproved && !d.approvedAt) continue;
-    if (d.debitAccount) {
-      const subId = d.debitSubAccount || null;
-      if (subId != null && !subAccountIdSet.has(subId)) continue;
-      const accId = accountByCode.get(d.debitAccount);
-      if (accId == null) continue;
-      const k = subId != null ? `sub:${subId}` : `acc:${accId}`;
-      const cur = movementByLineKey.get(k) || { debit: 0, credit: 0 };
-      cur.debit += numeric(d.debitAmount);
-      movementByLineKey.set(k, cur);
-    }
-    if (d.creditAccount) {
-      const subId = d.creditSubAccount || null;
-      if (subId != null && !subAccountIdSet.has(subId)) continue;
-      const accId = accountByCode.get(d.creditAccount);
-      if (accId == null) continue;
-      const k = subId != null ? `sub:${subId}` : `acc:${accId}`;
-      const cur = movementByLineKey.get(k) || { debit: 0, credit: 0 };
-      cur.credit += numeric(d.creditAmount);
-      movementByLineKey.set(k, cur);
-    }
+    route(d.debitAccount, d.debitSubAccount, d, 'debitAmount', 'debit');
+    route(d.creditAccount, d.creditSubAccount, d, 'creditAmount', 'credit');
   }
 };
 
@@ -55,14 +55,18 @@ const aggregateMovements = (details, accountByCode, subAccountIdSet, movementByL
  *
  * params:
  *   tenantId     - required
- *   term         - required, FiscalYear.term
- *   period       - optional { from, to } stored in meta
+ *   term         - required, FiscalYear.term. Opening is read from
+ *                  AccountRemaining/SubAccountRemaining AT THIS term (setup and
+ *                  closing both write a term's opening into that term's row).
+ *   period       - optional { from, to } stored in meta; the fetcher enforces it
  *   entrySources - array of { name, fetch } where fetch() resolves to detail rows
  *                  (CrossSlipDetail-like: debitAccount, debitSubAccount, debitAmount,
  *                   creditAccount, creditSubAccount, creditAmount, approvedAt)
  *   options:
  *     includeUnapproved - default false
- *     subAccount        - default true (emit one line per sub-account when subs exist)
+ *     subAccount        - default true. true → one line per sub-account when subs
+ *                         exist, movement keyed by sub. false → one line per
+ *                         account, sub-account movement rolled up to the parent.
  *     accountClassIds / projectIds / labelIds - filtering hints; fetcher enforces
  *
  * deps: { Account, SubAccount, AccountRemaining, SubAccountRemaining }
@@ -91,18 +95,17 @@ export async function balanceEngine(params, deps) {
     include: [{ model: deps.SubAccount, as: 'subAccounts' }],
   });
 
-  const priorTerm = term - 1;
   const accountRemaining = await deps.AccountRemaining.findAll({
-    where: { tenantId, term: priorTerm },
+    where: { tenantId, term },
   });
   const subAccountRemaining = await deps.SubAccountRemaining.findAll({
-    where: { tenantId, term: priorTerm },
+    where: { tenantId, term },
   });
 
   const accountByCode = new Map();
   const subAccountIdSet = new Set();
   for (const acc of accounts) {
-    accountByCode.set(acc.code, acc.id);
+    accountByCode.set(codeOf(acc), acc.id);
     if (acc.subAccounts) {
       for (const sub of acc.subAccounts) {
         subAccountIdSet.add(sub.id);
@@ -112,23 +115,22 @@ export async function balanceEngine(params, deps) {
 
   const lineDefs = [];
   for (const acc of accounts) {
+    const accCode = codeOf(acc);
     if (subAccount && acc.subAccounts && acc.subAccounts.length > 0) {
       for (const sub of acc.subAccounts) {
         lineDefs.push({
           accountId: acc.id,
-          accountCode: acc.code,
           subAccountId: sub.id,
           subCode: sub.subAccountCode,
-          code: acc.code,
+          code: accCode,
         });
       }
     } else {
       lineDefs.push({
         accountId: acc.id,
-        accountCode: acc.code,
         subAccountId: null,
         subCode: null,
-        code: acc.code,
+        code: accCode,
       });
     }
   }
@@ -141,7 +143,10 @@ export async function balanceEngine(params, deps) {
     }
     sourceNames.push(src.name);
     const details = await src.fetch();
-    aggregateMovements(details, accountByCode, subAccountIdSet, movementByLineKey, { includeUnapproved });
+    aggregateMovements(details, accountByCode, subAccountIdSet, movementByLineKey, {
+      includeUnapproved,
+      subAccount,
+    });
   }
 
   const lines = lineDefs.map((ld) => {

--- a/libs/trial_balance.js
+++ b/libs/trial_balance.js
@@ -1,30 +1,111 @@
 import models from '../models/index.js';
 const Op = models.Sequelize.Op;
 import Accounts from './accounts.js';
-import {numeric, dc} from './parse_account_code.js';
+import { numeric } from './parse_account_code.js';
+import { balanceEngine } from './reporting/balance-engine.js';
 
-export default async (tenantId, term, endDate, options, languagePair) => {
-  let lines = [];
-  let index = [];
-
-  let fy = await models.FiscalYear.findOne({
-    where: {
-      tenantId,
-      term: term
-    }
-  });
-
-  let accounts = await Accounts.all3(tenantId, term, languagePair);
-  for ( let i = 0; i < accounts.length; i += 1)   {
-    let acc = accounts[i];
-    let balance = numeric(acc.balance);     //  don't forget!!!
-    if  ( acc.subAccounts > 0 )  {
-      //console.log(acc);
-      for ( let j = 0 ; j < acc.subAccounts.length; j += 1)   {
-        let sub = acc.subAccounts[j];
-        balance += sub.balance ? sub.balance : 0;
+/**
+ * Fetch approved CrossSlipDetail rows for [startDate, endDate) for a tenant,
+ * flattened with the parent slip's approvedAt so the engine can filter.
+ */
+const actualEntrySource = (tenantId, startDate, endDate) => ({
+  name: 'actual',
+  fetch: async () => {
+    const rows = [];
+    for (let mon = new Date(startDate); mon < new Date(endDate); ) {
+      const slips = await models.CrossSlip.findAll({
+        where: {
+          [Op.and]: {
+            tenantId,
+            year: mon.getFullYear(),
+            month: mon.getMonth() + 1,
+          },
+        },
+        include: [{ model: models.CrossSlipDetail, as: 'lines' }],
+      });
+      for (const slip of slips) {
+        for (const d of slip.lines || []) {
+          rows.push({
+            debitAccount: d.debitAccount,
+            debitSubAccount: d.debitSubAccount,
+            debitAmount: d.debitAmount,
+            creditAccount: d.creditAccount,
+            creditSubAccount: d.creditSubAccount,
+            creditAmount: d.creditAmount,
+            approvedAt: slip.approvedAt,
+          });
+        }
       }
+      mon.setMonth(mon.getMonth() + 1);
     }
+    return rows;
+  },
+});
+
+/**
+ * Trial balance for a tenant/term. Delegates calculation to the canonical
+ * balanceEngine (libs/reporting/balance-engine.js) and shapes the result into
+ * the legacy account-level line contract the /api/trial-balance route and the
+ * trial-balance Svelte screen already consume:
+ *   { major_name, middle_name, minor_name, *_nameVi, acl_code,
+ *     name, nameVi, code, pickup, debit, credit, balance }
+ *
+ * pickup = opening balance, debit/credit = period movement, balance = ending.
+ * Account-level rollup (subAccount:false) keeps one row per account, matching
+ * the legacy screen which renders account rows with sub-accounts summed in.
+ */
+export default async (tenantId, term, endDate, options, languagePair) => {
+  const fy = await models.FiscalYear.findOne({ where: { tenantId, term } });
+
+  if (!endDate) {
+    endDate = fy.endDate;
+  }
+  let startDate;
+  if (options && options.monthly) {
+    startDate = new Date(endDate.getFullYear(), endDate.getMonth(), 1);
+  } else {
+    startDate = new Date(fy.startDate);
+  }
+  // endDate is an inclusive day boundary; advance one day so the month loop
+  // and detail fetch include the final day.
+  const fetchEnd = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate() + 1);
+
+  const result = await balanceEngine(
+    {
+      tenantId,
+      term,
+      period: { from: startDate, to: endDate },
+      entrySources: [actualEntrySource(tenantId, startDate, fetchEnd)],
+      options: { subAccount: false },
+    },
+    models,
+  );
+
+  // Engine returns flat, name-less lines keyed by accountId. Join with
+  // Accounts.all3 (the existing enriched-name + class-hierarchy source) so the
+  // response keeps its bilingual names and major/middle/minor headers.
+  const accounts = await Accounts.all3(tenantId, term, languagePair);
+  const byCode = new Map();
+  for (const line of result.lines) {
+    byCode.set(line.code, line);
+  }
+
+  const lines = [];
+  for (const acc of accounts) {
+    if (!acc.code) {
+      // account-class header row (no account); preserve for section rendering
+      lines.push({
+        major_name: acc.major_name,
+        middle_name: acc.middle_name,
+        minor_name: acc.minor_name,
+        major_nameVi: acc.major_nameVi || '',
+        middle_nameVi: acc.middle_nameVi || '',
+        minor_nameVi: acc.minor_nameVi || '',
+        acl_code: acc.acl_code,
+      });
+      continue;
+    }
+    const engineLine = byCode.get(acc.code);
     lines.push({
       major_name: acc.major_name,
       middle_name: acc.middle_name,
@@ -36,65 +117,12 @@ export default async (tenantId, term, endDate, options, languagePair) => {
       name: acc.name,
       nameVi: acc.nameVi || '',
       code: acc.code,
-      pickup: balance,
-      debit: 0,
-      credit: 0,
-      balance: 0
+      pickup: engineLine ? numeric(engineLine.openingBalance) : 0,
+      debit: engineLine ? numeric(engineLine.movementDebit) : 0,
+      credit: engineLine ? numeric(engineLine.movementCredit) : 0,
+      balance: engineLine ? numeric(engineLine.endingBalance) : 0,
     });
-    index[acc.code] = i;
   }
-  if  ( !endDate )    {
-    endDate = fy.endDate;
-  }
-  let startDate;
-  if (options && options.monthly) {
-    startDate = new Date(endDate.getFullYear(), endDate.getMonth(), 1);
-  } else {
-    startDate = new Date(fy.startDate);
-  }
-  for ( let mon = startDate; mon < endDate; ) {
-    let cross_slips = await models.CrossSlip.findAll({
-      where: {
-        [Op.and]: {
-          tenantId,
-          year: mon.getFullYear(),
-          month: mon.getMonth() + 1
-        }
-      },
-      include: [{
-        model: models.CrossSlipDetail,
-        as: 'lines'
-      }]
-    });
-    for ( let i = 0; i < cross_slips.length; i ++ ) {
-      let cross_slip = cross_slips[i];
-      if  (  cross_slip.approvedAt )  {
-        for ( let j = 0; j < cross_slip.lines.length; j ++ ) {
-          let detail = cross_slip.lines[j];
-          if ( detail.debitAccount ) {
-            let ix = index[detail.debitAccount];
-            lines[ix].debit += numeric(detail.debitAmount);
-          }
-          if ( detail.creditAccount ) {
-            let ix = index[detail.creditAccount];
-            lines[ix].credit += numeric(detail.creditAmount);
-          }
-        }
-      }
-    }
-    mon.setMonth(mon.getMonth() + 1);
-  }
-  for ( let line of lines )   {
-    if  ( line.code )   {
-      if ( dc(line.code) == 'D' ) {
-        line.balance = line.pickup + line.debit - line.credit;
-      } else {
-        line.balance = line.pickup - line.debit + line.credit;
-      }
-    }
-  }
-  return  ({
-    lines: lines,
-    accounts: accounts
-  });
-}
+
+  return { lines, accounts, warnings: result.warnings, meta: result.meta };
+};

--- a/test/reporting/balance-engine.test.mjs
+++ b/test/reporting/balance-engine.test.mjs
@@ -36,19 +36,19 @@ const accounts = [
 ];
 
 const accountRemaining = [
-  { accountId: 1, term: 0, debit: 100, credit: 0, balance: 100, tenantId: TENANT_A },
-  { accountId: 2, term: 0, debit: 0, credit: 0, balance: 0, tenantId: TENANT_A },
-  { accountId: 3, term: 0, debit: 50, credit: 50, balance: 0, tenantId: TENANT_A },
-  { accountId: 4, term: 0, debit: 999, credit: 0, balance: 999, tenantId: TENANT_A },
-  { accountId: 5, term: 0, debit: 0, credit: 123, balance: 123, tenantId: TENANT_A },
-  { accountId: 6, term: 0, debit: 0, credit: 0, balance: 0, tenantId: TENANT_A },
-  { subAccountId: 100, term: 0, debit: 0, credit: 200, balance: 200, tenantId: TENANT_A },
-  { subAccountId: 101, term: 0, debit: 300, credit: 0, balance: 300, tenantId: TENANT_A },
+  { accountId: 1, term: 1, debit: 100, credit: 0, balance: 100, tenantId: TENANT_A },
+  { accountId: 2, term: 1, debit: 0, credit: 0, balance: 0, tenantId: TENANT_A },
+  { accountId: 3, term: 1, debit: 50, credit: 50, balance: 0, tenantId: TENANT_A },
+  { accountId: 4, term: 1, debit: 999, credit: 0, balance: 999, tenantId: TENANT_A },
+  { accountId: 5, term: 1, debit: 0, credit: 123, balance: 123, tenantId: TENANT_A },
+  { accountId: 6, term: 1, debit: 0, credit: 0, balance: 0, tenantId: TENANT_A },
+  { subAccountId: 100, term: 1, debit: 0, credit: 200, balance: 200, tenantId: TENANT_A },
+  { subAccountId: 101, term: 1, debit: 300, credit: 0, balance: 300, tenantId: TENANT_A },
 ];
 
 const subAccountRemaining = [
-  { subAccountId: 100, term: 0, debit: 0, credit: 200, balance: 200, tenantId: TENANT_A },
-  { subAccountId: 101, term: 0, debit: 300, credit: 0, balance: 300, tenantId: TENANT_A },
+  { subAccountId: 100, term: 1, debit: 0, credit: 200, balance: 200, tenantId: TENANT_A },
+  { subAccountId: 101, term: 1, debit: 300, credit: 0, balance: 300, tenantId: TENANT_A },
 ];
 
 const makeDeps = (overrides = {}) => ({
@@ -443,5 +443,68 @@ describe('balanceEngine — integration', () => {
     assert.equal(sub100.endingBalance, 230);
     assert.equal(sub101.endingBalance, 260);
     assert.equal(parentTotal, 490, 'sub-account lines sum to parent effective total');
+  });
+
+  it('reads opening from AccountRemaining at the same term (no off-by-one)', async () => {
+    // accountRemaining for account 1 is stored at term 1 with balance 100.
+    const result = await balanceEngine(
+      { tenantId: TENANT_A, term: 1, entrySources: [] },
+      makeDeps()
+    );
+    const cash = result.lines.find((l) => l.code === '1110000');
+    assert.equal(cash.openingBalance, 100, 'opening read at term=1, not term-1');
+  });
+
+  it('normalizes accountCode field (Sequelize model uses accountCode, not code)', async () => {
+    const seqAccounts = [
+      { id: 1, accountCode: '1110000', tenantId: TENANT_A, subAccounts: [] },
+    ];
+    const deps = {
+      Account: { findAll: async () => seqAccounts },
+      SubAccount: {},
+      AccountRemaining: { findAll: async () => [
+        { accountId: 1, term: 1, debit: 0, credit: 0, balance: 500, tenantId: TENANT_A },
+      ]},
+      SubAccountRemaining: { findAll: async () => [] },
+    };
+    const result = await balanceEngine(
+      {
+        tenantId: TENANT_A,
+        term: 1,
+        entrySources: [{
+          name: 'actual',
+          fetch: async () => [{ debitAccount: '1110000', debitAmount: 50, ...APPROVED }],
+        }],
+      },
+      deps
+    );
+    assert.equal(result.lines.length, 1);
+    assert.equal(result.lines[0].code, '1110000');
+    assert.equal(result.lines[0].openingBalance, 500);
+    assert.equal(result.lines[0].movementDebit, 50);
+    assert.equal(result.lines[0].endingBalance, 550, 'D-nature: 500 + 50 - 0');
+  });
+
+  it('subAccount:false rolls sub-account movement up to the parent account line', async () => {
+    const result = await balanceEngine(
+      {
+        tenantId: TENANT_A,
+        term: 1,
+        options: { subAccount: false },
+        entrySources: [{
+          name: 'actual',
+          fetch: async () => [
+            { creditAccount: '3010000', creditSubAccount: 100, creditAmount: 30, ...APPROVED },
+            { debitAccount: '3010000', debitSubAccount: 101, debitAmount: 40, ...APPROVED },
+          ],
+        }],
+      },
+      makeDeps()
+    );
+    const parent = result.lines.find((l) => l.code === '3010000');
+    assert.equal(parent.subAccountId, null, 'one account-level line, no sub lines');
+    assert.equal(result.lines.filter((l) => l.code === '3010000').length, 1);
+    assert.equal(parent.movementCredit, 30, 'sub movements rolled into parent');
+    assert.equal(parent.movementDebit, 40);
   });
 });

--- a/test/reporting/trial-balance-e2e.test.mjs
+++ b/test/reporting/trial-balance-e2e.test.mjs
@@ -1,0 +1,198 @@
+/**
+ * E2E / integration — Issue #196: trial balance served by balanceEngine.
+ *
+ * Drives the real Express app over HTTP (supertest), self-seeds real data:
+ *   signup → setup (fiscal year + chart of accounts) → post approved journal
+ *   entries → GET /api/trial-balance → assert engine math is correct.
+ *
+ * Requires a live, migrated Postgres test DB (hieronymus_test). Run with: npm test
+ */
+
+import { strict as assert } from 'node:assert';
+import request from 'supertest';
+import app from '../../app.js';
+import models from '../../models/index.js';
+import { dc, numeric } from '../../libs/parse_account_code.js';
+
+const RUN = Date.now().toString(36);
+const USER = { name: `tbe2e_${RUN}`.slice(0, 20), password: 'password-1234' };
+
+async function signupAndLogin(user) {
+  const agent = request.agent(app);
+  const signupRes = await agent
+    .post('/api/user/signup')
+    .send({ user_name: user.name, password: user.password, legalName: user.name, email: `${user.name}@example.com` })
+    .expect('Content-Type', /json/);
+  assert.ok(
+    signupRes.body.result === 'OK' || signupRes.body.message?.includes('既に登録'),
+    `signup unexpected: ${JSON.stringify(signupRes.body)}`
+  );
+  const loginRes = await agent
+    .post('/api/user/login')
+    .send({ user_name: user.name, password: user.password })
+    .expect(200);
+  assert.equal(loginRes.body.result, 'OK', `login failed for ${user.name}`);
+  return agent;
+}
+
+describe('E2E — trial balance served by balanceEngine (real data)', function () {
+  this.timeout(60000);
+
+  let agent;
+  let tenantId;
+  const term = 1;
+  const year = 2026;
+  const setupBody = {
+    startDate: '2026-01-01',
+    endDate: '2026-12-31',
+    term,
+    year,
+    companyClass: 0,
+    roundingMethod: 0,
+  };
+
+  let dAcc; // debit-nature account
+  let cAcc; // credit-nature account
+
+  before(async function () {
+    agent = await signupAndLogin(USER);
+    const res = await agent.post('/api/setup').send(setupBody).expect(200);
+    assert.equal(res.body.code, 0, `setup failed: ${JSON.stringify(res.body)}`);
+
+    const u = await models.User.findOne({ where: { name: USER.name } });
+    const m = await models.TenantMember.findOne({ where: { userId: u.id, isDefault: true } });
+    tenantId = m.tenantId;
+
+    const accounts = await models.Account.findAll({
+      where: { tenantId },
+      order: [['accountCode', 'ASC']],
+    });
+    // Prefer accounts without sub-accounts so account-level posting is unambiguous.
+    const noSub = accounts.filter((a) => !a.subAccountCount || a.subAccountCount === 0);
+    dAcc = noSub.find((a) => dc(a.accountCode) === 'D');
+    cAcc = noSub.find((a) => dc(a.accountCode) === 'C');
+    assert.ok(dAcc, 'expected at least one debit-nature account from setup');
+    assert.ok(cAcc, 'expected at least one credit-nature account from setup');
+  });
+
+  it('setup seeded a fiscal year, chart of accounts, and opening remainings', async function () {
+    const fy = await models.FiscalYear.findOne({ where: { tenantId, term } });
+    assert.ok(fy, 'fiscal year for term 1 should exist');
+    const accCount = await models.Account.count({ where: { tenantId } });
+    assert.ok(accCount > 0, 'accounts should be seeded');
+    const remCount = await models.AccountRemaining.count({ where: { tenantId, term } });
+    assert.ok(remCount > 0, 'opening remainings should be seeded at the same term');
+  });
+
+  it('posts an approved journal entry (debit D / credit C) and TB reflects it', async function () {
+    const postRes = await agent
+      .post('/api/cross_slip')
+      .send({
+        year,
+        month: 4,
+        day: 15,
+        term,
+        lines: [{
+          debitAccount: dAcc.accountCode,
+          debitAmount: 10000,
+          creditAccount: cAcc.accountCode,
+          creditAmount: 10000,
+        }],
+      })
+      .expect(200);
+    assert.notEqual(postRes.body.code, -10, 'user should have accounting permission');
+    assert.notEqual(postRes.body.code, -2, 'slip date should be valid');
+
+    // The owner is approvable → slip auto-approves on create.
+    const slip = await models.CrossSlip.findOne({ where: { tenantId, year, month: 4 } });
+    assert.ok(slip, 'cross slip should be persisted');
+    assert.ok(slip.approvedAt, 'owner-created slip should be auto-approved');
+
+    const tb = await agent.get('/api/trial-balance').expect(200);
+    const lines = tb.body;
+    const dLine = lines.find((l) => l.code === dAcc.accountCode);
+    const cLine = lines.find((l) => l.code === cAcc.accountCode);
+    assert.ok(dLine, `debit account ${dAcc.accountCode} should appear in TB`);
+    assert.ok(cLine, `credit account ${cAcc.accountCode} should appear in TB`);
+
+    assert.equal(numeric(dLine.debit), 10000, 'debit movement recorded');
+    assert.equal(numeric(dLine.credit), 0);
+    assert.equal(numeric(cLine.credit), 10000, 'credit movement recorded');
+    assert.equal(numeric(cLine.debit), 0);
+
+    // D-nature: ending = pickup + debit - credit; C-nature: pickup - debit + credit.
+    assert.equal(numeric(dLine.balance), numeric(dLine.pickup) + 10000, 'D ending');
+    assert.equal(numeric(cLine.balance), numeric(cLine.pickup) + 10000, 'C ending');
+  });
+
+  it('debit total movement equals credit total movement (TB invariant)', async function () {
+    const tb = await agent.get('/api/trial-balance').expect(200);
+    const lines = tb.body.filter((l) => l.code);
+    const totalDebit = lines.reduce((s, l) => s + numeric(l.debit), 0);
+    const totalCredit = lines.reduce((s, l) => s + numeric(l.credit), 0);
+    assert.equal(totalDebit, totalCredit, `D=${totalDebit} C=${totalCredit}`);
+    assert.ok(totalDebit >= 10000, 'at least the posted entry is present');
+  });
+
+  it('monthly view isolates a single month of movement', async function () {
+    // Second entry in a different month (May).
+    await agent
+      .post('/api/cross_slip')
+      .send({
+        year,
+        month: 5,
+        day: 10,
+        term,
+        lines: [{
+          debitAccount: dAcc.accountCode,
+          debitAmount: 7000,
+          creditAccount: cAcc.accountCode,
+          creditAmount: 7000,
+        }],
+      })
+      .expect(200);
+
+    const april = await agent.get(`/api/trial-balance/${year}-4`).expect(200);
+    const aprilD = april.body.find((l) => l.code === dAcc.accountCode);
+    assert.equal(numeric(aprilD.debit), 10000, 'April view shows only April movement');
+
+    const may = await agent.get(`/api/trial-balance/${year}-5`).expect(200);
+    const mayD = may.body.find((l) => l.code === dAcc.accountCode);
+    assert.equal(numeric(mayD.debit), 7000, 'May view shows only May movement');
+
+    // Annual view accumulates both.
+    const annual = await agent.get('/api/trial-balance').expect(200);
+    const annualD = annual.body.find((l) => l.code === dAcc.accountCode);
+    assert.equal(numeric(annualD.debit), 17000, 'annual view sums all months');
+    assert.equal(numeric(annualD.balance), numeric(annualD.pickup) + 17000);
+  });
+
+  it('TB excludes unapproved entries', async function () {
+    // Create a slip as the owner (auto-approved), then un-approve it directly,
+    // and confirm the engine (includeUnapproved=false) drops it.
+    await agent
+      .post('/api/cross_slip')
+      .send({
+        year,
+        month: 6,
+        day: 1,
+        term,
+        lines: [{
+          debitAccount: dAcc.accountCode,
+          debitAmount: 5000,
+          creditAccount: cAcc.accountCode,
+          creditAmount: 5000,
+        }],
+      })
+      .expect(200);
+    const slip = await models.CrossSlip.findOne({ where: { tenantId, year, month: 6 } });
+    slip.approvedAt = null;
+    slip.approvedBy = null;
+    await slip.save();
+
+    const june = await agent.get(`/api/trial-balance/${year}-6`).expect(200);
+    const juneD = june.body.find((l) => l.code === dAcc.accountCode);
+    const juneMovement = juneD ? numeric(juneD.debit) : 0;
+    assert.equal(juneMovement, 0, 'unapproved June entry must not appear in TB');
+  });
+});


### PR DESCRIPTION
Closes #196
Part of epic:reporting-engine (#194)

## Summary

`libs/trial_balance.js` now delegates calculation to the canonical `balanceEngine` (#195) instead of computing balances itself. It builds an `actual` entrySource over approved `CrossSlipDetail` rows for the period, runs the engine at account level (`subAccount:false`), and shapes the result into the legacy line contract the `/api/trial-balance` route and Svelte screen already consume.

- Route unchanged; already guarded by `is_authenticated, requireTenant`.
- `trial-balance.svelte` no longer recomputes balance (`numeric()+dc()` removed); renders server `balance` directly.
- Existing consumers (`init-trial-balance.js`, `init-financial-statement.js`) keep all fields they read.

## Engine fixes surfaced by real data

- **Off-by-one term (critical):** opening was read at `term-1`; setup + closing write a term's opening into that term's row. Fixed to read at `term`.
- **Field name:** Sequelize `Account` exposes `accountCode`, not `code`.
- **Sub rollup:** `subAccount:false` rolls sub-account movement up to the parent line.

## Test Plan

- [x] 36 engine unit tests (incl. same-term opening regression guard, accountCode normalization, sub rollup)
- [x] 5 HTTP E2E tests, self-seeding real Postgres: signup → setup → approved journal entries → `/api/trial-balance`
- [x] Asserts movement, D/C ending formula, debit==credit invariant, monthly isolation, unapproved exclusion
- [x] `npm run build` ✅; `npm test` → 117 passing, 0 failing
- [x] Test Report posted on issue #196

## Files

- `libs/reporting/balance-engine.js` (3 real-data fixes)
- `libs/trial_balance.js` (rewritten to delegate)
- `front/svelte/trial-balance/trial-balance.svelte` (drop re-compute)
- `test/reporting/balance-engine.test.mjs` (+3 tests)
- `test/reporting/trial-balance-e2e.test.mjs` (new, 5 E2E tests)