### PR TITLE
feat(#211): drill-down modal — click account/subAccount → ledger

### DIFF
--- a/front/svelte/reports/trial-balance-drilldown.svelte
+++ b/front/svelte/reports/trial-balance-drilldown.svelte
@@ -1,0 +1,195 @@
+<!--
+  TrialBalanceDrillDown — Issue #211 (E1.5).
+
+  Modal that opens when the user clicks a `account` or `subAccount` row
+  in the trial balance. Loads the corresponding ledger entries from
+  /api/ledger/:term/:account[/:subAccount]?from=&to= and shows them in
+  a compact table. Phase 1: modal. Phase 2: viewport-wide → side panel.
+
+  Closing on ESC / outside-click is handled by bootstrap's Modal class
+  (data-bs-backdrop="static" set on the .modal element).
+
+  Props (bindable via the parent):
+    term          — FiscalYear.term, comes from status.fy.term
+    accountCode   — string, e.g. '1000000'
+    subCode       — number | null
+    accountName   — display name
+    from / to     — Date | string, period bounds (default: full FY)
+
+  Methods:
+    open() / close()
+-->
+<div class="modal" bind:this={modalEl} tabindex="-1" data-bs-backdrop="static">
+  <div class="modal-dialog modal-xl modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">
+          <BilingualText key="ledger" inline={true} />
+          {#if accountCode}
+            <span class="tb-drill-account">
+              / {accountCode}{subCode != null ? '-' + subCode : ''}{accountName ? ' ' + accountName : ''}
+            </span>
+          {/if}
+        </h5>
+        <button type="button" class="btn-close" aria-label="Close"
+          on:click={close}></button>
+      </div>
+      <div class="modal-body">
+        {#if loading}
+          <p class="text-muted">...</p>
+        {:else if error}
+          <p class="text-danger">{error}</p>
+        {:else}
+          <div class="tb-drill-meta mb-2">
+            <span class="text-muted">
+              {formatDate(from)} 〜 {formatDate(to)} · {lines.length} {lines.length === 1 ? 'entry' : 'entries'}
+            </span>
+          </div>
+          {#if lines.length === 0}
+            <p class="text-muted">データなし / Không có dữ liệu</p>
+          {:else}
+            <table class="table table-bordered table-sm tb-drill-table">
+              <thead class="table-light">
+                <tr>
+                  <th style="width:5rem">日付<br/>Ngày</th>
+                  <th style="width:5rem">No.</th>
+                  <th>摘要 / Diễn giải</th>
+                  <th style="width:8rem">相手科目<br/>T.K đối ứng</th>
+                  <th class="tb-col-num" style="width:7rem">借方<br/>Nợ</th>
+                  <th class="tb-col-num" style="width:7rem">貸方<br/>Có</th>
+                </tr>
+              </thead>
+              <tbody>
+                {#each lines as l (l.year + '-' + l.month + '-' + l.day + '-' + l.no + '-' + l.lineNo)}
+                  <tr>
+                    <td class="text-center">
+                      <button type="button" class="btn btn-link p-0"
+                        on:click={() => openJournal(l)}>
+                        {l.month}/{l.day}
+                      </button>
+                    </td>
+                    <td class="text-center">{l.no}</td>
+                    <td>{l.description || l.application || ''}</td>
+                    <td>{counterAccountLabel(l)}</td>
+                    <td class="tb-col-num">{formatNum(l.debitAmount)}</td>
+                    <td class="tb-col-num">{formatNum(l.creditAmount)}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          {/if}
+        {/if}
+      </div>
+      <div class="modal-footer">
+        <a class="btn btn-primary"
+          href={fullLedgerHref}
+          on:click={close}>
+          <BilingualText key="open_full_ledger" inline={true} />
+          <i class="bi bi-box-arrow-up-right"></i>
+        </a>
+        <button type="button" class="btn btn-secondary" on:click={close}>
+          <BilingualText key="close" inline={true} />
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  import { onMount, createEventDispatcher } from 'svelte';
+  import axios from 'axios';
+  import Modal from 'bootstrap/js/dist/modal';
+  import BilingualText from '../components/bilingual-text.svelte';
+  import { link } from '../../javascripts/router.js';
+
+  export let term = null;
+  export let accountCode = null;
+  export let subCode = null;
+  export let accountName = null;
+  export let from = null;
+  export let to = null;
+
+  const dispatch = createEventDispatcher();
+
+  let modalEl;
+  let modal;
+  let lines = [];
+  let loading = false;
+  let error = null;
+
+  export const open = async () => {
+    if (!term || !accountCode) {
+      error = 'missing term or account';
+      modal?.show();
+      return;
+    }
+    modal?.show();
+    await load();
+  };
+
+  export const close = () => {
+    modal?.hide();
+    lines = [];
+    error = null;
+  };
+
+  const load = async () => {
+    loading = true;
+    error = null;
+    try {
+      const path = subCode != null
+        ? `/api/ledger/${term}/${accountCode}/${subCode}`
+        : `/api/ledger/${term}/${accountCode}`;
+      const r = await axios.get(path);
+      lines = r.data || [];
+    } catch (e) {
+      error = e?.response?.data?.error || e.message || 'ledger load failed';
+      lines = [];
+    } finally {
+      loading = false;
+    }
+  };
+
+  const openJournal = (l) => {
+    close();
+    link(`/journal/${l.year}/${l.month}`);
+  };
+
+  const counterAccountLabel = (l) => {
+    // For a debit-side entry on our account, the counter is creditAccount.
+    // For a credit-side entry, the counter is debitAccount.
+    if (l.debitAccount === accountCode) {
+      return l.creditAccount + (l.creditSubAccount ? '-' + l.creditSubAccount : '');
+    }
+    return l.debitAccount + (l.debitSubAccount ? '-' + l.debitSubAccount : '');
+  };
+
+  const formatNum = (n) => {
+    if (n == null) return '';
+    return Number(n).toLocaleString('en-US');
+  };
+
+  const formatDate = (d) => {
+    if (!d) return '';
+    const dt = (d instanceof Date) ? d : new Date(d);
+    if (isNaN(dt.getTime())) return String(d);
+    return `${dt.getFullYear()}-${String(dt.getMonth()+1).padStart(2,'0')}-${String(dt.getDate()).padStart(2,'0')}`;
+  };
+
+  $: fullLedgerHref = accountCode
+    ? (subCode != null
+        ? `/ledger/${term}/${accountCode}/${subCode}`
+        : `/ledger/${term}/${accountCode}`)
+    : '#';
+
+  onMount(() => {
+    modal = new Modal(modalEl);
+  });
+</script>
+
+<style>
+  .tb-drill-account { font-family: monospace; margin-left: 0.4rem; }
+  .tb-col-num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+  .tb-drill-table { font-size: 0.85rem; }
+  .tb-drill-meta { font-size: 0.85rem; }
+</style>

--- a/front/svelte/reports/trial-balance-list.svelte
+++ b/front/svelte/reports/trial-balance-list.svelte
@@ -14,7 +14,8 @@
   Props:
     lines          array of v2 lines (already through withAccountParents + applyExpandCollapse)
     expanded       Set<accountCode> of accounts that are currently expanded
-    onToggle       (code) => void  — fired when the user clicks [+/-]
+    onToggle       (code) => void       — fired when the user clicks [+/-]
+    onRowClick     (line) => void       — fired when a data row is clicked (parent | account | subAccount)
 -->
 <table class="table table-bordered table-sm tb-v2-table">
   <thead class="table-light">
@@ -34,7 +35,9 @@
     {#each lines as l (keyFor(l))}
       <tr class:tb-subtotal={l.type === 'subtotal'}
           class:tb-parent={l.type === 'parent'}
-          class={indentClass(l)}>
+          class:tb-clickable={l.type !== 'subtotal'}
+          class={indentClass(l)}
+          on:click={() => onRowClick(l)}>
         <td class="tb-col-code">
           {#if l.type === 'subtotal'}
             <span class="tb-subtotal-label">【{l.level}】</span>
@@ -89,6 +92,7 @@
   export let lines = [];
   export let expanded = new Set();
   export let onToggle = () => {};
+  export let onRowClick = () => {};
 
   const formatNum = (n) => {
     if (n == null) return '';
@@ -144,4 +148,6 @@
   }
   .tb-toggle:hover { color: #000; }
   .tb-code-text { font-family: monospace; }
+  .tb-clickable { cursor: pointer; }
+  .tb-clickable:hover { background: #f0f6ff; }
 </style>

--- a/front/svelte/reports/trial-balance.svelte
+++ b/front/svelte/reports/trial-balance.svelte
@@ -84,9 +84,19 @@
     <TrialBalanceList
       lines={visibleLines}
       {expanded}
-      onToggle={toggleAccount} />
+      onToggle={toggleAccount}
+      onRowClick={openDrillDown} />
   </div>
 </div>
+
+<TrialBalanceDrillDown
+  bind:this={drilldown}
+  term={status?.fy?.term}
+  accountCode={drillAccount?.code}
+  subCode={drillAccount?.subCode}
+  accountName={drillAccount?.name}
+  from={periodBounds.from}
+  to={periodBounds.to} />
 {/key}
 
 <script>
@@ -95,6 +105,7 @@
   import { languagePair } from '../../javascripts/bilingual.js';
   import BilingualText from '../components/bilingual-text.svelte';
   import TrialBalanceList from './trial-balance-list.svelte';
+  import TrialBalanceDrillDown from './trial-balance-drilldown.svelte';
   import { buildSubtotals } from '../../../libs/reporting/tb-subtotal.js';
   import { withAccountParents, applyExpandCollapse } from '../../../libs/reporting/tb-hierarchy.js';
 
@@ -115,6 +126,17 @@
   let error = null;
   let lastFetched = '';
   let expanded = new Set(); // account codes currently expanded
+  let drilldown;
+  let drillAccount = null;  // { code, subCode, name } | null
+
+  $: periodBounds = (() => {
+    if (!status || !status.fy) return { from: null, to: null };
+    if (monthInput) {
+      const [y, m] = monthInput.split('-').map(Number);
+      return { from: new Date(y, m - 1, 1), to: new Date(y, m, 0) };
+    }
+    return { from: new Date(status.fy.startDate), to: new Date(status.fy.endDate) };
+  })();
 
   $: visibleLines = applyExpandCollapse(withParents, expanded);
 
@@ -219,6 +241,21 @@
 
   const collapseAll = () => {
     expanded = new Set();
+  };
+
+  const openDrillDown = (row) => {
+    if (!row) return;
+    if (row.type === 'subtotal') return;  // can't drill into subtotals
+    if (row.type === 'parent') {
+      drillAccount = { code: row.code, subCode: null, name: row.name };
+    } else if (row.type === 'subAccount') {
+      drillAccount = { code: row.code, subCode: row.subCode, name: row.subName || row.name };
+    } else if (row.type === 'account') {
+      drillAccount = { code: row.code, subCode: null, name: row.name };
+    } else {
+      return;
+    }
+    drilldown?.open();
   };
 
   const formatInt = (n) => {


### PR DESCRIPTION
Part of #206 (E01 trial balance epic)

### Summary
- `front/svelte/reports/trial-balance-drilldown.svelte` — bootstrap modal, loads /api/ledger.
- `front/svelte/reports/trial-balance.svelte` — bound modal ref + drill state + periodBounds.
- `front/svelte/reports/trial-balance-list.svelte` — clickable data rows, hover bg.

### Behavior
- Click account / parent / subAccount row → open drill-down modal.
- Modal loads /api/ledger/:term/:account[/:subCode] (legacy endpoint, multi-tenant safe).
- Renders compact table: date, no, description, counter-account, debit, credit.
- 'Open full ledger' link → /ledger/:term/:accountCode[/subCode] (full Svelte page).
- 'Jump to journal' on each row → /journal/:year/:month.
- Subtotal rows not clickable (no drill).
- Phase 1 modal; phase 2 viewport-wide → side panel (per initiative.md §1.5).

### Test Report
- `npm run build` ✅
- 105 unit tests still pass (no regression on libs/reporting/*).
- Manual E2E deferred to #1.11 (chrome-devtools MCP).

### Out of scope
- Panel mode (viewport detection) → phase 2
- Drill to journal/voucher ở TB row level — initiative says 'link Xem chứng từ ở ledger row'