### PR TITLE
feat(#207): API v2 trial balance — 3 report type + filter + totals + warnings stub

### DIFF
--- a/libs/reporting/trial-balance-v2.js
+++ b/libs/reporting/trial-balance-v2.js
@@ -1,0 +1,274 @@
+/**
+ * Trial Balance v2 — Issue #207 (E1.1).
+ *
+ * Public contract for the v2 response (additive, ?version=2 on the existing
+ * /api/trial-balance route). Legacy (no version param) is unchanged.
+ *
+ *   { version: 2,
+ *     meta:    { tenantId, term, reportType, period, fiscalYear,
+ *                languageMode, generatedAt, warnings, totals, filters },
+ *     lines:   [{ type, accountClassId, aclCode, major, middle, minor, ...,
+ *                 openingDebit, openingCredit, movementDebit, movementCredit,
+ *                 endingDebit, endingCredit, balance, warningCodes }, ...] }
+ *
+ * Three reportType values:
+ *   - balance   残高試算表   — opening + ending per account
+ *   - movement  合計試算表   — period movement per account
+ *   - combined  合計残高試算表 — all six columns
+ *
+ * Engine output is flat; subtotals are the consumer's job (libs/reporting/tb-subtotal,
+ * see E1.2). This module joins Account/SubAccount/AccountClass for bilingual
+ * names + class-id filter, applies the optional filters, computes totals.
+ */
+import { enrichBilingual as defaultEnrichBilingual } from '../bilingual-helper.js';
+import { balanceEngine } from './balance-engine.js';
+
+/**
+ * Build a CrossSlipDetail-shaped entry source for [startDate, endDate).
+ * Reused by E2 simulation; kept here so v2 has zero coupling to libs/trial_balance.
+ */
+function actualEntrySource(deps, tenantId, startDate, endDate) {
+  return {
+    name: 'actual',
+    fetch: async () => {
+      const rows = [];
+      for (let mon = new Date(startDate); mon < new Date(endDate); ) {
+        const slips = await deps.CrossSlip.findAll({
+          where: {
+            [deps.Sequelize.Op.and]: {
+              tenantId,
+              year: mon.getFullYear(),
+              month: mon.getMonth() + 1,
+            },
+          },
+          include: [{ model: deps.CrossSlipDetail, as: 'lines' }],
+        });
+        for (const slip of slips) {
+          for (const d of slip.lines || []) {
+            rows.push({
+              debitAccount: d.debitAccount,
+              debitSubAccount: d.debitSubAccount,
+              debitAmount: d.debitAmount,
+              creditAccount: d.creditAccount,
+              creditSubAccount: d.creditSubAccount,
+              creditAmount: d.creditAmount,
+              approvedAt: slip.approvedAt,
+            });
+          }
+        }
+        mon.setMonth(mon.getMonth() + 1);
+      }
+      return rows;
+    },
+  };
+}
+
+async function resolvePeriod(deps, tenantId, term, month) {
+  const fy = await deps.FiscalYear.findOne({ where: { tenantId, term } });
+  if (!fy) {
+    const e = new Error(`FiscalYear not found for tenant=${tenantId} term=${term}`);
+    e.status = 404;
+    throw e;
+  }
+  if (month) {
+    const m = String(month).match(/^(\d{4})-(\d{1,2})$/);
+    if (!m) {
+      const e = new Error(`month must be YYYY-MM (got ${month})`);
+      e.status = 400;
+      throw e;
+    }
+    const y = parseInt(m[1], 10);
+    const mo = parseInt(m[2], 10) - 1;
+    const start = new Date(y, mo, 1);
+    const last = new Date(y, mo + 1, 0);
+    return { fy, startDate: start, endDate: last, periodLabel: month };
+  }
+  return {
+    fy,
+    startDate: new Date(fy.startDate),
+    endDate: new Date(fy.endDate),
+    periodLabel: 'full',
+  };
+}
+
+/**
+ * Build the v2 response.
+ *
+ * params: { tenantId, term, reportType, month, accountClassIds, hideZero,
+ *           includeUnapproved, languagePair }
+ * deps:   models-like ({ Account, SubAccount, AccountClass, AccountRemaining,
+ *                       SubAccountRemaining, CrossSlip, CrossSlipDetail,
+ *                       FiscalYear, Sequelize })
+ */
+export async function trialBalanceV2(params, deps) {
+  if (!deps) {
+    throw new Error('trialBalanceV2: deps is required');
+  }
+  const {
+    tenantId,
+    term,
+    reportType = 'balance',
+    month = null,
+    accountClassIds = [],
+    hideZero = false,
+    includeUnapproved = false,
+    languagePair = null,
+  } = params || {};
+
+  if (tenantId == null) {
+    throw new Error('trialBalanceV2: tenantId is required (multi-tenant guard)');
+  }
+  if (term == null) {
+    throw new Error('trialBalanceV2: term is required');
+  }
+  if (!['balance', 'movement', 'combined'].includes(reportType)) {
+    const e = new Error(`reportType must be balance|movement|combined (got ${reportType})`);
+    e.status = 400;
+    throw e;
+  }
+
+  const { fy, startDate, endDate, periodLabel } = await resolvePeriod(deps, tenantId, term, month);
+  // endDate is inclusive day boundary; advance one day so the month loop
+  // and detail fetch include the final day.
+  const fetchEnd = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate() + 1);
+
+  const engineResult = await balanceEngine(
+    {
+      tenantId,
+      term,
+      period: { from: startDate, to: endDate },
+      entrySources: [actualEntrySource(deps, tenantId, startDate, fetchEnd)],
+      options: { subAccount: true, includeUnapproved },
+    },
+    deps,
+  );
+
+  // Enrich with Account/SubAccount/AccountClass names + class id (for filter).
+  const accountRows = await deps.Account.findAll({
+    where: { tenantId },
+    include: [
+      { model: deps.SubAccount, as: 'subAccounts' },
+      { model: deps.AccountClass, as: 'accountClass' },
+    ],
+  });
+  const enrichBilingual = (deps && deps.enrichBilingual) || defaultEnrichBilingual;
+  if (languagePair) {
+    await enrichBilingual('AccountClass', accountRows.map((a) => a.accountClass).filter(Boolean), languagePair);
+    await enrichBilingual('Account', accountRows, languagePair);
+    await enrichBilingual(
+      'SubAccount',
+      accountRows.flatMap((a) => a.subAccounts || []),
+      languagePair,
+    );
+  }
+
+  const codeToAcc = new Map();
+  const codeToClassId = new Map();
+  const subKeyToSub = new Map();
+  for (const a of accountRows) {
+    codeToAcc.set(a.accountCode, a);
+    codeToClassId.set(a.accountCode, a.accountClassId);
+    for (const sub of a.subAccounts || []) {
+      subKeyToSub.set(`${a.id}:${sub.subAccountCode}`, sub);
+    }
+  }
+
+  const classIdFilter = new Set(
+    (Array.isArray(accountClassIds) ? accountClassIds : String(accountClassIds).split(','))
+      .map((v) => parseInt(v, 10))
+      .filter((n) => Number.isFinite(n))
+  );
+
+  // Shape lines. Keep all six columns regardless of reportType; reportType
+  // is meta and is the UI's cue for which to emphasize. (Export layer trims.)
+  let lines = engineResult.lines.map((l) => {
+    const acc = codeToAcc.get(l.code);
+    const cls = acc ? acc.accountClass : null;
+    const sub = l.subAccountId != null ? subKeyToSub.get(`${l.accountId}:${l.subCode}`) : null;
+    return {
+      type: l.subAccountId != null ? 'subAccount' : 'account',
+      accountClassId: codeToClassId.get(l.code) || null,
+      aclCode: cls ? `${cls.field}${String(cls.adding).padStart(2, '0')}` : null,
+      major: cls ? cls.major : null,
+      middle: cls ? cls.middle : null,
+      minor: cls ? cls.minor : null,
+      majorVi: cls ? cls.getDataValue('majorVi') || null : null,
+      middleVi: cls ? cls.getDataValue('middleVi') || null : null,
+      minorVi: cls ? cls.getDataValue('minorVi') || null : null,
+      accountId: l.accountId,
+      code: l.code,
+      name: acc ? acc.name : l.code,
+      nameVi: acc ? acc.getDataValue('nameVi') || null : null,
+      subAccountId: l.subAccountId,
+      subCode: l.subCode,
+      subName: sub ? sub.name : null,
+      subNameVi: sub ? sub.getDataValue('nameVi') || null : null,
+      openingDebit: l.openingDebit,
+      openingCredit: l.openingCredit,
+      movementDebit: l.movementDebit,
+      movementCredit: l.movementCredit,
+      endingDebit: l.endingDebit,
+      endingCredit: l.endingCredit,
+      balance: l.endingBalance,
+      warningCodes: [],
+    };
+  });
+
+  // Filter: accountClassIds — only lines whose class is in the set.
+  if (classIdFilter.size > 0) {
+    lines = lines.filter((l) => l.accountClassId != null && classIdFilter.has(l.accountClassId));
+  }
+
+  // Filter: hideZero — a line is "non-zero" if any of the columns relevant to
+  // the reportType has a non-zero value.
+  if (hideZero) {
+    const showBal = reportType === 'balance' || reportType === 'combined';
+    const showMov = reportType === 'movement' || reportType === 'combined';
+    lines = lines.filter((l) =>
+      (showBal && (l.openingDebit || l.openingCredit || l.endingDebit || l.endingCredit)) ||
+      (showMov && (l.movementDebit || l.movementCredit))
+    );
+  }
+
+  // Totals: sums over the post-filter lines. The engine invariant guarantees
+  // movementDebit === movementCredit globally; reportType-specific totals
+  // follow trivially.
+  const totals = lines.reduce(
+    (acc, l) => {
+      acc.openingDebit += l.openingDebit || 0;
+      acc.openingCredit += l.openingCredit || 0;
+      acc.movementDebit += l.movementDebit || 0;
+      acc.movementCredit += l.movementCredit || 0;
+      acc.endingDebit += l.endingDebit || 0;
+      acc.endingCredit += l.endingCredit || 0;
+      return acc;
+    },
+    { openingDebit: 0, openingCredit: 0, movementDebit: 0, movementCredit: 0, endingDebit: 0, endingCredit: 0 }
+  );
+
+  return {
+    version: 2,
+    meta: {
+      tenantId,
+      term,
+      reportType,
+      period: { from: startDate, to: endDate, label: periodLabel },
+      fiscalYear: { start: fy.startDate, end: fy.endDate },
+      languageMode: languagePair
+        ? Object.keys(languagePair).sort().join('+')
+        : 'ja',
+      generatedAt: new Date(),
+      warnings: [], // populated by E1.6 warning-rules
+      totals,
+      filters: {
+        accountClassIds: Array.from(classIdFilter),
+        hideZero: !!hideZero,
+        includeUnapproved: !!includeUnapproved,
+        month: month || null,
+      },
+    },
+    lines,
+  };
+}
+
+export { resolvePeriod, actualEntrySource };

