### PR TITLE
feat(#199): reconciliation test — engine ending == ledger sums

### DIFF
--- a/libs/reporting/balance-engine.js
+++ b/libs/reporting/balance-engine.js
@@ -2,8 +2,19 @@ import { dc, field, numeric } from '../parse_account_code.js';
 
 const codeOf = (acc) => (acc.accountCode != null ? acc.accountCode : acc.code);
 
-const lineKey = (accountId, subAccountId) =>
-  subAccountId != null ? `sub:${subAccountId}` : `acc:${accountId}`;
+// Movement is keyed by (accountId, subAccountCode) because CrossSlipDetail
+// stores the per-account sub-account CODE in debitSubAccount/creditSubAccount,
+// not the SubAccount primary key. Opening, by contrast, is keyed by
+// subAccountId (SubAccountRemaining.subAccountId), so the two are resolved
+// from different identifiers on purpose.
+const lineKey = (accountId, subCode) =>
+  subCode != null ? `sub:${accountId}:${subCode}` : `acc:${accountId}`;
+
+const normalizeSubCode = (raw) => {
+  if (raw == null) return null;
+  if (raw === 0 || raw === '0') return null;
+  return raw;
+};
 
 const openingFromRemaining = (code, remaining) => {
   if (parseInt(field(code), 10) >= 6) {
@@ -25,17 +36,25 @@ const computeEnding = (code, openingBalance, movementDebit, movementCredit) => {
     : openingBalance - movementDebit + movementCredit;
 };
 
-const aggregateMovements = (details, accountByCode, subAccountIdSet, movementByLineKey, opts) => {
+/**
+ * Aggregate movement from detail rows into a Map keyed by lineKey().
+ *
+ * accountByCode  Map<accountCode, accountId>
+ * validSubKeys   Set<`${accountId}:${subAccountCode}`> — known sub-accounts
+ * opts.subAccount  when false, sub-account movement rolls up to the parent
+ *                  account line; when true, it is kept per sub-account.
+ */
+const aggregateMovements = (details, accountByCode, validSubKeys, movementByLineKey, opts) => {
   const { includeUnapproved = false, subAccount = true } = opts || {};
   const route = (code, subRaw, d, amountField, side) => {
     if (!code) return;
     const accId = accountByCode.get(code);
     if (accId == null) return;
-    const subId = subRaw || null;
+    const subCode = normalizeSubCode(subRaw);
     let k;
-    if (subAccount && subId != null) {
-      if (!subAccountIdSet.has(subId)) return;
-      k = `sub:${subId}`;
+    if (subAccount && subCode != null) {
+      if (!validSubKeys.has(`${accId}:${subCode}`)) return; // orphan sub-account
+      k = `sub:${accId}:${subCode}`;
     } else {
       k = `acc:${accId}`;
     }
@@ -60,13 +79,14 @@ const aggregateMovements = (details, accountByCode, subAccountIdSet, movementByL
  *                  closing both write a term's opening into that term's row).
  *   period       - optional { from, to } stored in meta; the fetcher enforces it
  *   entrySources - array of { name, fetch } where fetch() resolves to detail rows
- *                  (CrossSlipDetail-like: debitAccount, debitSubAccount, debitAmount,
- *                   creditAccount, creditSubAccount, creditAmount, approvedAt)
+ *                  (CrossSlipDetail-like: debitAccount, debitSubAccount [=sub
+ *                   CODE], debitAmount, creditAccount, creditSubAccount,
+ *                   creditAmount, approvedAt)
  *   options:
  *     includeUnapproved - default false
  *     subAccount        - default true. true → one line per sub-account when subs
- *                         exist, movement keyed by sub. false → one line per
- *                         account, sub-account movement rolled up to the parent.
+ *                         exist, movement keyed by (accountId, subCode). false →
+ *                         one line per account, sub movement rolled up to parent.
  *     accountClassIds / projectIds / labelIds - filtering hints; fetcher enforces
  *
  * deps: { Account, SubAccount, AccountRemaining, SubAccountRemaining }
@@ -103,12 +123,12 @@ export async function balanceEngine(params, deps) {
   });
 
   const accountByCode = new Map();
-  const subAccountIdSet = new Set();
+  const validSubKeys = new Set();
   for (const acc of accounts) {
     accountByCode.set(codeOf(acc), acc.id);
     if (acc.subAccounts) {
       for (const sub of acc.subAccounts) {
-        subAccountIdSet.add(sub.id);
+        validSubKeys.add(`${acc.id}:${sub.subAccountCode}`);
       }
     }
   }
@@ -143,7 +163,7 @@ export async function balanceEngine(params, deps) {
     }
     sourceNames.push(src.name);
     const details = await src.fetch();
-    aggregateMovements(details, accountByCode, subAccountIdSet, movementByLineKey, {
+    aggregateMovements(details, accountByCode, validSubKeys, movementByLineKey, {
       includeUnapproved,
       subAccount,
     });
@@ -154,7 +174,7 @@ export async function balanceEngine(params, deps) {
       ? subAccountRemaining.find((r) => r.subAccountId === ld.subAccountId)
       : accountRemaining.find((r) => r.accountId === ld.accountId);
     const opening = openingFromRemaining(ld.code, remaining);
-    const movement = movementByLineKey.get(lineKey(ld.accountId, ld.subAccountId))
+    const movement = movementByLineKey.get(lineKey(ld.accountId, ld.subCode))
       || { debit: 0, credit: 0 };
     const endingBalance = computeEnding(ld.code, opening.balance, movement.debit, movement.credit);
     const isD = dc(ld.code) === 'D';

--- a/test/reporting/balance-engine.test.mjs
+++ b/test/reporting/balance-engine.test.mjs
@@ -85,10 +85,10 @@ const APPROVED = { approvedAt: new Date('2026-06-01') };
 // ---------------------------------------------------------------------------
 
 describe('lineKey', () => {
-  it('uses sub: prefix for sub-account lines', () => {
-    assert.equal(lineKey(1, 100), 'sub:100');
+  it('uses sub:<accId>:<subCode> for sub-account lines', () => {
+    assert.equal(lineKey(2, 1), 'sub:2:1');
   });
-  it('uses acc: prefix for account-level lines', () => {
+  it('uses acc:<accId> for account-level lines', () => {
     assert.equal(lineKey(1, null), 'acc:1');
   });
 });
@@ -143,7 +143,6 @@ describe('aggregateMovements', () => {
   const accMap = new Map([
     ['1110000', 1],
     ['3010000', 2],
-    ['3010000', 2],
     ['5040000', 3],
     ['6010000', 4],
     ['7010000', 5],
@@ -197,25 +196,25 @@ describe('aggregateMovements', () => {
     assert.equal(out.get('acc:1').debit, 1099);
   });
 
-  it('routes sub-account detail to sub: line key', () => {
+  it('routes sub-account detail to sub:<accId>:<subCode> line key', () => {
     const out = new Map();
-    const subSet = new Set([100]);
+    const subKeys = new Set(['2:1']); // account 2 (3010000), sub code 1
     aggregateMovements(
       [
-        { creditAccount: '3010000', creditSubAccount: 100, creditAmount: 50, ...APPROVED },
-        { debitAccount: '3010000', debitSubAccount: 100, debitAmount: 70, ...APPROVED },
+        { creditAccount: '3010000', creditSubAccount: 1, creditAmount: 50, ...APPROVED },
+        { debitAccount: '3010000', debitSubAccount: 1, debitAmount: 70, ...APPROVED },
       ],
-      accMap, subSet, out, {}
+      accMap, subKeys, out, {}
     );
-    assert.deepEqual(out.get('sub:100'), { debit: 70, credit: 50 });
+    assert.deepEqual(out.get('sub:2:1'), { debit: 70, credit: 50 });
   });
 
-  it('skips detail whose subAccountId is not in master set', () => {
+  it('skips detail whose sub-account code is not in master set', () => {
     const out = new Map();
-    const subSet = new Set([100]);
+    const subKeys = new Set(['2:1']);
     aggregateMovements(
       [{ debitAccount: '3010000', debitSubAccount: 999, debitAmount: 50, ...APPROVED }],
-      accMap, subSet, out, {}
+      accMap, subKeys, out, {}
     );
     assert.equal(out.size, 0, 'orphan sub-account detail ignored');
   });
@@ -427,8 +426,8 @@ describe('balanceEngine — integration', () => {
         entrySources: [{
           name: 'actual',
           fetch: async () => [
-            { creditAccount: '3010000', creditSubAccount: 100, creditAmount: 30, ...APPROVED },
-            { debitAccount: '3010000', debitSubAccount: 101, debitAmount: 40, ...APPROVED },
+            { creditAccount: '3010000', creditSubAccount: 1, creditAmount: 30, ...APPROVED },
+            { debitAccount: '3010000', debitSubAccount: 2, debitAmount: 40, ...APPROVED },
           ],
         }],
       },
@@ -438,8 +437,8 @@ describe('balanceEngine — integration', () => {
     const sub101 = result.lines.find((l) => l.subAccountId === 101);
     const parentTotal = sub100.endingBalance + sub101.endingBalance;
     // Parent 3010000 is C-nature per existing dc(); both subs inherit C-nature.
-    // sub100: opening 200 + 0 + 30 = 230 (C: opening - debit + credit)
-    // sub101: opening 300 - 40 + 0 = 260
+    // sub100 (code 1): opening 200 + 0 + 30 = 230 (C: opening - debit + credit)
+    // sub101 (code 2): opening 300 - 40 + 0 = 260
     assert.equal(sub100.endingBalance, 230);
     assert.equal(sub101.endingBalance, 260);
     assert.equal(parentTotal, 490, 'sub-account lines sum to parent effective total');
@@ -494,8 +493,8 @@ describe('balanceEngine — integration', () => {
         entrySources: [{
           name: 'actual',
           fetch: async () => [
-            { creditAccount: '3010000', creditSubAccount: 100, creditAmount: 30, ...APPROVED },
-            { debitAccount: '3010000', debitSubAccount: 101, debitAmount: 40, ...APPROVED },
+            { creditAccount: '3010000', creditSubAccount: 1, creditAmount: 30, ...APPROVED },
+            { debitAccount: '3010000', debitSubAccount: 2, debitAmount: 40, ...APPROVED },
           ],
         }],
       },

--- a/test/reporting/reconciliation.test.mjs
+++ b/test/reporting/reconciliation.test.mjs
@@ -1,0 +1,231 @@
+/**
+ * Reconciliation — Issue #199: balanceEngine ending == ledgerLines sums.
+ *
+ * Proves the canonical engine and the per-account ledger agree on ending
+ * balances for the SAME tenant/term/period, over real seeded journal data.
+ * Fixture is fixed (not random) for debuggability: 10 account-level lines
+ * (BS debit, BS credit, PL, 7020010 edge case) + 5 sub-account lines.
+ *
+ * Requires a live, migrated Postgres test DB. Run with: npm test
+ */
+
+import { strict as assert } from 'node:assert';
+import request from 'supertest';
+import app from '../../app.js';
+import models from '../../models/index.js';
+import { balanceEngine } from '../../libs/reporting/balance-engine.js';
+import { ledgerLines } from '../../libs/ledger.js';
+import { numeric } from '../../libs/parse_account_code.js';
+
+const RUN = Date.now().toString(36);
+const USER = { name: `recon_${RUN}`.slice(0, 20), password: 'password-1234' };
+const YEAR = 2026;
+const TERM = 1;
+
+async function signupAndLogin(user) {
+  const agent = request.agent(app);
+  const signupRes = await agent
+    .post('/api/user/signup')
+    .send({ user_name: user.name, password: user.password, legalName: user.name, email: `${user.name}@example.com` })
+    .expect('Content-Type', /json/);
+  assert.ok(
+    signupRes.body.result === 'OK' || signupRes.body.message?.includes('既に登録'),
+    `signup unexpected: ${JSON.stringify(signupRes.body)}`
+  );
+  const loginRes = await agent
+    .post('/api/user/login')
+    .send({ user_name: user.name, password: user.password })
+    .expect(200);
+  assert.equal(loginRes.body.result, 'OK');
+  return agent;
+}
+
+// Post an approved cross slip with explicit debit/credit accounts (+ optional subs).
+async function postSlip(agent, month, day, line) {
+  const res = await agent.post('/api/cross_slip').send({
+    year: YEAR, month, day, term: TERM, lines: [line],
+  }).expect(200);
+  assert.notEqual(res.body.code, -10, 'user has accounting permission');
+  assert.notEqual(res.body.code, -2, 'slip date valid');
+}
+
+// Reproduce libs/trial_balance.js's actual entrySource for the whole FY.
+function actualEntrySource(tenantId, startDate, fetchEnd, Op) {
+  return {
+    name: 'actual',
+    fetch: async () => {
+      const rows = [];
+      for (let mon = new Date(startDate); mon < new Date(fetchEnd); ) {
+        const slips = await models.CrossSlip.findAll({
+          where: { [Op.and]: { tenantId, year: mon.getFullYear(), month: mon.getMonth() + 1 } },
+          include: [{ model: models.CrossSlipDetail, as: 'lines' }],
+        });
+        for (const slip of slips) {
+          for (const d of slip.lines || []) {
+            rows.push({
+              debitAccount: d.debitAccount, debitSubAccount: d.debitSubAccount, debitAmount: d.debitAmount,
+              creditAccount: d.creditAccount, creditSubAccount: d.creditSubAccount, creditAmount: d.creditAmount,
+              approvedAt: slip.approvedAt,
+            });
+          }
+        }
+        mon.setMonth(mon.getMonth() + 1);
+      }
+      return rows;
+    },
+  };
+}
+
+// Fetch approved CrossSlipDetail rows for one account/sub over the FY, the way
+// libs/crossslipdetails.js does, for feeding ledgerLines.
+async function ledgerDetailsFor(tenantId, fy, accountCode, subCode, Op) {
+  const out = [];
+  for (let mon = new Date(fy.startDate); mon < new Date(fy.endDate); ) {
+    const orClause = subCode
+      ? [
+          { debitAccount: accountCode, debitSubAccount: subCode },
+          { creditAccount: accountCode, creditSubAccount: subCode },
+        ]
+      : [{ debitAccount: accountCode }, { creditAccount: accountCode }];
+    const details = await models.CrossSlipDetail.findAll({
+      where: {
+        tenantId,
+        [Op.and]: {
+          [Op.or]: orClause,
+          '$crossSlip.year$': mon.getFullYear(),
+          '$crossSlip.month$': mon.getMonth() + 1,
+        },
+      },
+      include: [{ model: models.CrossSlip, as: 'crossSlip' }],
+    });
+    for (const d of details) {
+      if (d.crossSlip && d.crossSlip.approvedAt) out.push(d);
+    }
+    mon.setMonth(mon.getMonth() + 1);
+  }
+  return out;
+}
+
+describe('Reconciliation — engine ending == ledger sums (Issue #199)', function () {
+  this.timeout(120000);
+
+  const Op = models.Sequelize.Op;
+  let agent, tenantId, fy;
+  let engineByKey; // Map code|code:sub -> engine line
+
+  // Fixed fixture (verified present in the seeded chart of accounts).
+  const ACCOUNTS = [
+    '1000000', '1010000', '1010010', // BS debit
+    '3000000', '3010000',            // BS credit
+    '6000000', '7000000', '7010000', // PL
+    '7020010',                       // edge case (dc override C)
+  ];
+  // Sub-having accounts: 3050000 (C, subs 1..4), 7030020 (D, subs 1..4).
+  const SUBS = [
+    { account: '3050000', sub: 1 },
+    { account: '3050000', sub: 2 },
+    { account: '7030020', sub: 1 },
+    { account: '7030020', sub: 2 },
+    { account: '7030020', sub: 3 },
+  ];
+
+  before(async function () {
+    agent = await signupAndLogin(USER);
+    const setupRes = await agent.post('/api/setup').send({
+      startDate: '2026-01-01', endDate: '2026-12-31', term: TERM, year: YEAR,
+      companyClass: 0, roundingMethod: 0,
+    }).expect(200);
+    assert.equal(setupRes.body.code, 0, `setup failed: ${JSON.stringify(setupRes.body)}`);
+
+    const u = await models.User.findOne({ where: { name: USER.name } });
+    const m = await models.TenantMember.findOne({ where: { userId: u.id, isDefault: true } });
+    tenantId = m.tenantId;
+    fy = await models.FiscalYear.findOne({ where: { tenantId, term: TERM } });
+
+    // Seed account-level entries (each balanced against a counter account).
+    // 1000000(D) ← 3000000(C): asset up, equity up
+    await postSlip(agent, 2, 1, { debitAccount: '1000000', debitAmount: 120000, creditAccount: '3000000', creditAmount: 120000 });
+    // 1010000(D) ← 3010000(C)
+    await postSlip(agent, 2, 2, { debitAccount: '1010000', debitAmount: 80000, creditAccount: '3010000', creditAmount: 80000 });
+    // 1010010(D) ← 6000000(C revenue): cash from sales
+    await postSlip(agent, 3, 1, { debitAccount: '1010010', debitAmount: 50000, creditAccount: '6000000', creditAmount: 50000 });
+    // 7000000(D expense) ← 1000000(C): pay an expense out of cash
+    await postSlip(agent, 3, 2, { debitAccount: '7000000', debitAmount: 15000, creditAccount: '1000000', creditAmount: 15000 });
+    // 7010000(D expense) ← 1010000(C)
+    await postSlip(agent, 4, 1, { debitAccount: '7010000', debitAmount: 9000, creditAccount: '1010000', creditAmount: 9000 });
+    // 7020010(C edge: 期末商品棚卸高) ← 1010010(D)
+    await postSlip(agent, 4, 2, { debitAccount: '1010010', debitAmount: 6000, creditAccount: '7020010', creditAmount: 6000 });
+
+    // Seed sub-account entries (debit a sub of 7030020, credit a sub of 3050000).
+    await postSlip(agent, 5, 1, {
+      debitAccount: '7030020', debitSubAccount: 1, debitAmount: 3000,
+      creditAccount: '3050000', creditSubAccount: 1, creditAmount: 3000,
+    });
+    await postSlip(agent, 5, 2, {
+      debitAccount: '7030020', debitSubAccount: 2, debitAmount: 4000,
+      creditAccount: '3050000', creditSubAccount: 2, creditAmount: 4000,
+    });
+    await postSlip(agent, 6, 1, {
+      debitAccount: '7030020', debitSubAccount: 3, debitAmount: 2500,
+      creditAccount: '3050000', creditSubAccount: 1, creditAmount: 2500,
+    });
+
+    // Run the engine once at sub-account granularity for the whole FY.
+    const startDate = new Date(fy.startDate);
+    const end = new Date(fy.endDate);
+    const fetchEnd = new Date(end.getFullYear(), end.getMonth(), end.getDate() + 1);
+    const result = await balanceEngine({
+      tenantId, term: TERM,
+      period: { from: startDate, to: end },
+      entrySources: [actualEntrySource(tenantId, startDate, fetchEnd, Op)],
+      options: { subAccount: true },
+    }, models);
+
+    engineByKey = new Map();
+    for (const l of result.lines) {
+      const key = l.subCode != null ? `${l.code}:${l.subCode}` : l.code;
+      engineByKey.set(key, l);
+    }
+  });
+
+  it('engine ending == ledger sums for 10 fixed account-level lines', async function () {
+    for (const code of ACCOUNTS) {
+      const eng = engineByKey.get(code);
+      assert.ok(eng, `engine should have a line for ${code}`);
+      const details = await ledgerDetailsFor(tenantId, fy, code, null, Op);
+      // Opening after setup is 0 for all accounts.
+      const led = ledgerLines(code, null, { debit: 0, credit: 0, balance: 0 }, details);
+      assert.equal(
+        numeric(eng.endingBalance), numeric(led.sums.balance),
+        `account ${code}: engine ${eng.endingBalance} != ledger ${led.sums.balance}`
+      );
+    }
+  });
+
+  it('engine ending == ledger sums for 5 fixed sub-account lines', async function () {
+    for (const { account, sub } of SUBS) {
+      const eng = engineByKey.get(`${account}:${sub}`);
+      assert.ok(eng, `engine should have a line for ${account}/${sub}`);
+      const details = await ledgerDetailsFor(tenantId, fy, account, sub, Op);
+      const led = ledgerLines(account, sub, { debit: 0, credit: 0, balance: 0 }, details);
+      assert.equal(
+        numeric(eng.endingBalance), numeric(led.sums.balance),
+        `sub ${account}/${sub}: engine ${eng.endingBalance} != ledger ${led.sums.balance}`
+      );
+    }
+  });
+
+  it('total engine movement debit == credit (global invariant)', function () {
+    let d = 0, c = 0;
+    for (const l of engineByKey.values()) { d += l.movementDebit; c += l.movementCredit; }
+    assert.equal(d, c, `engine movement D=${d} C=${c}`);
+  });
+
+  it('7020010 edge case reconciles as C-nature', async function () {
+    const eng = engineByKey.get('7020010');
+    const details = await ledgerDetailsFor(tenantId, fy, '7020010', null, Op);
+    const led = ledgerLines('7020010', null, { debit: 0, credit: 0, balance: 0 }, details);
+    assert.equal(numeric(eng.endingBalance), numeric(led.sums.balance));
+    assert.equal(numeric(eng.endingBalance), 6000, 'credited 6000, C-nature: 0 - 0 + 6000');
+  });
+});


### PR DESCRIPTION
Closes #199
Part of epic:reporting-engine (#194)

## Summary

Proves `balanceEngine` and `ledgerLines` agree on ending balances for the same tenant/term/period over real seeded journal data. Fixed fixture: 10 account-level lines (BS debit, BS credit, PL, 7020010 edge case) + 5 sub-account lines (3050000/7030020).

## Engine fix surfaced here

`CrossSlipDetail.debitSubAccount`/`creditSubAccount` store the per-account **subAccountCode**, not the `SubAccount` PK. Engine had keyed sub movement on `SubAccount.id` (invisible through #196 which uses `subAccount:false`). Now keyed by `(accountId, subAccountCode)`; opening still resolves by `subAccountId`.

## Test Plan

- [x] engine ending == ledger sums for 10 account-level lines
- [x] engine ending == ledger sums for 5 sub-account lines
- [x] global movement debit == credit
- [x] 7020010 reconciles as C-nature
- [x] `npm run build` ✅; `npm test` → 127 passing, 0 failing

## Files

- `libs/reporting/balance-engine.js` (sub-key fix)
- `test/reporting/balance-engine.test.mjs` (unit tests updated)
- `test/reporting/reconciliation.test.mjs` (new)