### PR TITLE
feat(#212): warning rules W001/W002/W005 + UI banner

### DIFF
--- a/front/svelte/reports/trial-balance-list.svelte
+++ b/front/svelte/reports/trial-balance-list.svelte
@@ -36,6 +36,7 @@
       <tr class:tb-subtotal={l.type === 'subtotal'}
           class:tb-parent={l.type === 'parent'}
           class:tb-clickable={l.type !== 'subtotal'}
+          class:tb-warning-row={(l.warningCodes || []).some((c) => c === 'TB-W005')}
           class={indentClass(l)}
           on:click={() => onRowClick(l)}>
         <td class="tb-col-code">
@@ -150,4 +151,6 @@
   .tb-code-text { font-family: monospace; }
   .tb-clickable { cursor: pointer; }
   .tb-clickable:hover { background: #f0f6ff; }
+  .tb-warning-row { background: #fde7e7; }
+  .tb-warning-row:hover { background: #fbd0d0; }
 </style>

--- a/front/svelte/reports/trial-balance.svelte
+++ b/front/svelte/reports/trial-balance.svelte
@@ -80,6 +80,28 @@
     </div>
   </div>
 
+  {#if warnings && warnings.length > 0}
+    <div class="tb-warnings mt-2">
+      {#each warnings as w (w.code + JSON.stringify(w.detail || {}))}
+        <div class="alert tb-warning tb-warning-{w.severity}" role="alert">
+          <strong>[{w.code}]</strong>
+          <span class="tb-warning-title">{w.title} / {w.titleVi}</span>
+          {#if w.detail}
+            <span class="tb-warning-detail">
+              {#if w.code === 'TB-W001'}
+                D={formatInt(w.detail.movementDebit)} · C={formatInt(w.detail.movementCredit)} · diff={formatInt(w.detail.diff)}
+              {:else if w.code === 'TB-W002'}
+                {w.detail.count} unapproved slip(s) in this term
+              {:else if w.detail.error}
+                {w.detail.error}
+              {/if}
+            </span>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+
   <div class="row body-height">
     <TrialBalanceList
       lines={visibleLines}
@@ -121,6 +143,7 @@
   let monthInput = '';
   let rawLines = [];        // lines from buildSubtotals
   let withParents = [];     // rawLines + synthetic parents
+  let warnings = [];
   let meta = null;
   let loading = false;
   let error = null;
@@ -208,6 +231,7 @@
       const url = `/api/trial-balance?${params.toString()}`;
       const r = await axios.get(url);
       meta = r.data.meta;
+      warnings = r.data.meta?.warnings || [];
       const sub = buildSubtotals(r.data.lines || []);
       rawLines = sub;
       withParents = withAccountParents(sub);
@@ -221,6 +245,7 @@
       rawLines = [];
       withParents = [];
       meta = null;
+      warnings = [];
     } finally {
       loading = false;
     }
@@ -279,4 +304,10 @@
   .tb-tab { min-width: 9rem; }
   .tb-period-label { font-weight: 500; }
   .tb-meta { font-size: 0.85rem; }
+  .tb-warnings .tb-warning { padding: 0.4rem 0.75rem; margin-bottom: 0.4rem; font-size: 0.85rem; }
+  .tb-warning-critical { background: #f8d7da; border-color: #f5c2c7; color: #842029; }
+  .tb-warning-high { background: #fff3cd; border-color: #ffecb5; color: #664d03; }
+  .tb-warning-medium { background: #ffe5b4; border-color: #ffd09b; color: #7a4f01; }
+  .tb-warning-title { margin-left: 0.5rem; }
+  .tb-warning-detail { margin-left: 0.5rem; font-family: monospace; }
 </style>

--- a/libs/reporting/trial-balance-v2.js
+++ b/libs/reporting/trial-balance-v2.js
@@ -22,6 +22,11 @@
  */
 import { enrichBilingual as defaultEnrichBilingual } from '../bilingual-helper.js';
 import { balanceEngine } from './balance-engine.js';
+import {
+  runWarningRules,
+  splitBannerAndLine,
+  applyLineWarningCodes,
+} from './warning-rules.js';
 
 /**
  * Build a CrossSlipDetail-shaped entry source for [startDate, endDate).
@@ -246,6 +251,13 @@ export async function trialBalanceV2(params, deps) {
     { openingDebit: 0, openingCredit: 0, movementDebit: 0, movementCredit: 0, endingDebit: 0, endingCredit: 0 }
   );
 
+  // Warnings (E1.6). Banner messages go on meta.warnings; per-line codes
+  // get stamped onto each line's warningCodes. The v2 contract already
+  // declared warningCodes[]; this is where it actually gets populated.
+  const messages = await runWarningRules({ lines, meta: { tenantId, term, totals }, deps });
+  const { banners, byLineKey } = splitBannerAndLine(messages);
+  lines = applyLineWarningCodes(lines, byLineKey);
+
   return {
     version: 2,
     meta: {
@@ -258,7 +270,7 @@ export async function trialBalanceV2(params, deps) {
         ? Object.keys(languagePair).sort().join('+')
         : 'ja',
       generatedAt: new Date(),
-      warnings: [], // populated by E1.6 warning-rules
+      warnings: banners,
       totals,
       filters: {
         accountClassIds: Array.from(classIdFilter),

--- a/libs/reporting/warning-rules.js
+++ b/libs/reporting/warning-rules.js
@@ -1,0 +1,150 @@
+/**
+ * Warning rules — Issue #212 (E1.6).
+ *
+ * Three rules per initiative.md §Warnings:
+ *
+ *   TB-W001 critical — Σ movementDebit ≠ Σ movementCredit cho period.
+ *                     Top banner. Phase 1: does NOT block export.
+ *   TB-W002 high     — Có CrossSlip trong term hiện tại có approvedAt IS NULL.
+ *                     Banner + link tới danh sách unapproved.
+ *   TB-W005 medium   — 現金 / 普通預金 (cash/bank per config) có endingDebit
+ *                     < 0. Highlight row đỏ.
+ *
+ * Phase 1: rules are hard-coded; severity + title bilingual.
+ * Phase 2: expose config (lib/reporting/warning-rules-config.js) so each
+ * tenant can override which codes count as cash/bank.
+ *
+ * API:
+ *   const { messages } = await runWarningRules({ lines, meta, deps });
+ *   // → messages: [{ code, severity, title, titleVi, lineCode?, lineSubCode?, detail? }]
+ *   // Banner messages have NO lineCode/lineSubCode. Line messages do.
+ *
+ *   const { banners, byLineKey } = splitBannerAndLine(messages);
+ *   const linesWithCodes = applyLineWarningCodes(lines, byLineKey);
+ */
+
+// Phase 1 cash/bank config: account code prefixes (first 3 chars of 7-digit code).
+const CASH_BANK_PREFIXES = ['100', '101']; // 現金 (1000000) + 普通預金 (1010000)
+
+const isCashOrBank = (line) => {
+  if (!line || !line.code) return false;
+  return CASH_BANK_PREFIXES.some((p) => String(line.code).startsWith(p));
+};
+
+const warningRules = [
+  {
+    id: 'TB-W001',
+    severity: 'critical',
+    title: '借方合計 ≠ 貸方合計',
+    titleVi: 'Tổng Nợ ≠ Tổng Có',
+    evaluate: ({ meta }) => {
+      const t = meta.totals;
+      if (!t) return [];
+      if (t.movementDebit === t.movementCredit) return [];
+      return [{
+        detail: {
+          movementDebit: t.movementDebit,
+          movementCredit: t.movementCredit,
+          diff: t.movementDebit - t.movementCredit,
+        },
+      }];
+    },
+  },
+  {
+    id: 'TB-W002',
+    severity: 'high',
+    title: '未承認の伝票があります',
+    titleVi: 'Có chứng từ chưa duyệt',
+    evaluate: async ({ meta, deps }) => {
+      if (!deps || !deps.CrossSlip) return [];
+      const count = await deps.CrossSlip.count({
+        where: {
+          tenantId: meta.tenantId,
+          term: meta.term,
+          approvedAt: null,
+        },
+      });
+      if (count === 0) return [];
+      return [{ detail: { count } }];
+    },
+  },
+  {
+    id: 'TB-W005',
+    severity: 'medium',
+    title: '現金/預金の残高がマイナス',
+    titleVi: 'Số dư tiền mặt / ngân hàng âm',
+    evaluate: ({ lines }) => {
+      const out = [];
+      for (const l of lines) {
+        if (!isCashOrBank(l)) continue;
+        // For D-nature (cash/bank are field=1, D): balance = endingDebit - endingCredit.
+        // Negative when endingCredit > endingDebit, i.e. (endingDebit - endingCredit) < 0.
+        const bal = (l.endingDebit || 0) - (l.endingCredit || 0);
+        if (bal < 0) {
+          out.push({
+            lineCode: l.code,
+            lineSubCode: l.subCode != null ? l.subCode : null,
+            detail: { balance: l.balance, endingDebit: l.endingDebit, endingCredit: l.endingCredit },
+          });
+        }
+      }
+      return out;
+    },
+  },
+];
+
+export async function runWarningRules({ lines, meta, deps }) {
+  const out = [];
+  for (const rule of warningRules) {
+    let msgs = [];
+    try {
+      msgs = await rule.evaluate({ lines, meta, deps });
+    } catch (e) {
+      // Don't fail the whole pipeline on a single rule error; report as banner.
+      out.push({
+        code: rule.id,
+        severity: rule.severity,
+        title: rule.title,
+        titleVi: rule.titleVi,
+        detail: { error: e?.message || 'rule failed' },
+      });
+      continue;
+    }
+    for (const m of msgs || []) {
+      out.push({
+        code: rule.id,
+        severity: rule.severity,
+        title: rule.title,
+        titleVi: rule.titleVi,
+        ...m,
+      });
+    }
+  }
+  return out;
+}
+
+export function splitBannerAndLine(messages) {
+  const banners = [];
+  const byLineKey = new Map();
+  for (const m of messages) {
+    if (m.lineCode != null) {
+      const k = `${m.lineCode}|${m.lineSubCode != null ? m.lineSubCode : ''}`;
+      if (!byLineKey.has(k)) byLineKey.set(k, []);
+      byLineKey.get(k).push(m.code);
+    } else {
+      banners.push(m);
+    }
+  }
+  return { banners, byLineKey };
+}
+
+export function applyLineWarningCodes(lines, byLineKey) {
+  return lines.map((l) => {
+    const k = `${l.code || ''}|${l.subCode != null ? l.subCode : ''}`;
+    const codes = byLineKey.get(k);
+    if (!codes) return l;
+    return { ...l, warningCodes: [...(l.warningCodes || []), ...codes] };
+  });
+}
+
+export { warningRules, CASH_BANK_PREFIXES, isCashOrBank };

--- a/test/reporting/trial-balance-v2.test.mjs
+++ b/test/reporting/trial-balance-v2.test.mjs
@@ -131,6 +131,7 @@ const makeDeps = (overrides = {}) => {
         }
         return [];
       },
+      count: async () => 0,
     },
     CrossSlipDetail: {},
     FiscalYear: {

--- a/test/reporting/warning-rules.test.mjs
+++ b/test/reporting/warning-rules.test.mjs
@@ -1,0 +1,233 @@
+/**
+ * Unit tests — Issue #212 (E1.6): libs/reporting/warning-rules.js
+ *
+ * Run with: npx mocha test/reporting/warning-rules.test.mjs
+ */
+
+import { strict as assert } from 'node:assert';
+import {
+  runWarningRules,
+  splitBannerAndLine,
+  applyLineWarningCodes,
+  isCashOrBank,
+  CASH_BANK_PREFIXES,
+} from '../../libs/reporting/warning-rules.js';
+
+const meta = (over = {}) => ({
+  tenantId: 1,
+  term: 1,
+  totals: { movementDebit: 0, movementCredit: 0, openingDebit: 0, openingCredit: 0, endingDebit: 0, endingCredit: 0 },
+  ...over,
+});
+
+const line = (over) => ({
+  type: 'account',
+  code: '0000000', subCode: null,
+  endingDebit: 0, endingCredit: 0,
+  warningCodes: [],
+  ...over,
+});
+
+// ---------------------------------------------------------------------------
+// CASH_BANK_PREFIXES
+// ---------------------------------------------------------------------------
+
+describe('CASH_BANK_PREFIXES', () => {
+  it('treats 1000000 (現金) and 1010000 (普通預金) as cash/bank', () => {
+    assert.ok(isCashOrBank(line({ code: '1000000' })));
+    assert.ok(isCashOrBank(line({ code: '1010000' })));
+  });
+  it('does NOT treat 3000000 (資本金) as cash/bank', () => {
+    assert.ok(!isCashOrBank(line({ code: '3000000' })));
+  });
+  it('handles sub-account line on cash/bank parent', () => {
+    assert.ok(isCashOrBank(line({ code: '1000000', type: 'subAccount', subCode: 1 })));
+  });
+  it('null/empty code → false', () => {
+    assert.ok(!isCashOrBank(line({ code: null })));
+    assert.ok(!isCashOrBank(line({ code: '' })));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TB-W001 — movement debit ≠ credit
+// ---------------------------------------------------------------------------
+
+describe('TB-W001', () => {
+  it('fires when movementDebit !== movementCredit', async () => {
+    const m = meta({ totals: { movementDebit: 100, movementCredit: 90 } });
+    const out = await runWarningRules({ lines: [], meta: m, deps: {} });
+    const w001 = out.find((m) => m.code === 'TB-W001');
+    assert.ok(w001);
+    assert.equal(w001.severity, 'critical');
+    assert.equal(w001.detail.diff, 10);
+  });
+
+  it('does NOT fire when totals balance', async () => {
+    const m = meta({ totals: { movementDebit: 100, movementCredit: 100 } });
+    const out = await runWarningRules({ lines: [], meta: m, deps: {} });
+    assert.ok(!out.some((m) => m.code === 'TB-W001'));
+  });
+
+  it('missing totals → does not throw, no W001', async () => {
+    const m = { tenantId: 1, term: 1 };
+    const out = await runWarningRules({ lines: [], meta: m, deps: {} });
+    assert.ok(!out.some((m) => m.code === 'TB-W001'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TB-W002 — unapproved CrossSlip
+// ---------------------------------------------------------------------------
+
+describe('TB-W002', () => {
+  it('fires when CrossSlip.count(...) returns > 0', async () => {
+    const deps = { CrossSlip: { count: async () => 5 } };
+    const m = meta();
+    const out = await runWarningRules({ lines: [], meta: m, deps });
+    const w002 = out.find((m) => m.code === 'TB-W002');
+    assert.ok(w002);
+    assert.equal(w002.severity, 'high');
+    assert.equal(w002.detail.count, 5);
+  });
+
+  it('does NOT fire when count is 0', async () => {
+    const deps = { CrossSlip: { count: async () => 0 } };
+    const out = await runWarningRules({ lines: [], meta: meta(), deps });
+    assert.ok(!out.some((m) => m.code === 'TB-W002'));
+  });
+
+  it('missing CrossSlip dep → no W002 (does not throw)', async () => {
+    const out = await runWarningRules({ lines: [], meta: meta(), deps: {} });
+    assert.ok(!out.some((m) => m.code === 'TB-W002'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TB-W005 — cash/bank negative ending
+// ---------------------------------------------------------------------------
+
+describe('TB-W005', () => {
+  it('fires for cash account with endingDebit < endingCredit', async () => {
+    const lines = [
+      line({ code: '1000000', endingDebit: 0, endingCredit: 50, balance: -50 }),
+      line({ code: '3000000', endingDebit: 0, endingCredit: 0 }),
+    ];
+    const out = await runWarningRules({ lines, meta: meta(), deps: {} });
+    const w005 = out.find((m) => m.code === 'TB-W005');
+    assert.ok(w005);
+    assert.equal(w005.severity, 'medium');
+    assert.equal(w005.lineCode, '1000000');
+    assert.equal(w005.lineSubCode, null);
+  });
+
+  it('does NOT fire when cash account has positive ending', async () => {
+    const lines = [
+      line({ code: '1000000', endingDebit: 100, endingCredit: 0, balance: 100 }),
+    ];
+    const out = await runWarningRules({ lines, meta: meta(), deps: {} });
+    assert.ok(!out.some((m) => m.code === 'TB-W005'));
+  });
+
+  it('does NOT fire for non-cash negative accounts', async () => {
+    const lines = [
+      line({ code: '3000000', endingDebit: 0, endingCredit: 200, balance: -200 }),
+    ];
+    const out = await runWarningRules({ lines, meta: meta(), deps: {} });
+    assert.ok(!out.some((m) => m.code === 'TB-W005'));
+  });
+
+  it('fires for subAccount line under cash parent', async () => {
+    const lines = [
+      line({ type: 'subAccount', code: '1010000', subCode: 1, endingDebit: 0, endingCredit: 10 }),
+    ];
+    const out = await runWarningRules({ lines, meta: meta(), deps: {} });
+    const w005 = out.find((m) => m.code === 'TB-W005');
+    assert.ok(w005);
+    assert.equal(w005.lineCode, '1010000');
+    assert.equal(w005.lineSubCode, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// splitBannerAndLine + applyLineWarningCodes
+// ---------------------------------------------------------------------------
+
+describe('splitBannerAndLine', () => {
+  it('separates banner and per-line messages', () => {
+    const messages = [
+      { code: 'TB-W001', severity: 'critical' },
+      { code: 'TB-W005', severity: 'medium', lineCode: '1000000', lineSubCode: null },
+      { code: 'TB-W005', severity: 'medium', lineCode: '1010000', lineSubCode: 2 },
+    ];
+    const { banners, byLineKey } = splitBannerAndLine(messages);
+    assert.equal(banners.length, 1);
+    assert.equal(banners[0].code, 'TB-W001');
+    assert.equal(byLineKey.size, 2);
+    assert.deepEqual(byLineKey.get('1000000|'), ['TB-W005']);
+    assert.deepEqual(byLineKey.get('1010000|2'), ['TB-W005']);
+  });
+});
+
+describe('applyLineWarningCodes', () => {
+  const lines = [
+    line({ code: '1000000' }),
+    line({ code: '1010000', subCode: 2, type: 'subAccount' }),
+  ];
+
+  it('stamps matching codes onto the right lines', () => {
+    const byLineKey = new Map([
+      ['1000000|', ['TB-W005']],
+      ['1010000|2', ['TB-W005']],
+    ]);
+    const out = applyLineWarningCodes(lines, byLineKey);
+    assert.deepEqual(out[0].warningCodes, ['TB-W005']);
+    assert.deepEqual(out[1].warningCodes, ['TB-W005']);
+  });
+
+  it('preserves existing warningCodes (does not clobber)', () => {
+    const linesWithExisting = [
+      line({ code: '1000000', warningCodes: ['TB-W001'] }),
+    ];
+    const byLineKey = new Map([['1000000|', ['TB-W005']]]);
+    const out = applyLineWarningCodes(linesWithExisting, byLineKey);
+    assert.deepEqual(out[0].warningCodes, ['TB-W001', 'TB-W005']);
+  });
+
+  it('lines not in byLineKey → unchanged', () => {
+    const byLineKey = new Map();
+    const out = applyLineWarningCodes(lines, byLineKey);
+    assert.deepEqual(out[0].warningCodes, []);
+    assert.deepEqual(out[1].warningCodes, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration with v2 (smoke)
+// ---------------------------------------------------------------------------
+
+describe('rules error handling', () => {
+  it('a rule throwing is reported as banner, does not fail others', async () => {
+    const badRule = {
+      id: 'TB-XXX',
+      severity: 'low',
+      title: 't',
+      titleVi: 't',
+      evaluate: () => { throw new Error('boom'); },
+    };
+    // Import the internal list indirectly by running it through runWarningRules
+    // after temporarily injecting. Use a fresh call: inject into the rules list
+    // by monkey-patching won't work here. Instead, simulate by passing a
+    // deliberately broken deps.
+    const deps = {
+      CrossSlip: {
+        count: async () => { throw new Error('db down'); },
+      },
+    };
+    const m = meta();
+    const out = await runWarningRules({ lines: [], meta: m, deps });
+    const w002 = out.find((m) => m.code === 'TB-W002');
+    assert.ok(w002);
+    assert.match(w002.detail.error, /db down/);
+  });
+});


### PR DESCRIPTION
Part of #206 (E01 trial balance epic)

### Summary
- `libs/reporting/warning-rules.js` — 3 hard-coded rules with bilingual title + severity, evaluated by `runWarningRules({lines, meta, deps})`. W002 is async (uses deps.CrossSlip.count).
- `libs/reporting/trial-balance-v2.js` — invokes runWarningRules after totals, populates meta.warnings + per-line warningCodes.
- View: alerts above table, severity-coloured; W005 row highlight.

### Behavior
- W001 critical fires when Σ movementDebit ≠ Σ movementCredit.
- W002 high fires when there's ≥ 1 unapproved CrossSlip in this tenant/term.
- W005 medium fires when any cash/bank line (codes 100*, 101*) has endingDebit < endingCredit.
- Per-rule exceptions caught and surfaced as banner — never fail the whole pipeline.
- W001 phase 1 does NOT block export (per initiative.md §1.6).

### Test Report
- `npm run build` ✅
- 124 unit tests pass (E0 36 + v2 29 + subtotal 19 + hierarchy 21 + warnings 19).
- v2 mock extended with `CrossSlip.count: async () => 0` so W002 doesn't fire in fixtures.

### Out of scope
- Configurable cash/bank codes (phase 2)
- W003/W004/W006-W010 (deferred per initiative)
- Export-blocking mode for W001 (phase 2)