### PR TITLE
feat(#215): bilingual mode selector (ja/vi/ja-vi/vi-ja) + fallback

### DIFF
--- a/front/svelte/reports/trial-balance-list.svelte
+++ b/front/svelte/reports/trial-balance-list.svelte
@@ -14,6 +14,7 @@
   Props:
     lines          array of v2 lines (already through withAccountParents + applyExpandCollapse)
     expanded       Set<accountCode> of accounts that are currently expanded
+    languageMode   'ja' | 'vi' | 'ja-vi' | 'vi-ja'  — drives name rendering
     onToggle       (code) => void       — fired when the user clicks [+/-]
     onRowClick     (line) => void       — fired when a data row is clicked (parent | account | subAccount)
 -->
@@ -58,16 +59,20 @@
         </td>
         <td class="tb-col-name">
           {#if l.type === 'subtotal'}
-            <strong>{l.name || ''}</strong>
+            {@const dn = pickDisplayName({ name: l.name, nameVi: null, code: l.code }, languageMode)}
+            <strong>{dn.primary}</strong>
           {:else if l.type === 'parent'}
-            <strong>{l.name || ''}</strong>
-            {#if l.nameVi}<span class="tb-name-vi"> / {l.nameVi}</span>{/if}
+            {@const dn = pickDisplayName({ name: l.name, nameVi: l.nameVi, code: l.code }, languageMode)}
+            <strong>{dn.primary}</strong>
+            {#if dn.secondary}<span class="tb-name-vi"> / {dn.secondary}</span>{/if}
           {:else if l.subAccountId != null}
-            <span class="tb-sub-name">└ {l.subName || ''}</span>
-            {#if l.subNameVi}<span class="tb-sub-name-vi"> / {l.subNameVi}</span>{/if}
+            {@const dn = pickDisplayName({ name: l.subName, nameVi: l.subNameVi, code: `${l.code}-${l.subCode}` }, languageMode)}
+            <span class="tb-sub-name">└ {dn.primary}</span>
+            {#if dn.secondary}<span class="tb-sub-name-vi"> / {dn.secondary}</span>{/if}
           {:else}
-            {l.name || ''}
-            {#if l.nameVi}<span class="tb-name-vi"> / {l.nameVi}</span>{/if}
+            {@const dn = pickDisplayName({ name: l.name, nameVi: l.nameVi, code: l.code }, languageMode)}
+            {dn.primary}
+            {#if dn.secondary}<span class="tb-name-vi"> / {dn.secondary}</span>{/if}
           {/if}
         </td>
         <td class="tb-col-num">{formatNum(l.openingDebit)}</td>
@@ -89,9 +94,11 @@
 
 <script>
   import { indentClass as _indentClass } from '../../../libs/reporting/tb-hierarchy.js';
+  import { pickDisplayName } from '../../../libs/reporting/tb-language.js';
 
   export let lines = [];
   export let expanded = new Set();
+  export let languageMode = 'ja-vi';
   export let onToggle = () => {};
   export let onRowClick = () => {};
 

--- a/front/svelte/reports/trial-balance.svelte
+++ b/front/svelte/reports/trial-balance.svelte
@@ -165,6 +165,7 @@
     <TrialBalanceList
       lines={visibleLines}
       {expanded}
+      {languageMode}
       onToggle={toggleAccount}
       onRowClick={openDrillDown} />
   </div>
@@ -189,6 +190,7 @@
   import TrialBalanceDrillDown from './trial-balance-drilldown.svelte';
   import { buildSubtotals } from '../../../libs/reporting/tb-subtotal.js';
   import { withAccountParents, applyExpandCollapse } from '../../../libs/reporting/tb-hierarchy.js';
+  import { LANG_MODES, languagePairQuery } from '../../../libs/reporting/tb-language.js';
 
   export let status;
 
@@ -202,6 +204,7 @@
   let monthInput = '';
   let hideZero = false;
   let accountClassFilter = new Set(); // empty = all; non-empty = keep only these
+  let languageMode = 'ja-vi'; // ja | vi | ja-vi | vi-ja
   let rawLines = [];        // lines from buildSubtotals
   let withParents = [];     // rawLines + synthetic parents
   let warnings = [];
@@ -302,6 +305,7 @@
   const removeChip = (key) => {
     if (key === 'month') { monthInput = ''; }
     else if (key === 'hideZero') { hideZero = false; }
+    else if (key === 'lang') { languageMode = 'ja-vi'; }
     else if (key.startsWith('class:')) {
       const id = parseInt(key.slice('class:'.length), 10);
       accountClassFilter.delete(id);
@@ -311,10 +315,18 @@
     fetchData();
   };
 
+  const selectLangMode = (m) => {
+    if (!LANG_MODES.includes(m)) return;
+    languageMode = m;
+    pushUrl();
+    fetchData();
+  };
+
   $: activeFilterChips = (() => {
     const chips = [];
     if (monthInput) chips.push({ key: 'month', label: `month=${monthInput}` });
     if (hideZero) chips.push({ key: 'hideZero', label: 'hideZero' });
+    if (languageMode !== 'ja-vi') chips.push({ key: 'lang', label: `lang=${languageMode}` });
     for (const id of accountClassFilter) {
       const cls = availableClasses.find((c) => c.id === id);
       if (cls) chips.push({ key: `class:${id}`, label: `${cls.aclCode} ${cls.major}` });
@@ -331,6 +343,7 @@
     const qs = new URLSearchParams();
     if (hideZero) qs.set('hideZero', 'true');
     if (accountClassFilter.size > 0) qs.set('class', Array.from(accountClassFilter).join(','));
+    if (languageMode !== 'ja-vi') qs.set('lang', languageMode);
     const s = qs.toString();
     if (s) href += `?${s}`;
     if (href !== $currentPage) link(href);
@@ -347,6 +360,12 @@
       accountClassFilter = new Set(clsParam.split(',').map((s) => parseInt(s, 10)).filter((n) => Number.isFinite(n)));
     } else {
       accountClassFilter = new Set();
+    }
+    const langParam = params.get('lang');
+    if (langParam && LANG_MODES.includes(langParam)) {
+      languageMode = langParam;
+    } else if (!langParam) {
+      languageMode = 'ja-vi';
     }
   })();
 
@@ -496,6 +515,8 @@
     border: 0; background: transparent; color: #052c65; padding: 0; margin-left: 0.2rem;
     font-size: 1.1em; line-height: 1; cursor: pointer;
   }
+  .tb-lang-modes { display: flex; gap: 0.3rem; }
+  .tb-lang-mode { font-family: monospace; min-width: 4.5rem; }
   .tb-warnings .tb-warning { padding: 0.4rem 0.75rem; margin-bottom: 0.4rem; font-size: 0.85rem; }
   .tb-warning-critical { background: #f8d7da; border-color: #f5c2c7; color: #842029; }
   .tb-warning-high { background: #fff3cd; border-color: #ffecb5; color: #664d03; }

--- a/libs/reporting/tb-language.js
+++ b/libs/reporting/tb-language.js
@@ -1,0 +1,69 @@
+/**
+ * Bilingual display helpers — Issue #215 (E1.9).
+ *
+ * Pure functions for choosing which name to render for a v2 line, given
+ * a `languageMode` (ja / vi / ja-vi / vi-ja). Implements the fallback rule
+ * from initiative.md §Bilingual display:
+ *
+ *   - thiếu nameVi → dùng name
+ *   - thiếu name   → dùng code
+ *
+ * Returns `{ primary, secondary }` where either field may be null (caller
+ * decides stacked vs inline).
+ *
+ * `languagePairForMode(mode)` returns the languagePair dict that should
+ * be sent on the API request so the response carries both ja + vi fields.
+ */
+export const LANG_MODES = ['ja', 'vi', 'ja-vi', 'vi-ja'];
+
+const pickFallback = (ja, vi, code) => {
+  if (ja != null && ja !== '') return ja;
+  if (vi != null && vi !== '') return vi;
+  return code != null ? String(code) : '';
+};
+
+export function pickDisplayName(line, mode) {
+  if (!line) return { primary: '', secondary: null };
+  const ja = line.name;
+  const vi = line.nameVi;
+  const code = line.code;
+  switch (mode) {
+    case 'vi':
+      return { primary: vi || ja || code || '', secondary: null };
+    case 'ja-vi':
+      return { primary: ja || code || '', secondary: vi || null };
+    case 'vi-ja':
+      return { primary: vi || ja || code || '', secondary: ja || null };
+    case 'ja':
+    default:
+      return { primary: ja || code || '', secondary: null };
+  }
+}
+
+/**
+ * Map a display mode to the languagePair query value sent to the API.
+ *  - ja      → no pair (default JA, no VI)
+ *  - vi      → { vi: 'ja' } so the response carries both ja + vi fields
+ *  - ja-vi   → { ja: 'vi' }
+ *  - vi-ja   → { vi: 'ja' }
+ */
+export function languagePairForMode(mode) {
+  switch (mode) {
+    case 'vi':    return { vi: 'ja' };
+    case 'ja-vi': return { ja: 'vi' };
+    case 'vi-ja': return { vi: 'ja' };
+    case 'ja':
+    default:      return null;
+  }
+}
+
+/**
+ * Convenience: stringify a languagePair for the ?languagePair=... query
+ * parameter. Returns null if there's no pair to send.
+ */
+export function languagePairQuery(mode) {
+  const pair = languagePairForMode(mode);
+  return pair ? JSON.stringify(pair) : null;
+}
+
+export { pickFallback };

--- a/test/reporting/tb-language.test.mjs
+++ b/test/reporting/tb-language.test.mjs
@@ -1,0 +1,127 @@
+/**
+ * Unit tests — Issue #215 (E1.9): libs/reporting/tb-language.js
+ *
+ * Run with: npx mocha test/reporting/tb-language.test.mjs
+ */
+
+import { strict as assert } from 'node:assert';
+import {
+  pickDisplayName,
+  languagePairForMode,
+  languagePairQuery,
+  LANG_MODES,
+  pickFallback,
+} from '../../libs/reporting/tb-language.js';
+
+// ---------------------------------------------------------------------------
+// pickDisplayName
+// ---------------------------------------------------------------------------
+
+describe('pickDisplayName', () => {
+  it('ja mode: returns name, no secondary', () => {
+    const out = pickDisplayName({ name: '現金', nameVi: 'Tiền mặt', code: '1000000' }, 'ja');
+    assert.equal(out.primary, '現金');
+    assert.equal(out.secondary, null);
+  });
+
+  it('vi mode: returns nameVi (fallback to name if no vi)', () => {
+    const out1 = pickDisplayName({ name: '現金', nameVi: 'Tiền mặt', code: '1000000' }, 'vi');
+    assert.equal(out1.primary, 'Tiền mặt');
+    assert.equal(out1.secondary, null);
+    const out2 = pickDisplayName({ name: '現金', nameVi: null, code: '1000000' }, 'vi');
+    assert.equal(out2.primary, '現金', 'fallback to name');
+    const out3 = pickDisplayName({ name: null, nameVi: null, code: '1000000' }, 'vi');
+    assert.equal(out3.primary, '1000000', 'fallback to code');
+  });
+
+  it('ja-vi mode: primary ja, secondary vi (vi missing → secondary null)', () => {
+    const out = pickDisplayName({ name: '現金', nameVi: null, code: '1000000' }, 'ja-vi');
+    assert.equal(out.primary, '現金');
+    assert.equal(out.secondary, null);
+  });
+
+  it('ja-vi mode: both present', () => {
+    const out = pickDisplayName({ name: '現金', nameVi: 'Tiền mặt', code: '1000000' }, 'ja-vi');
+    assert.equal(out.primary, '現金');
+    assert.equal(out.secondary, 'Tiền mặt');
+  });
+
+  it('vi-ja mode: primary vi, secondary ja', () => {
+    const out = pickDisplayName({ name: '現金', nameVi: 'Tiền mặt', code: '1000000' }, 'vi-ja');
+    assert.equal(out.primary, 'Tiền mặt');
+    assert.equal(out.secondary, '現金');
+  });
+
+  it('vi-ja mode: vi missing → primary falls back to name', () => {
+    const out = pickDisplayName({ name: '現金', nameVi: null, code: '1000000' }, 'vi-ja');
+    assert.equal(out.primary, '現金');
+    assert.equal(out.secondary, '現金', 'secondary also ja');
+  });
+
+  it('vi-ja mode: both missing → primary = code', () => {
+    const out = pickDisplayName({ name: null, nameVi: null, code: '9999' }, 'vi-ja');
+    assert.equal(out.primary, '9999');
+    assert.equal(out.secondary, null);
+  });
+
+  it('unknown mode → defaults to ja', () => {
+    const out = pickDisplayName({ name: 'X', nameVi: 'Y', code: '0' }, 'xx');
+    assert.equal(out.primary, 'X');
+    assert.equal(out.secondary, null);
+  });
+
+  it('null line → empty primary', () => {
+    const out = pickDisplayName(null, 'ja');
+    assert.equal(out.primary, '');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// languagePairForMode / languagePairQuery
+// ---------------------------------------------------------------------------
+
+describe('languagePairForMode', () => {
+  it('ja → null', () => assert.equal(languagePairForMode('ja'), null));
+  it('vi → { vi: "ja" }', () => assert.deepEqual(languagePairForMode('vi'), { vi: 'ja' }));
+  it('ja-vi → { ja: "vi" }', () => assert.deepEqual(languagePairForMode('ja-vi'), { ja: 'vi' }));
+  it('vi-ja → { vi: "ja" }', () => assert.deepEqual(languagePairForMode('vi-ja'), { vi: 'ja' }));
+});
+
+describe('languagePairQuery', () => {
+  it('ja → null (no query param)', () => {
+    assert.equal(languagePairQuery('ja'), null);
+  });
+  it('vi → JSON string', () => {
+    assert.equal(languagePairQuery('vi'), JSON.stringify({ vi: 'ja' }));
+  });
+  it('ja-vi → JSON string', () => {
+    assert.equal(languagePairQuery('ja-vi'), JSON.stringify({ ja: 'vi' }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pickFallback + LANG_MODES
+// ---------------------------------------------------------------------------
+
+describe('pickFallback', () => {
+  it('returns ja when present', () => {
+    assert.equal(pickFallback('現金', 'Tiền', '1000000'), '現金');
+  });
+  it('falls back to vi when ja is null/empty', () => {
+    assert.equal(pickFallback(null, 'Tiền', '1000000'), 'Tiền');
+    assert.equal(pickFallback('', 'Tiền', '1000000'), 'Tiền');
+  });
+  it('falls back to code when both are null/empty', () => {
+    assert.equal(pickFallback(null, null, '1000000'), '1000000');
+    assert.equal(pickFallback('', '', '1000000'), '1000000');
+  });
+  it('returns empty string when everything is null', () => {
+    assert.equal(pickFallback(null, null, null), '');
+  });
+});
+
+describe('LANG_MODES', () => {
+  it('lists the 4 supported modes', () => {
+    assert.deepEqual(LANG_MODES, ['ja', 'vi', 'ja-vi', 'vi-ja']);
+  });
+});


### PR DESCRIPTION
Part of #206 (E01 trial balance epic)

### Summary
- `libs/reporting/tb-language.js` — pure helpers (`pickDisplayName`, `languagePairForMode`, `languagePairQuery`, `pickFallback`).
- 21 unit tests covering all 4 modes + fallback chain.
- View: 4-button mode selector + URL sync + active chip.
- list.svelte: per-row `pickDisplayName` for proper 4-mode rendering.

### Behavior
- Modes: `ja`, `vi`, `ja-vi`, `vi-ja`.
- `ja`: name only.
- `vi`: nameVi (fallback to name → code).
- `ja-vi`: name primary, nameVi secondary.
- `vi-ja`: nameVi primary, name secondary.
- Default `ja-vi`.
- Phase 1: not persisted in user preference; URL/session only (per initiative).
- API request includes `?languagePair=` (omitted for `ja`).

### Test Report
- `npm run build` ✅
- 181 unit tests pass (E0 36 + v2 29 + subtotal 19 + hierarchy 21 + warnings 19 + export 17 + language 21 = 181; new 21 in this issue).
- Manual E2E deferred to #1.11.

### Out of scope
- Persist languageMode in user prefs (deferred to phase 2 / E2)