### PR TITLE
feat(#210): 5-level hierarchy + expand/collapse

### DIFF
--- a/front/svelte/reports/trial-balance-list.svelte
+++ b/front/svelte/reports/trial-balance-list.svelte
@@ -1,14 +1,20 @@
 <!--
-  TrialBalanceList — flat table render for v2 lines (E1.3).
+  TrialBalanceList — 5-level hierarchy render (E1.3 + E1.4).
 
-  Renders one row per line. Subtotal rows are visually distinguished (bold,
-  light grey background) but no expand/collapse here — that lives in E1.4.
-  All six numeric columns are shown; the tab on the parent decides which
-  to emphasize, but the API returns the full set so this component stays
-  reportType-agnostic.
+  Renders one row per line in the v2 contract (account | subAccount |
+  subtotal), with a synthetic 'parent' row above each cluster of
+  subAccount rows (大/中/小/勘定/補助科目). Expand/collapse is per account:
+  the parent row carries a [+/-] button that toggles visibility of its
+  subAccount children via the `expanded` set.
+
+  Indent comes from the `indentClass(line)` helper in
+  libs/reporting/tb-hierarchy.js, mapped to .tb-indent-0..4 in the
+  <style> block.
 
   Props:
-    lines  — array of v2 lines (account | subAccount | subtotal)
+    lines          array of v2 lines (already through withAccountParents + applyExpandCollapse)
+    expanded       Set<accountCode> of accounts that are currently expanded
+    onToggle       (code) => void  — fired when the user clicks [+/-]
 -->
 <table class="table table-bordered table-sm tb-v2-table">
   <thead class="table-light">
@@ -25,11 +31,21 @@
     </tr>
   </thead>
   <tbody>
-    {#each lines as l (l.type + ':' + (l.code || l.major) + ':' + (l.subCode || '') + ':' + (l.level || ''))}
-      <tr class:tb-subtotal={l.type === 'subtotal'}>
+    {#each lines as l (keyFor(l))}
+      <tr class:tb-subtotal={l.type === 'subtotal'}
+          class:tb-parent={l.type === 'parent'}
+          class={indentClass(l)}>
         <td class="tb-col-code">
           {#if l.type === 'subtotal'}
             <span class="tb-subtotal-label">【{l.level}】</span>
+          {:else if l.type === 'parent'}
+            <button type="button"
+              class="btn btn-sm btn-link tb-toggle p-0 me-1"
+              aria-label={isExpanded(l.code) ? 'collapse' : 'expand'}
+              on:click={() => onToggle(l.code)}>
+              {isExpanded(l.code) ? '−' : '+'}
+            </button>
+            <span class="tb-code-text">{l.code}</span>
           {:else if l.subCode != null}
             {l.code}-{l.subCode}
           {:else}
@@ -39,6 +55,9 @@
         <td class="tb-col-name">
           {#if l.type === 'subtotal'}
             <strong>{l.name || ''}</strong>
+          {:else if l.type === 'parent'}
+            <strong>{l.name || ''}</strong>
+            {#if l.nameVi}<span class="tb-name-vi"> / {l.nameVi}</span>{/if}
           {:else if l.subAccountId != null}
             <span class="tb-sub-name">└ {l.subName || ''}</span>
             {#if l.subNameVi}<span class="tb-sub-name-vi"> / {l.subNameVi}</span>{/if}
@@ -65,12 +84,28 @@
 </table>
 
 <script>
+  import { indentClass as _indentClass } from '../../../libs/reporting/tb-hierarchy.js';
+
   export let lines = [];
+  export let expanded = new Set();
+  export let onToggle = () => {};
 
   const formatNum = (n) => {
     if (n == null) return '';
     return Number(n).toLocaleString('en-US');
   };
+
+  const isExpanded = (code) => code != null && expanded.has(code);
+
+  const keyFor = (l) => {
+    if (l.type === 'subtotal') return `subtotal:${l.level}:${l.major}:${l.middle}:${l.minor}`;
+    if (l.type === 'parent') return `parent:${l.code}`;
+    if (l.type === 'subAccount') return `sub:${l.code}:${l.subCode}`;
+    return `account:${l.code}`;
+  };
+
+  // Re-export for template use
+  const indentClass = _indentClass;
 </script>
 
 <style>
@@ -85,4 +120,28 @@
   .tb-subtotal-label { color: #666; font-size: 0.8rem; }
   .tb-sub-name { color: #555; }
   .tb-sub-name-vi, .tb-name-vi { color: #777; font-size: 0.85em; }
+
+  /* 5-level indent: 大/中/小/勘定/補助 */
+  .tb-indent-0 td.tb-col-code { padding-left: 0.5rem; }
+  .tb-indent-1 td.tb-col-code { padding-left: 1.25rem; }
+  .tb-indent-2 td.tb-col-code { padding-left: 2.0rem; }
+  .tb-indent-3 td.tb-col-code { padding-left: 2.75rem; }
+  .tb-indent-4 td.tb-col-code { padding-left: 3.75rem; }
+  .tb-indent-3 td.tb-col-name,
+  .tb-indent-4 td.tb-col-name { padding-left: 0.5rem; }
+
+  .tb-parent { background: #fafafa; }
+  .tb-parent .tb-col-name { font-weight: 600; }
+  .tb-parent .tb-col-num { font-weight: 500; }
+  .tb-toggle {
+    display: inline-block;
+    width: 1.4em;
+    line-height: 1;
+    font-weight: 600;
+    color: #555;
+    text-decoration: none;
+    font-family: monospace;
+  }
+  .tb-toggle:hover { color: #000; }
+  .tb-code-text { font-family: monospace; }
 </style>

--- a/front/svelte/reports/trial-balance.svelte
+++ b/front/svelte/reports/trial-balance.svelte
@@ -1,17 +1,8 @@
 <!--
-  Trial Balance v2 — Issue #209 (E1.3).
+  Trial Balance v2 — Issue #209 (E1.3) + #210 (E1.4).
 
-  New view /reports/trial-balance with three report-type tabs:
-    - balance    残高試算表       (default)
-    - movement   合計試算表
-    - combined   合計残高試算表
-
-  Phase-1 scope (E1.3):
-    - 3-tab nav, bilingual header
-    - Period selector (current FY + month picker — full filter in E1.8)
-    - Calls GET /api/trial-balance?version=2&reportType=...
-    - Renders flat lines with subtotal rows (via libs/reporting/tb-subtotal)
-    - Subtotal rows visually distinct; no expand/collapse (E1.4)
+  3 tabs (balance/movement/combined), bilingual header, period selector,
+  5-level hierarchy with per-account expand/collapse (E1.4).
 
   Out of scope: drill-down modal (E1.5), warnings banner (E1.6),
   export (E1.7), full filter UI (E1.8), bilingual mode selector (E1.9),
@@ -66,6 +57,16 @@
         <BilingualText primary="年度全体" secondary="Cả năm" inline={true} />
       </button>
     </div>
+    <div class="col-md-auto">
+      <button type="button" class="btn btn-sm btn-outline-secondary"
+        on:click={expandAll}>
+        <BilingualText primary="すべて展開" secondary="Mở rộng" inline={true} />
+      </button>
+      <button type="button" class="btn btn-sm btn-outline-secondary ms-1"
+        on:click={collapseAll}>
+        <BilingualText primary="すべて折りたたみ" secondary="Thu gọn" inline={true} />
+      </button>
+    </div>
     <div class="col-md-auto tb-meta" role="status">
       {#if loading}
         <span class="text-muted">...</span>
@@ -80,7 +81,10 @@
   </div>
 
   <div class="row body-height">
-    <TrialBalanceList lines={lines} />
+    <TrialBalanceList
+      lines={visibleLines}
+      {expanded}
+      onToggle={toggleAccount} />
   </div>
 </div>
 {/key}
@@ -92,6 +96,7 @@
   import BilingualText from '../components/bilingual-text.svelte';
   import TrialBalanceList from './trial-balance-list.svelte';
   import { buildSubtotals } from '../../../libs/reporting/tb-subtotal.js';
+  import { withAccountParents, applyExpandCollapse } from '../../../libs/reporting/tb-hierarchy.js';
 
   export let status;
 
@@ -103,19 +108,22 @@
 
   let reportType = 'balance';
   let monthInput = '';
-  let lines = [];
+  let rawLines = [];        // lines from buildSubtotals
+  let withParents = [];     // rawLines + synthetic parents
   let meta = null;
   let loading = false;
   let error = null;
   let lastFetched = '';
+  let expanded = new Set(); // account codes currently expanded
+
+  $: visibleLines = applyExpandCollapse(withParents, expanded);
 
   $: if ($currentPage && $currentPage !== lastFetched) {
     syncFromUrl();
     lastFetched = $currentPage;
     fetchData();
   }
-  $: if (status && status.fy && status.fy.term && lastFetched && !loading && lines.length === 0 && !error) {
-    // initial mount when status is ready
+  $: if (status && status.fy && status.fy.term && lastFetched && !loading && rawLines.length === 0 && !error) {
     fetchData();
   }
 
@@ -178,14 +186,39 @@
       const url = `/api/trial-balance?${params.toString()}`;
       const r = await axios.get(url);
       meta = r.data.meta;
-      lines = buildSubtotals(r.data.lines || []);
+      const sub = buildSubtotals(r.data.lines || []);
+      rawLines = sub;
+      withParents = withAccountParents(sub);
+      // Default expand: all account codes that appear as sub parents.
+      expanded = new Set(
+        sub.filter((l) => l.type === 'subAccount' && l.code)
+           .map((l) => l.code)
+      );
     } catch (e) {
       error = e?.response?.data?.error || e.message || 'fetch failed';
-      lines = [];
+      rawLines = [];
+      withParents = [];
       meta = null;
     } finally {
       loading = false;
     }
+  };
+
+  const toggleAccount = (code) => {
+    if (!code) return;
+    const next = new Set(expanded);
+    if (next.has(code)) next.delete(code); else next.add(code);
+    expanded = next;
+  };
+
+  const expandAll = () => {
+    expanded = new Set(
+      rawLines.filter((l) => l.type === 'subAccount' && l.code).map((l) => l.code)
+    );
+  };
+
+  const collapseAll = () => {
+    expanded = new Set();
   };
 
   const formatInt = (n) => {

--- a/libs/reporting/tb-hierarchy.js
+++ b/libs/reporting/tb-hierarchy.js
@@ -1,0 +1,108 @@
+/**
+ * Hierarchy view helpers — Issue #210 (E1.4).
+ *
+ * Pure functions that take the flat lines emitted by the v2 contract
+ * (optionally with subtotals already inserted via libs/reporting/tb-subtotal)
+ * and reshape them for the 5-level 試算表 view (大/中/小/勘定/補助科目).
+ *
+ *   - withAccountParents(lines)
+ *       Insert a synthetic `type:'parent'` row above each cluster of
+ *       subAccount lines that share the same account code, so the UI
+ *       can render a 勘定 (account) header with a [+/-] toggle. The
+ *       parent row's name / code / class fields come from the first
+ *       sub's v2 mapping (the engine returns the account name in
+ *       `name`/`nameVi` even on subAccount lines, see trial-balance-v2).
+ *
+ *   - applyExpandCollapse(lines, expanded)
+ *       Hide subAccount rows whose parent code is not in `expanded`.
+ *       Parent / account / subtotal rows are always visible.
+ *
+ *   - indentClass(line)
+ *       Returns a CSS class key for the line's level:
+ *         major subtotal      → 'tb-indent-0'
+ *         middle subtotal     → 'tb-indent-1'
+ *         minor subtotal      → 'tb-indent-2'
+ *         parent (勘定)       → 'tb-indent-3'
+ *         standalone account  → 'tb-indent-3'
+ *         subAccount (補助)   → 'tb-indent-4'
+ */
+
+function nextSubAccountCode(lines, i) {
+  // Helper: find the next subAccount's parent code from index i+1, scanning
+  // forward until we find a subAccount or a different "kind" boundary.
+  for (let j = i + 1; j < lines.length; j += 1) {
+    const x = lines[j];
+    if (x.type === 'subAccount') return x.code;
+    if (x.type === 'account' || x.type === 'subtotal' || x.type === 'parent') return null;
+  }
+  return null;
+}
+
+export function withAccountParents(lines) {
+  if (!Array.isArray(lines)) return [];
+  const out = [];
+  let lastSubCode = null;
+  for (const l of lines) {
+    if (l.type === 'subAccount') {
+      if (lastSubCode !== l.code) {
+        // Insert a synthetic parent row above the first sub of this account.
+        out.push({
+          type: 'parent',
+          isParent: true,
+          code: l.code,
+          accountId: l.accountId,
+          accountClassId: l.accountClassId,
+          aclCode: l.aclCode,
+          major: l.major,
+          middle: l.middle,
+          minor: l.minor,
+          majorVi: l.majorVi,
+          middleVi: l.middleVi,
+          minorVi: l.minorVi,
+          name: l.name,
+          nameVi: l.nameVi,
+          warningCodes: [],
+        });
+        lastSubCode = l.code;
+      }
+      out.push(l);
+    } else {
+      // Any non-sub line breaks the cluster. The next sub we see starts a
+      // fresh account group (if it differs from the one we just emitted).
+      if (l.type === 'account' || l.type === 'subtotal' || l.type === 'parent') {
+        lastSubCode = null;
+      }
+      out.push(l);
+    }
+  }
+  return out;
+}
+
+export function applyExpandCollapse(lines, expanded) {
+  if (!Array.isArray(lines)) return [];
+  if (!(expanded instanceof Set)) expanded = new Set();
+  return lines.filter((l) => {
+    if (l.type === 'subAccount') {
+      // Hide sub rows whose parent is collapsed. A sub without a code is
+      // an orphan — never show.
+      if (l.code == null) return false;
+      return expanded.has(l.code);
+    }
+    return true;
+  });
+}
+
+export function indentClass(line) {
+  if (!line) return 'tb-indent-0';
+  if (line.type === 'subtotal') {
+    if (line.level === 'major') return 'tb-indent-0';
+    if (line.level === 'middle') return 'tb-indent-1';
+    return 'tb-indent-2'; // minor
+  }
+  if (line.type === 'parent') return 'tb-indent-3';
+  if (line.type === 'account') return 'tb-indent-3';
+  if (line.type === 'subAccount') return 'tb-indent-4';
+  return 'tb-indent-0';
+}
+
+export { nextSubAccountCode };

--- a/test/reporting/tb-hierarchy.test.mjs
+++ b/test/reporting/tb-hierarchy.test.mjs
@@ -1,0 +1,191 @@
+/**
+ * Unit tests — Issue #210 (E1.4): libs/reporting/tb-hierarchy.js
+ *
+ * Run with: npx mocha test/reporting/tb-hierarchy.test.mjs
+ */
+
+import { strict as assert } from 'node:assert';
+import { withAccountParents, applyExpandCollapse, indentClass } from '../../libs/reporting/tb-hierarchy.js';
+
+const line = (over) => ({
+  type: 'account',
+  accountId: 1, code: '0000000',
+  name: 'x', nameVi: null,
+  subAccountId: null, subCode: null, subName: null, subNameVi: null,
+  major: 'M', middle: 'M1', minor: 'm',
+  majorVi: null, middleVi: null, minorVi: null,
+  openingDebit: 0, openingCredit: 0,
+  movementDebit: 0, movementCredit: 0,
+  endingDebit: 0, endingCredit: 0,
+  balance: 0,
+  warningCodes: [],
+  ...over,
+});
+
+// ---------------------------------------------------------------------------
+// withAccountParents
+// ---------------------------------------------------------------------------
+
+describe('withAccountParents', () => {
+  it('inserts a parent row above a single subAccount cluster', () => {
+    const out = withAccountParents([
+      line({ type: 'subAccount', code: '3050000', subAccountId: 100, subCode: 1, name: '買掛金', subName: 'A社' }),
+    ]);
+    assert.equal(out.length, 2);
+    assert.equal(out[0].type, 'parent');
+    assert.equal(out[0].code, '3050000');
+    assert.equal(out[0].name, '買掛金');
+    assert.equal(out[0].isParent, true);
+    assert.equal(out[1].type, 'subAccount');
+  });
+
+  it('inserts one parent per cluster of subs sharing the same code', () => {
+    const out = withAccountParents([
+      line({ type: 'subAccount', code: '3050000', subCode: 1, name: '買掛金' }),
+      line({ type: 'subAccount', code: '3050000', subCode: 2, name: '買掛金' }),
+      line({ type: 'subAccount', code: '3050000', subCode: 3, name: '買掛金' }),
+    ]);
+    const parents = out.filter((l) => l.type === 'parent');
+    assert.equal(parents.length, 1, 'one parent for 3 subs of the same account');
+    assert.equal(parents[0].code, '3050000');
+  });
+
+  it('inserts separate parents for different account codes', () => {
+    const out = withAccountParents([
+      line({ type: 'subAccount', code: '3050000', subCode: 1, name: '買掛金' }),
+      line({ type: 'subAccount', code: '3050000', subCode: 2, name: '買掛金' }),
+      line({ type: 'subAccount', code: '7030020', subCode: 1, name: '経費' }),
+    ]);
+    const parents = out.filter((l) => l.type === 'parent');
+    assert.equal(parents.length, 2);
+    assert.deepEqual(parents.map((p) => p.code), ['3050000', '7030020']);
+  });
+
+  it('does not insert parent for standalone account lines', () => {
+    const out = withAccountParents([
+      line({ type: 'account', code: '1000000', name: '現金' }),
+    ]);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].type, 'account');
+  });
+
+  it('mixed: account + subAccount cluster + standalone account', () => {
+    const out = withAccountParents([
+      line({ type: 'account', code: '1000000', name: '現金' }),
+      line({ type: 'subAccount', code: '3050000', subCode: 1, name: '買掛金' }),
+      line({ type: 'account', code: '3000000', name: '資本金' }),
+    ]);
+    const types = out.map((l) => l.type);
+    assert.deepEqual(types, ['account', 'parent', 'subAccount', 'account']);
+    assert.equal(out[1].code, '3050000');
+  });
+
+  it('subAccount cluster split by subtotal → separate parents', () => {
+    // Theoretically unlikely after buildSubtotals, but the helper is defensive.
+    const out = withAccountParents([
+      line({ type: 'subAccount', code: '3050000', subCode: 1, name: '買掛金' }),
+      line({ type: 'subtotal', level: 'minor', name: 'X' }),
+      line({ type: 'subAccount', code: '3050000', subCode: 2, name: '買掛金' }),
+    ]);
+    const parents = out.filter((l) => l.type === 'parent');
+    assert.equal(parents.length, 2, 'split cluster → 2 parents');
+  });
+
+  it('non-array input → empty output', () => {
+    assert.deepEqual(withAccountParents(null), []);
+  });
+
+  it('parent row carries the account class fields from the sub', () => {
+    const out = withAccountParents([
+      line({ type: 'subAccount', code: '3050000', subCode: 1, name: '買掛金',
+        major: '負債', middle: '流動負債', minor: '買掛金',
+        majorVi: 'Nợ', middleVi: 'Nợ ngắn hạn', minorVi: 'Phải trả',
+        accountClassId: 20, aclCode: '305' }),
+    ]);
+    const p = out[0];
+    assert.equal(p.major, '負債');
+    assert.equal(p.minorVi, 'Phải trả');
+    assert.equal(p.accountClassId, 20);
+    assert.equal(p.aclCode, '305');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyExpandCollapse
+// ---------------------------------------------------------------------------
+
+describe('applyExpandCollapse', () => {
+  const sample = [
+    line({ type: 'parent', code: '3050000' }),
+    line({ type: 'subAccount', code: '3050000', subCode: 1 }),
+    line({ type: 'subAccount', code: '3050000', subCode: 2 }),
+    line({ type: 'parent', code: '7030020' }),
+    line({ type: 'subAccount', code: '7030020', subCode: 1 }),
+    line({ type: 'subAccount', code: '7030020', subCode: 2 }),
+    line({ type: 'subAccount', code: '7030020', subCode: 3 }),
+    line({ type: 'account', code: '1000000' }),
+  ];
+
+  it('expanded = empty: hides all sub rows, keeps parents + accounts', () => {
+    const out = applyExpandCollapse(sample, new Set());
+    assert.equal(out.length, 3, 'parent(3050000), parent(7030020), account(1000000)');
+    assert.deepEqual(out.map((l) => l.code), ['3050000', '7030020', '1000000']);
+  });
+
+  it('expanded = {3050000}: shows subs only for 3050000', () => {
+    const out = applyExpandCollapse(sample, new Set(['3050000']));
+    assert.equal(out.length, 5, 'parent(3050000) + 2 subs + parent(7030020) + account(1000000)');
+    const subs = out.filter((l) => l.type === 'subAccount');
+    assert.equal(subs.length, 2);
+    assert.ok(subs.every((l) => l.code === '3050000'));
+  });
+
+  it('expanded = all: passes everything through', () => {
+    const out = applyExpandCollapse(sample, new Set(['3050000', '7030020']));
+    assert.equal(out.length, sample.length);
+  });
+
+  it('orphan subAccount (no code) is always hidden', () => {
+    const orphan = line({ type: 'subAccount', code: null });
+    const out = applyExpandCollapse([orphan, ...sample], new Set(['3050000', '7030020']));
+    assert.ok(!out.includes(orphan));
+  });
+
+  it('non-Set expanded → treated as empty (collapsed)', () => {
+    const out = applyExpandCollapse(sample, null);
+    assert.equal(out.length, 3);
+  });
+
+  it('non-array input → empty output', () => {
+    assert.deepEqual(applyExpandCollapse(null, new Set()), []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// indentClass
+// ---------------------------------------------------------------------------
+
+describe('indentClass', () => {
+  it('major subtotal → indent-0', () => {
+    assert.equal(indentClass({ type: 'subtotal', level: 'major' }), 'tb-indent-0');
+  });
+  it('middle subtotal → indent-1', () => {
+    assert.equal(indentClass({ type: 'subtotal', level: 'middle' }), 'tb-indent-1');
+  });
+  it('minor subtotal → indent-2', () => {
+    assert.equal(indentClass({ type: 'subtotal', level: 'minor' }), 'tb-indent-2');
+  });
+  it('parent (勘定) → indent-3', () => {
+    assert.equal(indentClass({ type: 'parent' }), 'tb-indent-3');
+  });
+  it('standalone account → indent-3', () => {
+    assert.equal(indentClass({ type: 'account' }), 'tb-indent-3');
+  });
+  it('subAccount (補助) → indent-4', () => {
+    assert.equal(indentClass({ type: 'subAccount' }), 'tb-indent-4');
+  });
+  it('null/undefined → indent-0', () => {
+    assert.equal(indentClass(null), 'tb-indent-0');
+    assert.equal(indentClass(undefined), 'tb-indent-0');
+  });
+});


### PR DESCRIPTION
Part of #206 (E01 trial balance epic)

### Summary
- `libs/reporting/tb-hierarchy.js` — pure helpers: `withAccountParents`, `applyExpandCollapse`, `indentClass`.
- `front/svelte/reports/trial-balance-list.svelte` — 5 indent levels, +/- button on parent rows.
- `front/svelte/reports/trial-balance.svelte` — `expanded` Set state, default all expanded, expand-all/collapse-all.

### Behavior
- For each cluster of `subAccount` lines with the same account `code`, a synthetic `type:'parent'` row is inserted above them, carrying the account's name, code, and class fields. The parent row is the 勘定 (account) header; its sub rows are 補助 (sub-account).
- Clicking +/- on a parent toggles whether its sub rows are visible. State is a plain `Set<accountCode>`.
- Indent via 5 `tb-indent-N` CSS classes mapped from `indentClass(line)`.
- Default: all account codes that have subs are expanded. Expand-all / collapse-all buttons.

### Test Report
- `npm run build` ✅
- `npx mocha` total: **105 passing** (E0 36 + v2 29 + subtotal 19 + hierarchy 21).
- 21 new cases in this issue: withAccountParents (8), applyExpandCollapse (6), indentClass (7).

### Out of scope (later)
- Minor/middle/major-level collapse (E1.4 ships only account-level)
- Persist expand state in URL (session-only for now)
- Drill-down → E1.5