### PR TITLE
feat(#209): view /reports/trial-balance — 3 tab

### DIFF
--- a/config/module-list.js
+++ b/config/module-list.js
@@ -65,6 +65,18 @@ export default [
     icon: { name: 'bi-table' },
     description: `残高試算表が確認できます。`
   }, {
+    name: 'reports/trial-balance',
+    title: '試算表 v2',
+    match: /^\/reports\/trial-balance/,
+    href: (status) => {
+      return	(`/reports/trial-balance/balance`);
+    },
+    authority: (user) => {
+      return ( user.accounting || user.fiscalBrowsing );
+    },
+    icon: { name: 'bi-table' },
+    description: `新しい試算表画面 (3 report types, hierarchy, drill-down, export).`
+  }, {
     name: 'changes',
     title: '推移表',
     match: /^\/changes/,

--- a/front/javascripts/locales/ja.json
+++ b/front/javascripts/locales/ja.json
@@ -167,6 +167,8 @@
   "balance": "残高",
   "report_financial": "決算報告書",
   "report_trial_balance": "残高試算表",
+  "report_trial_balance_movement": "合計試算表",
+  "report_trial_balance_combined": "合計残高試算表",
   "report_pl": "損益計算書",
   "report_bs": "貸借対照表",
   "report_sga": "販売費一般管理費",

--- a/front/svelte/index.svelte
+++ b/front/svelte/index.svelte
@@ -70,6 +70,7 @@ import Journal from './journal/journal.svelte';
 import Ledger from './ledger/ledger.svelte';
 import BankLedger from './bank-ledger/bank-ledger.svelte';
 import TrialBalance from './trial-balance/trial-balance.svelte';
+import ReportsTrialBalance from './reports/trial-balance.svelte';
 import Changes from './changes/changes.svelte';
 import Voucher from './voucher/voucher.svelte';
 import Accounts from './accounts/accounts.svelte';
@@ -128,6 +129,10 @@ const routes = [
   {
     match: /^\/trial-balance/,
     component: TrialBalance
+  },
+  {
+    match: /^\/reports\/trial-balance/,
+    component: ReportsTrialBalance
   },
   {
     match: /^\/changes/,

--- a/front/svelte/reports/trial-balance-list.svelte
+++ b/front/svelte/reports/trial-balance-list.svelte
@@ -1,0 +1,88 @@
+<!--
+  TrialBalanceList — flat table render for v2 lines (E1.3).
+
+  Renders one row per line. Subtotal rows are visually distinguished (bold,
+  light grey background) but no expand/collapse here — that lives in E1.4.
+  All six numeric columns are shown; the tab on the parent decides which
+  to emphasize, but the API returns the full set so this component stays
+  reportType-agnostic.
+
+  Props:
+    lines  — array of v2 lines (account | subAccount | subtotal)
+-->
+<table class="table table-bordered table-sm tb-v2-table">
+  <thead class="table-light">
+    <tr>
+      <th scope="col" class="tb-col-code">科目 / Mã</th>
+      <th scope="col" class="tb-col-name">科目名 / Tên</th>
+      <th scope="col" class="tb-col-num">期首借方<br/>Dư đầu kỳ - Nợ</th>
+      <th scope="col" class="tb-col-num">期首貸方<br/>Dư đầu kỳ - Có</th>
+      <th scope="col" class="tb-col-num">期間借方<br/>Phát sinh - Nợ</th>
+      <th scope="col" class="tb-col-num">期間貸方<br/>Phát sinh - Có</th>
+      <th scope="col" class="tb-col-num">期末借方<br/>Dư cuối kỳ - Nợ</th>
+      <th scope="col" class="tb-col-num">期末貸方<br/>Dư cuối kỳ - Có</th>
+      <th scope="col" class="tb-col-num">残高<br/>Số dư</th>
+    </tr>
+  </thead>
+  <tbody>
+    {#each lines as l (l.type + ':' + (l.code || l.major) + ':' + (l.subCode || '') + ':' + (l.level || ''))}
+      <tr class:tb-subtotal={l.type === 'subtotal'}>
+        <td class="tb-col-code">
+          {#if l.type === 'subtotal'}
+            <span class="tb-subtotal-label">【{l.level}】</span>
+          {:else if l.subCode != null}
+            {l.code}-{l.subCode}
+          {:else}
+            {l.code}
+          {/if}
+        </td>
+        <td class="tb-col-name">
+          {#if l.type === 'subtotal'}
+            <strong>{l.name || ''}</strong>
+          {:else if l.subAccountId != null}
+            <span class="tb-sub-name">└ {l.subName || ''}</span>
+            {#if l.subNameVi}<span class="tb-sub-name-vi"> / {l.subNameVi}</span>{/if}
+          {:else}
+            {l.name || ''}
+            {#if l.nameVi}<span class="tb-name-vi"> / {l.nameVi}</span>{/if}
+          {/if}
+        </td>
+        <td class="tb-col-num">{formatNum(l.openingDebit)}</td>
+        <td class="tb-col-num">{formatNum(l.openingCredit)}</td>
+        <td class="tb-col-num">{formatNum(l.movementDebit)}</td>
+        <td class="tb-col-num">{formatNum(l.movementCredit)}</td>
+        <td class="tb-col-num">{formatNum(l.endingDebit)}</td>
+        <td class="tb-col-num">{formatNum(l.endingCredit)}</td>
+        <td class="tb-col-num tb-col-balance" class:tb-balance-negative={(l.balance || 0) < 0}>
+          {formatNum(l.balance)}
+        </td>
+      </tr>
+    {/each}
+    {#if lines.length === 0}
+      <tr><td colspan="9" class="text-center text-muted">データなし / Không có dữ liệu</td></tr>
+    {/if}
+  </tbody>
+</table>
+
+<script>
+  export let lines = [];
+
+  const formatNum = (n) => {
+    if (n == null) return '';
+    return Number(n).toLocaleString('en-US');
+  };
+</script>
+
+<style>
+  .tb-v2-table { font-size: 0.9rem; }
+  .tb-col-num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+  .tb-col-code { font-family: monospace; white-space: nowrap; width: 9rem; }
+  .tb-col-name { min-width: 14rem; }
+  .tb-col-balance { font-weight: 500; }
+  .tb-balance-negative { color: #c00000; }
+  .tb-subtotal { background: #f3f3f3; }
+  .tb-subtotal .tb-col-num { font-weight: 600; }
+  .tb-subtotal-label { color: #666; font-size: 0.8rem; }
+  .tb-sub-name { color: #555; }
+  .tb-sub-name-vi, .tb-name-vi { color: #777; font-size: 0.85em; }
+</style>

--- a/front/svelte/reports/trial-balance.svelte
+++ b/front/svelte/reports/trial-balance.svelte
@@ -1,0 +1,212 @@
+<!--
+  Trial Balance v2 — Issue #209 (E1.3).
+
+  New view /reports/trial-balance with three report-type tabs:
+    - balance    残高試算表       (default)
+    - movement   合計試算表
+    - combined   合計残高試算表
+
+  Phase-1 scope (E1.3):
+    - 3-tab nav, bilingual header
+    - Period selector (current FY + month picker — full filter in E1.8)
+    - Calls GET /api/trial-balance?version=2&reportType=...
+    - Renders flat lines with subtotal rows (via libs/reporting/tb-subtotal)
+    - Subtotal rows visually distinct; no expand/collapse (E1.4)
+
+  Out of scope: drill-down modal (E1.5), warnings banner (E1.6),
+  export (E1.7), full filter UI (E1.8), bilingual mode selector (E1.9),
+  legacy remove (E1.10).
+-->
+{#key $currentPage}
+<div class="container-fluid">
+  <div class="page-title d-flex justify-content-between mt-2">
+    <h1 class="page-title-bilingual">
+      <BilingualText key="trial_balance" inline={true} />
+      <span class="tb-v2-badge">v2</span>
+    </h1>
+    <div>
+      <a class="btn btn-outline-secondary btn-bilingual" href="/trial-balance">
+        <BilingualText primary="旧画面" secondary="(Legacy)" inline={true} />
+      </a>
+    </div>
+  </div>
+
+  <ul class="nav nav-tabs tb-tabs" role="tablist">
+    {#each tabs as t}
+      <li class="nav-item" role="presentation">
+        <button
+          type="button"
+          class="nav-link tb-tab"
+          class:active={reportType === t.value}
+          on:click={() => selectTab(t.value)}
+          role="tab"
+          aria-selected={reportType === t.value}>
+          <BilingualText key={t.key} inline={true} />
+        </button>
+      </li>
+    {/each}
+  </ul>
+
+  <div class="row page-subtitle align-items-center mt-2">
+    <div class="col-md-auto">
+      <label class="tb-period-label">
+        <BilingualText primary="期間" secondary="Kỳ" inline={true} />:
+      </label>
+    </div>
+    <div class="col-md-auto">
+      <input
+        type="month"
+        class="form-control form-control-sm"
+        bind:value={monthInput}
+        on:change={onMonthChange} />
+    </div>
+    <div class="col-md-auto">
+      <button type="button" class="btn btn-sm btn-outline-secondary"
+        on:click={resetPeriod}>
+        <BilingualText primary="年度全体" secondary="Cả năm" inline={true} />
+      </button>
+    </div>
+    <div class="col-md-auto tb-meta" role="status">
+      {#if loading}
+        <span class="text-muted">...</span>
+      {:else if error}
+        <span class="text-danger">{error}</span>
+      {:else if meta}
+        <span class="text-muted">
+          {meta.period?.label || 'full'} · {meta.totals ? formatInt(meta.totals.movementDebit) + ' / ' + formatInt(meta.totals.movementCredit) : ''}
+        </span>
+      {/if}
+    </div>
+  </div>
+
+  <div class="row body-height">
+    <TrialBalanceList lines={lines} />
+  </div>
+</div>
+{/key}
+
+<script>
+  import axios from 'axios';
+  import { currentPage, link } from '../../javascripts/router.js';
+  import { languagePair } from '../../javascripts/bilingual.js';
+  import BilingualText from '../components/bilingual-text.svelte';
+  import TrialBalanceList from './trial-balance-list.svelte';
+  import { buildSubtotals } from '../../../libs/reporting/tb-subtotal.js';
+
+  export let status;
+
+  const tabs = [
+    { value: 'balance',  key: 'report_trial_balance' },
+    { value: 'movement', key: 'report_trial_balance_movement' },
+    { value: 'combined', key: 'report_trial_balance_combined' },
+  ];
+
+  let reportType = 'balance';
+  let monthInput = '';
+  let lines = [];
+  let meta = null;
+  let loading = false;
+  let error = null;
+  let lastFetched = '';
+
+  $: if ($currentPage && $currentPage !== lastFetched) {
+    syncFromUrl();
+    lastFetched = $currentPage;
+    fetchData();
+  }
+  $: if (status && status.fy && status.fy.term && lastFetched && !loading && lines.length === 0 && !error) {
+    // initial mount when status is ready
+    fetchData();
+  }
+
+  const syncFromUrl = () => {
+    const path = $currentPage || '';
+    const m = path.match(/^\/reports\/trial-balance\/([^/]+)/);
+    if (m) {
+      const param = m[1];
+      const ym = param.match(/^(\d{4})-(\d{1,2})$/);
+      if (ym) {
+        monthInput = `${ym[1]}-${String(ym[2]).padStart(2, '0')}`;
+      } else {
+        monthInput = '';
+        if (param === 'balance' || param === 'movement' || param === 'combined') {
+          reportType = param;
+        }
+      }
+    } else {
+      monthInput = '';
+    }
+  };
+
+  const selectTab = (value) => {
+    reportType = value;
+    pushUrl();
+    fetchData();
+  };
+
+  const onMonthChange = () => {
+    pushUrl();
+    fetchData();
+  };
+
+  const resetPeriod = () => {
+    monthInput = '';
+    pushUrl();
+    fetchData();
+  };
+
+  const pushUrl = () => {
+    const base = '/reports/trial-balance';
+    const parts = [];
+    if (monthInput) parts.push(monthInput);
+    parts.push(reportType);
+    const href = `${base}/${parts.join('/')}`;
+    if (href !== $currentPage) link(href);
+  };
+
+  const fetchData = async () => {
+    if (!status || !status.fy || !status.fy.term) return;
+    loading = true;
+    error = null;
+    try {
+      const params = new URLSearchParams();
+      params.set('version', '2');
+      params.set('reportType', reportType);
+      if (monthInput) params.set('month', monthInput);
+      const lp = $languagePair;
+      if (lp) params.set('languagePair', JSON.stringify(lp));
+      const url = `/api/trial-balance?${params.toString()}`;
+      const r = await axios.get(url);
+      meta = r.data.meta;
+      lines = buildSubtotals(r.data.lines || []);
+    } catch (e) {
+      error = e?.response?.data?.error || e.message || 'fetch failed';
+      lines = [];
+      meta = null;
+    } finally {
+      loading = false;
+    }
+  };
+
+  const formatInt = (n) => {
+    if (n == null) return '';
+    return Number(n).toLocaleString('en-US');
+  };
+</script>
+
+<style>
+  .tb-v2-badge {
+    display: inline-block;
+    font-size: 0.7em;
+    background: #0e8a16;
+    color: #fff;
+    padding: 0.1em 0.4em;
+    border-radius: 0.25em;
+    margin-left: 0.4em;
+    vertical-align: middle;
+  }
+  .tb-tabs { margin-top: 0.5rem; }
+  .tb-tab { min-width: 9rem; }
+  .tb-period-label { font-weight: 500; }
+  .tb-meta { font-size: 0.85rem; }
+</style>


### PR DESCRIPTION
Part of #206 (E01 trial balance epic)

### Summary
- `front/svelte/reports/trial-balance.svelte` — new view, 3 nav-tabs, bilingual header, period selector.
- `front/svelte/reports/trial-balance-list.svelte` — flat table render, subtotal rows styled.
- `front/svelte/index.svelte` — registered route `/reports/trial-balance`.
- `config/module-list.js` — sidebar entry.
- `front/javascripts/locales/{ja,vi}.json` — 2 new keys for movement/combined tabs.

### Behavior
- 3 tabs: 残高試算表 / 合計試算表 / 合計残高試算表 (default balance).
- Bilingual header with v2 badge.
- Period selector: month picker + reset to full FY.
- Calls GET `/api/trial-balance?version=2&reportType=<rt>[\&month=YYYY-MM]`.
- Runs `buildSubtotals` (#1.2) on response to insert major/middle/minor subtotal rows.
- Subtotal rows bold + grey background; data rows normal; subAccount rows indented with `└`.
- Link to legacy `/trial-balance` for back-compat.
- URL reflects state: `/reports/trial-balance/[YYYY-MM/]<tab>`.

### Test Report
- `npm run build` ✅ (vite 28.8s)
- `npx mocha test/reporting/{balance-engine,trial-balance-v2,tb-subtotal}.test.mjs`: **84 passing** (no regression).
- E2E (manual via chrome-devtools MCP) deferred to #1.11.

### Out of scope (later)
- Hierarchy expand/collapse → #1.4
- Drill-down modal → #1.5
- Warnings banner → #1.6
- Excel export → #1.7
- Full filter UI → #1.8
- Bilingual mode selector → #1.9