--- a/routes/api_trial_balance.js
+++ b/routes/api_trial_balance.js
@@ -1,10 +1,71 @@
 import trial_balance from '../libs/trial_balance.js';
 import models from '../models/index.js';
+import { trialBalanceV2 } from '../libs/reporting/trial-balance-v2.js';
+
+const parseBool = (v, dflt = false) => {
+  if (v == null) return dflt;
+  const s = String(v).toLowerCase();
+  return s === 'true' || s === '1' || s === 'yes';
+};
+
+const parseCsv = (v) => {
+  if (v == null || v === '') return [];
+  return String(v).split(',').map((x) => x.trim()).filter(Boolean);
+};
 
 export default {
   get: async (req, res, next) => {
     const tenantId = req.currentTenantId;
     try {
+      // Branch: ?version=2 → new contract (E1.1). Legacy untouched.
+      const version = parseInt(req.query.version, 10);
+      if (version === 2) {
+        let term;
+        const param = req.params.param;
+        let ym;
+        if (param) {
+          const params = param.split('-');
+          if (params[1]) {
+            ym = params;
+            if (!req.session || !req.session.term) {
+              return res.status(401).json({ error: 'Unauthorized: term not set in session.' });
+            }
+            term = req.session.term;
+          } else {
+            term = parseInt(params[0], 10);
+          }
+        } else {
+          if (!req.session || !req.session.term) {
+            return res.status(401).json({ error: 'Unauthorized: term not set in session.' });
+          }
+          term = req.session.term;
+        }
+
+        // Query param `month` (YYYY-MM) overrides :param-derived month.
+        const month = req.query.month || (ym ? `${ym[0]}-${String(ym[1]).padStart(2, '0')}` : null);
+        const reportType = req.query.reportType || 'balance';
+        const accountClassIds = parseCsv(req.query.accountClassIds);
+        const hideZero = parseBool(req.query.hideZero);
+        const includeUnapproved = parseBool(req.query.includeUnapproved, false);
+        const lp = req.query.languagePair ? JSON.parse(req.query.languagePair) : req.session?.languagePair;
+
+        const out = await trialBalanceV2(
+          {
+            tenantId,
+            term,
+            reportType,
+            month,
+            accountClassIds,
+            hideZero,
+            includeUnapproved,
+            languagePair: lp,
+          },
+          models,
+        );
+        return res.json(out);
+      }
+
+      // Legacy path (no version param, or version=1).
       let term;
       let lastDate;
       const param = req.params.param;

--- a/test/reporting/trial-balance-v2.test.mjs
+++ b/test/reporting/trial-balance-v2.test.mjs
@@ -1,0 +1,374 @@
+/**
+ * Unit tests — Issue #207 (E1.1): libs/reporting/trial-balance-v2.js
+ *
+ * Pure-function tests; deps is mocked inline. Covers the v2 response contract:
+ *   - version 2 envelope
+ *   - 3 reportType values (balance, movement, combined) — selection only,
+ *     all six columns are always present
+ *   - filter accountClassIds / hideZero
+ *   - includeUnapproved toggle
+ *   - totals block
+ *   - languagePair metadata only (no VI mock; just label shape)
+ *   - multi-tenant guards
+ *
+ * Run with: npm test
+ */
+
+import { strict as assert } from 'node:assert';
+import { trialBalanceV2, resolvePeriod } from '../../libs/reporting/trial-balance-v2.js';
+
+const TENANT_A = 1;
+const TENANT_B = 2;
+
+// Mimic Sequelize's getDataValue: returns the named property. Production
+// models get it from sequelize; test fixtures are plain objects.
+const withGd = (o) => {
+  if (o && typeof o.getDataValue !== 'function') {
+    o.getDataValue = (k) => o[k];
+  }
+  return o;
+};
+
+const fy = {
+  tenantId: TENANT_A,
+  term: 1,
+  startDate: '2026-01-01',
+  endDate: '2026-12-31',
+};
+
+// 1 BS debit (cash) + 1 BS credit (capital) + 1 PL expense + 1 sub-having
+// account whose sub 1 will have movement. Two AccountClasses so we can
+// filter by class.
+const accountRows = [
+  withGd({ id: 1, accountCode: '1000000', tenantId: TENANT_A, accountClassId: 10,
+    name: '現金', nameVi: 'Tiền mặt',
+    accountClass: withGd({ id: 10, field: 1, adding: 0, major: '資産', middle: '流動資産', minor: '現金' }),
+    subAccounts: [] }),
+  withGd({ id: 2, accountCode: '3000000', tenantId: TENANT_A, accountClassId: 20,
+    name: '資本金', nameVi: 'Vốn',
+    accountClass: withGd({ id: 20, field: 3, adding: 0, major: '負債', middle: '資本', minor: '資本金' }),
+    subAccounts: [] }),
+  withGd({ id: 3, accountCode: '7000000', tenantId: TENANT_A, accountClassId: 30,
+    name: '売上原価', nameVi: 'Giá vốn',
+    accountClass: withGd({ id: 30, field: 7, adding: 0, major: '費用', middle: '売上原価', minor: '仕入' }),
+    subAccounts: [] }),
+  withGd({ id: 4, accountCode: '3050000', tenantId: TENANT_A, accountClassId: 20,
+    name: '買掛金', nameVi: 'Phải trả',
+    accountClass: withGd({ id: 20, field: 3, adding: 5, major: '負債', middle: '流動負債', minor: '買掛金' }),
+    subAccounts: [
+      withGd({ id: 100, accountId: 4, subAccountCode: 1, name: 'A社', nameVi: 'Cty A' }),
+    ] }),
+  withGd({ id: 99, accountCode: '9990000', tenantId: TENANT_B, accountClassId: 99,
+    name: 'OTHER', nameVi: null,
+    accountClass: withGd({ id: 99, field: 9, adding: 0, major: '他', middle: '', minor: '' }),
+    subAccounts: [] }),
+  withGd({ id: 5, accountCode: '2000000', tenantId: TENANT_A, accountClassId: 40,
+    name: '普通預金', nameVi: 'TK thường',
+    accountClass: withGd({ id: 40, field: 2, adding: 0, major: '資産', middle: '流動資産', minor: '普通預金' }),
+    subAccounts: [] }),
+];
+
+const accountRemaining = [
+  { accountId: 1, term: 1, debit: 100, credit: 0, balance: 100, tenantId: TENANT_A },
+  { accountId: 2, term: 1, debit: 0, credit: 100, balance: 100, tenantId: TENANT_A },
+  { accountId: 3, term: 1, debit: 0, credit: 0, balance: 0, tenantId: TENANT_A },
+  { accountId: 5, term: 1, debit: 0, credit: 0, balance: 0, tenantId: TENANT_A },
+  { subAccountId: 100, term: 1, debit: 0, credit: 0, balance: 0, tenantId: TENANT_A },
+  { accountId: 99, term: 1, debit: 0, credit: 0, balance: 0, tenantId: TENANT_B },
+];
+
+const subAccountRemaining = [
+  { subAccountId: 100, term: 1, debit: 0, credit: 0, balance: 0, tenantId: TENANT_A },
+];
+
+const APPROVED = { approvedAt: new Date('2026-06-01') };
+
+// 1000000(D) ← 3000000(C) for 200; 7000000(D) ← 1000000(C) for 50;
+// 3050000/1 credit 30, 1000000 debit 30.
+const detailsFor = () => ([
+  { debitAccount: '1000000', debitSubAccount: null, debitAmount: 200, ...APPROVED, creditAccount: '3000000', creditSubAccount: null, creditAmount: 200 },
+  { debitAccount: '7000000', debitSubAccount: null, debitAmount: 50,  ...APPROVED, creditAccount: '1000000', creditSubAccount: null, creditAmount: 50 },
+  { debitAccount: '1000000', debitSubAccount: null, debitAmount: 30,  ...APPROVED, creditAccount: '3050000', creditSubAccount: 1, creditAmount: 30 },
+]);
+
+const makeDeps = (overrides = {}) => {
+  // CrossSlip.findAll is called once per month by actualEntrySource. The
+  // production DB returns data only for months with slips; in this unit
+  // test, return data only on the first call so the engine doesn't sum
+  // the same fixtures 12 times.
+  let crossSlipCalls = 0;
+  return {
+    Sequelize: { Op: { and: Symbol.for('and') } },
+    Account: {
+      findAll: async ({ where }) => {
+        const tid = where && where.tenantId;
+        return accountRows.filter((a) => tid == null || a.tenantId === tid);
+      },
+    },
+    SubAccount: {},
+    AccountClass: {},
+    AccountRemaining: {
+      findAll: async ({ where }) => {
+        const tid = where && where.tenantId;
+        const term = where && where.term;
+        return accountRemaining.filter((r) =>
+          (tid == null || r.tenantId === tid) && (term == null || r.term === term));
+      },
+    },
+    SubAccountRemaining: {
+      findAll: async ({ where }) => {
+        const tid = where && where.tenantId;
+        const term = where && where.term;
+        return subAccountRemaining.filter((r) =>
+          (tid == null || r.tenantId === tid) && (term == null || r.term === term));
+      },
+    },
+    CrossSlip: {
+      findAll: async () => {
+        crossSlipCalls += 1;
+        if (crossSlipCalls === 1) {
+          return [{ lines: detailsFor(), approvedAt: APPROVED.approvedAt }];
+        }
+        return [];
+      },
+    },
+    CrossSlipDetail: {},
+    FiscalYear: {
+      findOne: async () => fy,
+    },
+    // No-op stub: tests don't exercise the real DB-driven translation join.
+    enrichBilingual: async () => {},
+    ...overrides,
+  };
+};
+
+const baseParams = (over = {}) => ({
+  tenantId: TENANT_A,
+  term: 1,
+  ...over,
+});
+
+// ---------------------------------------------------------------------------
+// resolvePeriod
+// ---------------------------------------------------------------------------
+
+describe('resolvePeriod', () => {
+  it('returns full FY when no month', async () => {
+    const out = await resolvePeriod(makeDeps(), TENANT_A, 1, null);
+    assert.equal(out.periodLabel, 'full');
+    assert.equal(out.fy, fy);
+  });
+  it('returns monthly window for YYYY-MM', async () => {
+    const out = await resolvePeriod(makeDeps(), TENANT_A, 1, '2026-06');
+    assert.equal(out.periodLabel, '2026-06');
+    assert.equal(out.startDate.getMonth(), 5);
+    assert.equal(out.startDate.getDate(), 1);
+    // Last day of June is June 30 — getMonth() is 0-indexed, so 5 (June).
+    assert.equal(out.endDate.getMonth(), 5);
+    assert.equal(out.endDate.getDate(), 30);
+  });
+  it('throws on malformed month', async () => {
+    await assert.rejects(
+      () => resolvePeriod(makeDeps(), TENANT_A, 1, '2026/06'),
+      /YYYY-MM/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// envelope
+// ---------------------------------------------------------------------------
+
+describe('trialBalanceV2 — envelope', () => {
+  it('returns version: 2 with meta + lines', async () => {
+    const out = await trialBalanceV2(baseParams(), makeDeps());
+    assert.equal(out.version, 2);
+    assert.ok(out.meta);
+    assert.ok(Array.isArray(out.lines));
+    assert.ok(out.meta.generatedAt instanceof Date);
+  });
+  it('rejects missing deps', async () => {
+    await assert.rejects(() => trialBalanceV2(baseParams(), null), /deps is required/);
+  });
+  it('rejects missing tenantId', async () => {
+    await assert.rejects(
+      () => trialBalanceV2({ term: 1 }, makeDeps()),
+      /tenantId is required/
+    );
+  });
+  it('rejects missing term', async () => {
+    await assert.rejects(
+      () => trialBalanceV2({ tenantId: TENANT_A }, makeDeps()),
+      /term is required/
+    );
+  });
+  it('rejects unknown reportType', async () => {
+    await assert.rejects(
+      () => trialBalanceV2({ ...baseParams(), reportType: 'nope' }, makeDeps()),
+      /balance\|movement\|combined/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reportType — selection only; all 6 columns present
+// ---------------------------------------------------------------------------
+
+describe('trialBalanceV2 — reportType', () => {
+  it('defaults to balance', async () => {
+    const out = await trialBalanceV2(baseParams(), makeDeps());
+    assert.equal(out.meta.reportType, 'balance');
+  });
+  it('accepts movement', async () => {
+    const out = await trialBalanceV2({ ...baseParams(), reportType: 'movement' }, makeDeps());
+    assert.equal(out.meta.reportType, 'movement');
+  });
+  it('accepts combined', async () => {
+    const out = await trialBalanceV2({ ...baseParams(), reportType: 'combined' }, makeDeps());
+    assert.equal(out.meta.reportType, 'combined');
+  });
+  it('every line has all six columns regardless of reportType', async () => {
+    for (const rt of ['balance', 'movement', 'combined']) {
+      const out = await trialBalanceV2({ ...baseParams(), reportType: rt }, makeDeps());
+      for (const l of out.lines) {
+        for (const k of ['openingDebit','openingCredit','movementDebit','movementCredit','endingDebit','endingCredit']) {
+          assert.equal(typeof l[k], 'number', `${rt} line ${l.code} missing ${k}`);
+        }
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// per-line shape
+// ---------------------------------------------------------------------------
+
+describe('trialBalanceV2 — per-line shape', () => {
+  it('emits subAccount type for accounts with sub lines', async () => {
+    const out = await trialBalanceV2(baseParams(), makeDeps());
+    const sub = out.lines.find((l) => l.subAccountId === 100);
+    assert.ok(sub, 'sub line for 3050000/1 should exist');
+    assert.equal(sub.type, 'subAccount');
+    assert.equal(sub.subCode, 1);
+    assert.equal(sub.subName, 'A社');
+    assert.equal(sub.subNameVi, 'Cty A');
+  });
+  it('emits account type for accounts with no subs', async () => {
+    const out = await trialBalanceV2(baseParams(), makeDeps());
+    const cash = out.lines.find((l) => l.code === '1000000');
+    assert.equal(cash.type, 'account');
+    assert.equal(cash.subAccountId, null);
+    assert.equal(cash.name, '現金');
+  });
+  it('attaches accountClassId + aclCode for filter', async () => {
+    const out = await trialBalanceV2(baseParams(), makeDeps());
+    const cash = out.lines.find((l) => l.code === '1000000');
+    assert.equal(cash.accountClassId, 10);
+    assert.equal(cash.aclCode, '100');
+  });
+  it('warningCodes is always an empty array (E1.6 populates it)', async () => {
+    const out = await trialBalanceV2(baseParams(), makeDeps());
+    for (const l of out.lines) assert.deepEqual(l.warningCodes, []);
+  });
+  it('multi-tenant isolation: tenant A lines do not include tenant B accounts', async () => {
+    const out = await trialBalanceV2(baseParams(), makeDeps());
+    assert.ok(out.lines.every((l) => l.code !== '9990000'));
+  });
+  it('tenant B gets only its own accounts', async () => {
+    const out = await trialBalanceV2({ ...baseParams(), tenantId: TENANT_B }, makeDeps());
+    assert.equal(out.lines.length, 1);
+    assert.equal(out.lines[0].code, '9990000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filters
+// ---------------------------------------------------------------------------
+
+describe('trialBalanceV2 — filters', () => {
+  it('accountClassIds: keeps only matching class', async () => {
+    const out = await trialBalanceV2({ ...baseParams(), accountClassIds: [20] }, makeDeps());
+    const codes = out.lines.map((l) => l.code).filter((c, i, a) => a.indexOf(c) === i);
+    assert.ok(codes.every((c) => ['3000000', '3050000'].includes(c)), `unexpected codes: ${codes.join(',')}`);
+  });
+  it('accountClassIds accepts csv string', async () => {
+    const out = await trialBalanceV2({ ...baseParams(), accountClassIds: '10,30' }, makeDeps());
+    const codes = new Set(out.lines.map((l) => l.code));
+    assert.ok(codes.has('1000000'));
+    assert.ok(codes.has('7000000'));
+    assert.ok(!codes.has('3000000'));
+  });
+  it('hideZero: drops all-zero lines for the report type', async () => {
+    // 2000000 (普通預金): no opening, no movement — should be hidden in any
+    // mode under hideZero. 3000000 has movement (credit 200 from detail 1),
+    // so it must remain in movement mode.
+    const balance = await trialBalanceV2({ ...baseParams(), hideZero: true }, makeDeps());
+    assert.ok(!balance.lines.some((l) => l.code === '2000000'),
+      'all-zero account should be hidden in balance mode');
+    const movement = await trialBalanceV2({ ...baseParams(), reportType: 'movement', hideZero: true }, makeDeps());
+    assert.ok(!movement.lines.some((l) => l.code === '2000000'),
+      'all-zero account should be hidden in movement mode');
+    assert.ok(movement.lines.some((l) => l.code === '3000000'),
+      'capital with credit-movement 200 should remain in movement mode');
+  });
+  it('hideZero: combined mode keeps lines with any of opening/movement/ending', async () => {
+    const combined = await trialBalanceV2({ ...baseParams(), reportType: 'combined', hideZero: true }, makeDeps());
+    assert.ok(combined.lines.some((l) => l.code === '7000000'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// includeUnapproved
+// ---------------------------------------------------------------------------
+
+describe('trialBalanceV2 — includeUnapproved', () => {
+  it('default false: filter reaches the engine', async () => {
+    const out = await trialBalanceV2(baseParams(), makeDeps());
+    assert.equal(out.meta.filters.includeUnapproved, false);
+  });
+  it('true toggle is reflected in meta', async () => {
+    const out = await trialBalanceV2({ ...baseParams(), includeUnapproved: true }, makeDeps());
+    assert.equal(out.meta.filters.includeUnapproved, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// totals
+// ---------------------------------------------------------------------------
+
+describe('trialBalanceV2 — totals', () => {
+  it('totals.movementDebit === totals.movementCredit (engine invariant)', async () => {
+    const out = await trialBalanceV2(baseParams(), makeDeps());
+    assert.equal(out.meta.totals.movementDebit, out.meta.totals.movementCredit);
+  });
+  it('totals match sum of post-filter lines', async () => {
+    const out = await trialBalanceV2(baseParams(), makeDeps());
+    const sum = (k) => out.lines.reduce((s, l) => s + (l[k] || 0), 0);
+    for (const k of ['openingDebit','openingCredit','movementDebit','movementCredit','endingDebit','endingCredit']) {
+      assert.equal(out.meta.totals[k], sum(k), `totals.${k} mismatch`);
+    }
+  });
+  it('totals respect accountClassIds filter', async () => {
+    const full = await trialBalanceV2(baseParams(), makeDeps());
+    const filtered = await trialBalanceV2({ ...baseParams(), accountClassIds: [10] }, makeDeps());
+    assert.notEqual(full.meta.totals.movementDebit, filtered.meta.totals.movementDebit);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// languagePair meta
+// ---------------------------------------------------------------------------
+
+describe('trialBalanceV2 — languagePair', () => {
+  it('languageMode is "ja" when no languagePair', async () => {
+    const out = await trialBalanceV2(baseParams(), makeDeps());
+    assert.equal(out.meta.languageMode, 'ja');
+  });
+  it('languageMode joins keys with "+" when languagePair present', async () => {
+    const out = await trialBalanceV2(
+      { ...baseParams(), languagePair: { ja: 'vi', vi: 'ja' } },
+      makeDeps()
+    );
+    assert.equal(out.meta.languageMode, 'ja+vi');
+  });
+});


### PR DESCRIPTION
Part of #206 (E01 trial balance epic)

### Summary
- `libs/reporting/trial-balance-v2.js` — new v2 module shaping E0 engine output into the v2 contract.
- `routes/api_trial_balance.js` — branch on `?version=2`; legacy (no version) untouched.
- `test/reporting/trial-balance-v2.test.mjs` — 29 unit tests, pure-function deps mocks.

### V2 contract
```json
{ "version": 2,
  "meta":   { "tenantId", "term", "reportType", "period",
               "fiscalYear", "languageMode", "generatedAt",
               "warnings": [], "totals": {...}, "filters": {...} },
  "lines":  [ { "type": "account"|"subAccount",
                 "accountClassId", "aclCode", "major"/"middle"/"minor",
                 "accountId"/"code"/"name"/"nameVi",
                 "subAccountId"/"subCode"/"subName"/"subNameVi",
                 "openingDebit/Credit", "movementDebit/Credit",
                 "endingDebit/Credit", "balance", "warningCodes": [] } ] }
```

### What works
- 3 reportType: `balance` (残高), `movement` (合計), `combined` (合計残高). All 6 columns always present; reportType is a UI hint.
- Filters: `accountClassIds` (csv or array), `hideZero` (respects reportType), `includeUnapproved` (default false).
- Totals block matches sum of post-filter lines; engine invariant `movementDebit === movementCredit` preserved.
- Multi-tenant guard: missing `tenantId` throws; lines scoped to tenant.
- Sub-account lines preserve `subName`/`subNameVi` for #1.5 drill-down.
- `languageMode` meta reflects `languagePair` key ordering (e.g. `ja+vi`).
- `meta.warnings = []` stub; populated by E1.6.

### Test Report
- `npm run build` ✅ (vite 28s)
- `npx mocha test/reporting/balance-engine.test.mjs test/reporting/trial-balance-v2.test.mjs`: **65 passing** (E0 36 + v2 29).
- Coverage: envelope / reportType / per-line shape / filters (class, hideZero, includeUnapproved) / totals / languagePair / multi-tenant guards / period resolution.

### Out of scope (later)
- Subtotal rows → #1.2
- Excel export → #1.7
- Warnings rule logic → #1.6
- UI → #1.3 / #1.4 / #1.5 / #1.8 / #1.9