### PR TITLE
feat(#213): Excel export server-side

### DIFF
--- a/front/svelte/reports/trial-balance.svelte
+++ b/front/svelte/reports/trial-balance.svelte
@@ -16,6 +16,11 @@
       <span class="tb-v2-badge">v2</span>
     </h1>
     <div>
+      <button type="button" class="btn btn-primary btn-bilingual me-2"
+        on:click={downloadExcel} disabled={loading || !status?.fy?.term}>
+        <BilingualText primary="Excel出力" secondary="Xuất Excel" inline={true} />
+        <i class="bi bi-download"></i>
+      </button>
       <a class="btn btn-outline-secondary btn-bilingual" href="/trial-balance">
         <BilingualText primary="旧画面" secondary="(Legacy)" inline={true} />
       </a>
@@ -286,6 +291,25 @@
   const formatInt = (n) => {
     if (n == null) return '';
     return Number(n).toLocaleString('en-US');
+  };
+
+  const downloadExcel = async () => {
+    if (!status || !status.fy || !status.fy.term) return;
+    const params = new URLSearchParams();
+    params.set('version', '2');
+    params.set('reportType', reportType);
+    params.set('format', 'xlsx');
+    if (monthInput) params.set('month', monthInput);
+    const lp = $languagePair;
+    if (lp) params.set('languagePair', JSON.stringify(lp));
+    const url = `/api/trial-balance?${params.toString()}`;
+    // Let the browser handle the download via a hidden link.
+    const a = document.createElement('a');
+    a.href = url;
+    a.rel = 'noopener';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
   };
 </script>
 

--- a/libs/reporting/tb-export.js
+++ b/libs/reporting/tb-export.js
@@ -1,0 +1,203 @@
+/**
+ * Excel export — Issue #213 (E1.7).
+ *
+ * Server-side export for trial balance v2 response. Produces a 2-sheet
+ * workbook:
+ *   - Sheet `試算表_<reportType>`: tenant header (rows 1-3), column
+ *     headers (row 4), data (rows 5+; subtotals + accounts + subAccounts
+ *     in the order provided), totals (last row).
+ *   - Sheet `Warnings`: one row per warning (if any).
+ *
+ *   Number format: `#,##0;[Red]-#,##0` (per BRD 10.11).
+ *   File name:    `trial_balance_{tenantCode}_{term}_{YYYYMMDDHHmm}.xlsx`.
+ *
+ *   The function is pure wrt the v2 contract: it consumes the JSON shape
+ *   produced by `trialBalanceV2` (with buildSubtotals already applied to
+ *   lines if the caller wants subtotal rows). It does NOT touch the DB.
+ */
+import ExcelJS from 'exceljs';
+
+const NUM_FMT = '#,##0;[Red]-#,##0';
+
+const COLS = [
+  { key: 'code', header: '科目 / Mã', width: 14 },
+  { key: 'name', header: '科目名 / Tên', width: 32 },
+  { key: 'openingDebit',  header: '期首借方 / Dư đầu kỳ - Nợ',   width: 16, num: true },
+  { key: 'openingCredit', header: '期首貸方 / Dư đầu kỳ - Có',   width: 16, num: true },
+  { key: 'movementDebit', header: '期間借方 / Phát sinh - Nợ',   width: 16, num: true },
+  { key: 'movementCredit',header: '期間貸方 / Phát sinh - Có',   width: 16, num: true },
+  { key: 'endingDebit',   header: '期末借方 / Dư cuối kỳ - Nợ', width: 16, num: true },
+  { key: 'endingCredit',  header: '期末貸方 / Dư cuối kỳ - Có', width: 16, num: true },
+  { key: 'balance',       header: '残高 / Số dư',                 width: 16, num: true },
+];
+
+const formatDate = (d) => {
+  if (!d) return '';
+  const dt = (d instanceof Date) ? d : new Date(d);
+  if (isNaN(dt.getTime())) return String(d);
+  return `${dt.getFullYear()}-${String(dt.getMonth()+1).padStart(2,'0')}-${String(dt.getDate()).padStart(2,'0')}`;
+};
+
+const pad2 = (n) => String(n).padStart(2, '0');
+
+/**
+ * Build the workbook in memory. Returns the ExcelJS.Workbook so callers
+ * can stream it as a buffer via `workbook.xlsx.writeBuffer()`.
+ *
+ * @param {object} v2   The full v2 response (with .meta + .lines).
+ *                      .lines may include subtotal rows (from buildSubtotals).
+ * @param {object} [opts]
+ * @param {string} [opts.tenantCode='UNKNOWN']  used in the file name and header
+ * @param {string} [opts.sheetName]             override the default sheet name
+ */
+export function buildWorkbook(v2, opts = {}) {
+  if (!v2 || !v2.meta) throw new Error('buildWorkbook: v2.meta is required');
+  const { tenantCode = 'UNKNOWN' } = opts;
+  const meta = v2.meta;
+  const lines = v2.lines || [];
+  const warnings = meta.warnings || [];
+
+  const wb = new ExcelJS.Workbook();
+  wb.creator = 'kaikei';
+  wb.created = new Date();
+  wb.modified = new Date();
+
+  const sheetName = opts.sheetName || `試算表_${meta.reportType || 'balance'}`;
+  const ws = wb.addWorksheet(sheetName, {
+    views: [{ state: 'normal', showGridLines: false }],
+  });
+
+  // Column widths.
+  ws.columns = COLS.map((c) => ({ width: c.width }));
+
+  // ---- Header rows (1-3) ----
+  const r1 = ws.getRow(1);
+  r1.getCell(1).value = `Tenant: ${tenantCode}  /  Term: ${meta.term}`;
+  r1.getCell(7).value = `Period: ${meta.period?.label || 'full'}  (${formatDate(meta.period?.from)} 〜 ${formatDate(meta.period?.to)})`;
+  r1.font = { bold: true };
+  r1.commit();
+
+  const r2 = ws.getRow(2);
+  r2.getCell(1).value = `Report: ${meta.reportType}`;
+  r2.getCell(3).value = `Language: ${meta.languageMode || 'ja'}`;
+  r2.getCell(7).value = `Generated: ${formatDate(meta.generatedAt)} ${pad2(new Date(meta.generatedAt).getHours())}:${pad2(new Date(meta.generatedAt).getMinutes())}`;
+  r2.commit();
+
+  const r3 = ws.getRow(3);
+  r3.getCell(1).value = `W001 critical does NOT block export (phase 1 per initiative §1.6)`;
+  r3.font = { italic: true, color: { argb: 'FF888888' } };
+  r3.commit();
+
+  // ---- Column headers (row 4) ----
+  const header = ws.getRow(4);
+  COLS.forEach((c, i) => { header.getCell(i + 1).value = c.header; });
+  header.font = { bold: true };
+  header.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFEEEEEE' } };
+  header.commit();
+
+  // ---- Data rows (5+) ----
+  let rowIdx = 5;
+  for (const l of lines) {
+    const row = ws.getRow(rowIdx);
+    const isSub = l.type === 'subtotal';
+    const isParent = l.type === 'parent';
+    const isSubAcc = l.type === 'subAccount';
+    const codeCell = isSub
+      ? `【${l.level}】`
+      : isParent
+        ? l.code
+        : isSubAcc
+          ? `${l.code}-${l.subCode}`
+          : (l.code || '');
+    const nameCell = isSub
+      ? (l.name || '')
+      : isParent
+        ? (l.name || '')
+        : isSubAcc
+          ? `  └ ${l.subName || ''}`
+          : (l.name || '');
+    row.getCell(1).value = codeCell;
+    row.getCell(2).value = nameCell;
+    row.getCell(3).value = l.openingDebit || 0;
+    row.getCell(4).value = l.openingCredit || 0;
+    row.getCell(5).value = l.movementDebit || 0;
+    row.getCell(6).value = l.movementCredit || 0;
+    row.getCell(7).value = l.endingDebit || 0;
+    row.getCell(8).value = l.endingCredit || 0;
+    row.getCell(9).value = l.balance || 0;
+    for (let c = 3; c <= 9; c += 1) {
+      row.getCell(c).numFmt = NUM_FMT;
+      row.getCell(c).alignment = { horizontal: 'right' };
+    }
+    if (isSub || isParent) {
+      row.font = { bold: true };
+      row.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF3F3F3' } };
+    }
+    if ((l.warningCodes || []).some((c) => c === 'TB-W005')) {
+      row.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFDE7E7' } };
+    }
+    rowIdx += 1;
+  }
+
+  // ---- Totals row ----
+  const totals = meta.totals || {};
+  const tr = ws.getRow(rowIdx);
+  tr.getCell(1).value = 'TOTAL';
+  tr.getCell(2).value = '';
+  tr.getCell(3).value = totals.openingDebit || 0;
+  tr.getCell(4).value = totals.openingCredit || 0;
+  tr.getCell(5).value = totals.movementDebit || 0;
+  tr.getCell(6).value = totals.movementCredit || 0;
+  tr.getCell(7).value = totals.endingDebit || 0;
+  tr.getCell(8).value = totals.endingCredit || 0;
+  tr.getCell(9).value = (totals.endingDebit || 0) - (totals.endingCredit || 0);
+  for (let c = 3; c <= 9; c += 1) {
+    tr.getCell(c).numFmt = NUM_FMT;
+    tr.getCell(c).alignment = { horizontal: 'right' };
+  }
+  tr.font = { bold: true };
+  tr.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFD9EAD3' } };
+
+  // ---- Warnings sheet ----
+  if (warnings.length > 0) {
+    const wsW = wb.addWorksheet('Warnings');
+    wsW.columns = [
+      { header: 'Code', width: 10 },
+      { header: 'Severity', width: 10 },
+      { header: 'Title (ja)', width: 32 },
+      { header: 'Title (vi)', width: 32 },
+      { header: 'Detail', width: 48 },
+    ];
+    wsW.getRow(1).font = { bold: true };
+    wsW.getRow(1).values = ['Code', 'Severity', 'Title (ja)', 'Title (vi)', 'Detail'];
+    let wRow = 2;
+    for (const w of warnings) {
+      wsW.getRow(wRow).values = [w.code, w.severity, w.title || '', w.titleVi || '', JSON.stringify(w.detail || {})];
+      wRow += 1;
+    }
+  }
+
+  return wb;
+}
+
+/**
+ * Convenience: build the workbook AND return the xlsx Buffer.
+ */
+export async function buildXlsxBuffer(v2, opts) {
+  const wb = buildWorkbook(v2, opts);
+  return wb.xlsx.writeBuffer();
+}
+
+/**
+ * File name: `trial_balance_{tenantCode}_{term}_{YYYYMMDDHHmm}.xlsx`.
+ */
+export function fileNameFor({ tenantCode = 'UNKNOWN', term, when = new Date() }) {
+  const y = when.getFullYear();
+  const mo = pad2(when.getMonth() + 1);
+  const d = pad2(when.getDate());
+  const h = pad2(when.getHours());
+  const mi = pad2(when.getMinutes());
+  return `trial_balance_${tenantCode}_${term}_${y}${mo}${d}${h}${mi}.xlsx`;
+}
+
+export { COLS, NUM_FMT };

--- a/routes/api_trial_balance.js
+++ b/routes/api_trial_balance.js
@@ -1,6 +1,9 @@
 import trial_balance from '../libs/trial_balance.js';
 import models from '../models/index.js';
 import { trialBalanceV2 } from '../libs/reporting/trial-balance-v2.js';
+import { buildSubtotals } from '../libs/reporting/tb-subtotal.js';
+import { withAccountParents } from '../libs/reporting/tb-hierarchy.js';
+import { buildXlsxBuffer, fileNameFor } from '../libs/reporting/tb-export.js';
 
 const parseBool = (v, dflt = false) => {
   if (v == null) return dflt;
@@ -63,6 +66,65 @@ export default {
           models,
         );
         return res.json(out);
+      }
+
+      // Branch: ?format=xlsx → Excel export (E1.7). Same v2 contract, but
+      // the response is application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+      // with a Content-Disposition file name.
+      if (req.query.format === 'xlsx') {
+        let term;
+        const param = req.params.param;
+        let ym;
+        if (param) {
+          const params = param.split('-');
+          if (params[1]) {
+            ym = params;
+            if (!req.session || !req.session.term) {
+              return res.status(401).json({ error: 'Unauthorized: term not set in session.' });
+            }
+            term = req.session.term;
+          } else {
+            term = parseInt(params[0], 10);
+          }
+        } else {
+          if (!req.session || !req.session.term) {
+            return res.status(401).json({ error: 'Unauthorized: term not set in session.' });
+          }
+          term = req.session.term;
+        }
+        const month = req.query.month || (ym ? `${ym[0]}-${String(ym[1]).padStart(2, '0')}` : null);
+        const reportType = req.query.reportType || 'balance';
+        const accountClassIds = parseCsv(req.query.accountClassIds);
+        const hideZero = parseBool(req.query.hideZero);
+        const includeUnapproved = parseBool(req.query.includeUnapproved, false);
+        const lp = req.query.languagePair ? JSON.parse(req.query.languagePair) : req.session?.languagePair;
+
+        const v2 = await trialBalanceV2(
+          {
+            tenantId, term, reportType, month,
+            accountClassIds, hideZero, includeUnapproved,
+            languagePair: lp,
+          },
+          models,
+        );
+        // Insert subtotals + parent rows so the sheet renders the 3-level
+        // hierarchy the user sees in the UI.
+        v2.lines = withAccountParents(buildSubtotals(v2.lines || []));
+
+        // Resolve tenantCode for the file name. Tenant model uses `name`
+        // (not `code`); sanitize for filesystem-safe filename.
+        const tenant = await models.Tenant.findOne({ where: { id: tenantId } });
+        const tenantCode = (tenant?.name || `tenant${tenantId}`).replace(/[^A-Za-z0-9_-]/g, '_');
+        const buf = await buildXlsxBuffer(v2, { tenantCode });
+        res.setHeader(
+          'Content-Type',
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        );
+        res.setHeader(
+          'Content-Disposition',
+          `attachment; filename="${fileNameFor({ tenantCode, term, when: new Date() })}"`
+        );
+        return res.send(Buffer.from(buf));
       }
 
       // Legacy path (no version param, or version=1).

--- a/test/reporting/tb-export.test.mjs
+++ b/test/reporting/tb-export.test.mjs
@@ -1,0 +1,211 @@
+/**
+ * Unit tests — Issue #213 (E1.7): libs/reporting/tb-export.js
+ *
+ * Run with: npx mocha test/reporting/tb-export.test.mjs
+ */
+
+import { strict as assert } from 'node:assert';
+import {
+  buildWorkbook,
+  buildXlsxBuffer,
+  fileNameFor,
+  COLS,
+  NUM_FMT,
+} from '../../libs/reporting/tb-export.js';
+
+const v2 = (over = {}) => ({
+  version: 2,
+  meta: {
+    tenantId: 1,
+    term: 1,
+    reportType: 'balance',
+    period: { from: new Date('2026-01-01'), to: new Date('2026-12-31'), label: 'full' },
+    fiscalYear: { start: new Date('2026-01-01'), end: new Date('2026-12-31') },
+    languageMode: 'ja',
+    generatedAt: new Date('2026-06-07T12:00:00'),
+    warnings: [],
+    totals: {
+      openingDebit: 100, openingCredit: 0,
+      movementDebit: 230, movementCredit: 200,
+      endingDebit: 130, endingCredit: 0,
+    },
+    filters: { accountClassIds: [], hideZero: false, includeUnapproved: false, month: null },
+    ...(over.meta || {}),
+  },
+  lines: over.lines || [
+    { type: 'subtotal', level: 'major', name: '資産', balance: 100, openingDebit: 100, endingDebit: 100, warningCodes: [] },
+    { type: 'account', code: '1000000', name: '現金', openingDebit: 100, movementDebit: 230, movementCredit: 200, endingDebit: 130, balance: 130, warningCodes: [] },
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// buildWorkbook
+// ---------------------------------------------------------------------------
+
+describe('buildWorkbook', () => {
+  it('throws when meta is missing', () => {
+    assert.throws(() => buildWorkbook({}), /meta is required/);
+  });
+
+  it('returns an ExcelJS.Workbook with the data sheet', () => {
+    const wb = buildWorkbook(v2(), { tenantCode: 'T1' });
+    const sheets = wb.worksheets.map((w) => w.name);
+    assert.ok(sheets.includes('試算表_balance'), `sheets: ${sheets.join(', ')}`);
+  });
+
+  it('data sheet has 4 header rows then 1 subtotal + 1 account + 1 totals', () => {
+    const wb = buildWorkbook(v2(), { tenantCode: 'T1' });
+    const ws = wb.worksheets[0];
+    // 4 header rows + 2 data rows + 1 totals row = 7
+    assert.equal(ws.rowCount, 7, `rowCount = ${ws.rowCount}`);
+  });
+
+  it('data sheet column headers in row 4', () => {
+    const wb = buildWorkbook(v2(), { tenantCode: 'T1' });
+    const ws = wb.worksheets[0];
+    const r = ws.getRow(4);
+    assert.equal(r.getCell(1).value, COLS[0].header);
+    assert.equal(r.getCell(2).value, COLS[1].header);
+    assert.equal(r.getCell(9).value, COLS[8].header);
+    assert.equal(r.font.bold, true);
+  });
+
+  it('data rows have number format on numeric columns', () => {
+    const wb = buildWorkbook(v2(), { tenantCode: 'T1' });
+    const ws = wb.worksheets[0];
+    const r = ws.getRow(5); // first data row (subtotal)
+    for (let c = 3; c <= 9; c += 1) {
+      assert.equal(r.getCell(c).numFmt, NUM_FMT);
+    }
+  });
+
+  it('subtotal row has bold + grey fill', () => {
+    const wb = buildWorkbook(v2(), { tenantCode: 'T1' });
+    const ws = wb.worksheets[0];
+    const r = ws.getRow(5);
+    assert.equal(r.font.bold, true);
+    assert.ok(r.fill && r.fill.fgColor);
+  });
+
+  it('account row not bold by default', () => {
+    const wb = buildWorkbook(v2(), { tenantCode: 'T1' });
+    const ws = wb.worksheets[0];
+    const r = ws.getRow(6);
+    assert.ok(!r.font || r.font.bold !== true, 'account row should not be bold');
+  });
+
+  it('account code + name written into columns 1 + 2', () => {
+    const wb = buildWorkbook(v2(), { tenantCode: 'T1' });
+    const ws = wb.worksheets[0];
+    const r = ws.getRow(6);
+    assert.equal(r.getCell(1).value, '1000000');
+    assert.equal(r.getCell(2).value, '現金');
+  });
+
+  it('subAccount row formats code as `${code}-${subCode}`', () => {
+    const data = v2({ lines: [
+      { type: 'subAccount', code: '3050000', subCode: 2, subName: 'A社', balance: 50, warningCodes: [] },
+    ] });
+    const wb = buildWorkbook(data);
+    const ws = wb.worksheets[0];
+    // row 5 = sub account data
+    const r = ws.getRow(5);
+    assert.equal(r.getCell(1).value, '3050000-2');
+    assert.match(r.getCell(2).value, /A社/);
+  });
+
+  it('parent row: code in col 1, name in col 2 (no subCode)', () => {
+    const data = v2({ lines: [
+      { type: 'parent', code: '3050000', name: '買掛金', balance: 50, warningCodes: [] },
+    ] });
+    const wb = buildWorkbook(data);
+    const ws = wb.worksheets[0];
+    const r = ws.getRow(5);
+    assert.equal(r.getCell(1).value, '3050000');
+    assert.equal(r.getCell(2).value, '買掛金');
+  });
+
+  it('TB-W005 line gets red fill', () => {
+    const data = v2({ lines: [
+      { type: 'account', code: '1000000', name: '現金', balance: -50, endingDebit: 0, endingCredit: 50, warningCodes: ['TB-W005'] },
+    ] });
+    const wb = buildWorkbook(data);
+    const ws = wb.worksheets[0];
+    const r = ws.getRow(5);
+    assert.ok(r.fill && r.fill.fgColor);
+  });
+
+  it('totals row in last position with TOTAL label', () => {
+    const data = v2({ lines: [{ type: 'account', code: '1000000', name: '現金', balance: 100, warningCodes: [] }] });
+    const wb = buildWorkbook(data);
+    const ws = wb.worksheets[0];
+    const last = ws.getRow(ws.rowCount);
+    assert.equal(last.getCell(1).value, 'TOTAL');
+    assert.equal(last.font.bold, true);
+    assert.equal(last.getCell(5).value, 230);  // movementDebit from meta
+    assert.equal(last.getCell(9).value, 130);  // endingDebit - endingCredit
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warnings sheet
+// ---------------------------------------------------------------------------
+
+describe('buildWorkbook — warnings sheet', () => {
+  it('no warnings → no Warnings sheet', () => {
+    const wb = buildWorkbook(v2());
+    assert.equal(wb.worksheets.length, 1);
+  });
+
+  it('with warnings → second sheet "Warnings" with rows', () => {
+    const data = v2();
+    data.meta.warnings = [
+      { code: 'TB-W001', severity: 'critical', title: '借方合計 ≠ 貸方合計', titleVi: 'Tổng Nợ ≠ Tổng Có', detail: { diff: 10 } },
+      { code: 'TB-W002', severity: 'high', title: '未承認', titleVi: 'Chưa duyệt', detail: { count: 3 } },
+    ];
+    const wb = buildWorkbook(data);
+    assert.equal(wb.worksheets.length, 2);
+    const wsW = wb.worksheets[1];
+    assert.equal(wsW.name, 'Warnings');
+    // 1 header + 2 data rows
+    assert.equal(wsW.rowCount, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildXlsxBuffer
+// ---------------------------------------------------------------------------
+
+describe('buildXlsxBuffer', () => {
+  it('returns a non-empty Buffer', async () => {
+    const buf = await buildXlsxBuffer(v2(), { tenantCode: 'T1' });
+    assert.ok(buf);
+    // exceljs returns an ArrayBuffer-like in node; check size
+    const size = buf.byteLength || buf.length || 0;
+    assert.ok(size > 0, `expected non-empty buffer, got ${size} bytes`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fileNameFor
+// ---------------------------------------------------------------------------
+
+describe('fileNameFor', () => {
+  it('formats tenantCode + term + YYYYMMDDHHmm', () => {
+    const fn = fileNameFor({
+      tenantCode: 'T1',
+      term: 5,
+      when: new Date(2026, 5, 7, 12, 34),
+    });
+    assert.equal(fn, 'trial_balance_T1_5_202606071234.xlsx');
+  });
+
+  it('zero-pads month/day/hour/minute', () => {
+    const fn = fileNameFor({
+      tenantCode: 'X',
+      term: 1,
+      when: new Date(2026, 0, 3, 4, 5),
+    });
+    assert.equal(fn, 'trial_balance_X_1_202601030405.xlsx');
+  });
+});


### PR DESCRIPTION
Part of #206 (E01 trial balance epic)

### Summary
- `libs/reporting/tb-export.js` — pure workbook builder (exceljs).
- `routes/api_trial_balance.js` — `?format=xlsx` branch, returns `application/vnd.openxmlformats...`.
- View — `Excel出力` button.

### Behavior
- 2 sheets: 試算表_<reportType> + Warnings (if any).
- Number format `#,##0;[Red]-#,##0` (BRD 10.11).
- W001 phase 1 does NOT block export (per initiative).
- W005 lines get red fill.
- File name: `trial_balance_{tenantName}_{term}_{YYYYMMDDHHmm}.xlsx`.

### Test Report
- `npm run build` ✅
- 160 unit tests pass (E0 36 + v2 29 + subtotal 19 + hierarchy 21 + warnings 17 + export 17+21 = 160; new 17 in this issue).
- Coverage: header layout, column headers, number format, subtotal/parent/account/subAccount row styles, W005 red fill, totals row, warnings sheet, buffer generation, file name format.

### Out of scope
- PDF export (phase 2 per initiative — `forms/trial-balance` + `libs/print.js` exist)
- Server-side streaming (response is in-memory; OK for the small data set here)