### PR TITLE
feat(#229): simulation Scenario + Entry models + migrations

### DIFF
--- a/migrations/20260608000000-create-simulation-scenario.cjs
+++ b/migrations/20260608000000-create-simulation-scenario.cjs
@@ -1,0 +1,95 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('SimulationScenarios', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      tenantId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'Tenants', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'RESTRICT'
+      },
+      name: {
+        type: Sequelize.STRING(200),
+        allowNull: false
+      },
+      description: {
+        type: Sequelize.TEXT,
+        allowNull: true
+      },
+      baseTerm: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      basePeriodFrom: {
+        type: Sequelize.DATEONLY,
+        allowNull: false
+      },
+      basePeriodTo: {
+        type: Sequelize.DATEONLY,
+        allowNull: false
+      },
+      simPeriodFrom: {
+        type: Sequelize.DATEONLY,
+        allowNull: false
+      },
+      simPeriodTo: {
+        type: Sequelize.DATEONLY,
+        allowNull: false
+      },
+      status: {
+        type: Sequelize.STRING(16),
+        allowNull: false,
+        defaultValue: 'draft'
+      },
+      ownerId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'Users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'RESTRICT'
+      },
+      visibility: {
+        type: Sequelize.STRING(16),
+        allowNull: false,
+        defaultValue: 'private'
+      },
+      lockedAt: {
+        type: Sequelize.DATEONLY,
+        allowNull: true
+      },
+      lockedBy: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: { model: 'Users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL'
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+    await queryInterface.addIndex('SimulationScenarios', ['tenantId', 'status'], {
+      name: 'simulation_scenarios_tenant_status_idx'
+    });
+    await queryInterface.addIndex('SimulationScenarios', ['tenantId', 'ownerId'], {
+      name: 'simulation_scenarios_tenant_owner_idx'
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('SimulationScenarios');
+  }
+};

--- a/migrations/20260608000100-create-simulation-entry.cjs
+++ b/migrations/20260608000100-create-simulation-entry.cjs
@@ -1,0 +1,92 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('SimulationEntries', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      tenantId: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      scenarioId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'SimulationScenarios', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      date: {
+        type: Sequelize.DATEONLY,
+        allowNull: false
+      },
+      debitAccount: {
+        type: Sequelize.STRING(20),
+        allowNull: false
+      },
+      debitSubAccount: {
+        type: Sequelize.INTEGER,
+        allowNull: true
+      },
+      debitAmount: {
+        type: Sequelize.DECIMAL(12),
+        allowNull: false
+      },
+      creditAccount: {
+        type: Sequelize.STRING(20),
+        allowNull: false
+      },
+      creditSubAccount: {
+        type: Sequelize.INTEGER,
+        allowNull: true
+      },
+      creditAmount: {
+        type: Sequelize.DECIMAL(12),
+        allowNull: false
+      },
+      taxRuleId: {
+        type: Sequelize.INTEGER,
+        allowNull: true
+      },
+      projectId: {
+        type: Sequelize.INTEGER,
+        allowNull: true
+      },
+      labelId: {
+        type: Sequelize.INTEGER,
+        allowNull: true
+      },
+      memo: {
+        type: Sequelize.STRING(500),
+        allowNull: true
+      },
+      sourceType: {
+        type: Sequelize.STRING(16),
+        allowNull: false,
+        defaultValue: 'manual'
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+    await queryInterface.addIndex('SimulationEntries', ['scenarioId'], {
+      name: 'simulation_entries_scenario_idx'
+    });
+    await queryInterface.addIndex('SimulationEntries', ['tenantId'], {
+      name: 'simulation_entries_tenant_idx'
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('SimulationEntries');
+  }
+};

--- a/models/index.js
+++ b/models/index.js
@@ -24,6 +24,8 @@ import Sticky from './sticky.js';
 import StickyStatus from './stickystatus.js';
 import SubAccount from './subaccount.js';
 import SubAccountRemaining from './subaccountremaining.js';
+import SimulationScenario from './simulationscenario.js';
+import SimulationEntry from './simulationentry.js';
 import Task from './task.js';
 import TaskDetail from './task-detail.js';
 import TaxRule from './tax-rule.js';
@@ -78,6 +80,8 @@ const models = {
   StickyStatus: StickyStatus(sequelize, DataTypes),
   SubAccount: SubAccount(sequelize, DataTypes),
   SubAccountRemaining: SubAccountRemaining(sequelize, DataTypes),
+  SimulationScenario: SimulationScenario(sequelize, DataTypes),
+  SimulationEntry: SimulationEntry(sequelize, DataTypes),
   Task: Task(sequelize, DataTypes),
   TaskDetail: TaskDetail(sequelize, DataTypes),
   TaxRule: TaxRule(sequelize, DataTypes),

--- a/models/simulationentry.js
+++ b/models/simulationentry.js
@@ -1,0 +1,38 @@
+import {Model} from 'sequelize';
+
+export default (sequelize, DataTypes) => {
+  class SimulationEntry extends Model {
+    static associate(models) {
+      this.belongsTo(models.SimulationScenario, {
+        foreignKey: 'scenarioId',
+        as: 'scenario',
+        onDelete: 'cascade',
+        onUpdate: 'cascade'
+      });
+      this.belongsTo(models.Tenant, {
+        foreignKey: 'tenantId',
+        as: 'tenant'
+      });
+    }
+  };
+  SimulationEntry.init({
+    tenantId: { type: DataTypes.INTEGER, allowNull: false },
+    scenarioId: { type: DataTypes.INTEGER, allowNull: false },
+    date: { type: DataTypes.DATEONLY, allowNull: false },
+    debitAccount: { type: DataTypes.STRING(20), allowNull: false },
+    debitSubAccount: { type: DataTypes.INTEGER, allowNull: true },
+    debitAmount: { type: DataTypes.DECIMAL(12), allowNull: false },
+    creditAccount: { type: DataTypes.STRING(20), allowNull: false },
+    creditSubAccount: { type: DataTypes.INTEGER, allowNull: true },
+    creditAmount: { type: DataTypes.DECIMAL(12), allowNull: false },
+    taxRuleId: { type: DataTypes.INTEGER, allowNull: true },
+    projectId: { type: DataTypes.INTEGER, allowNull: true },
+    labelId: { type: DataTypes.INTEGER, allowNull: true },
+    memo: { type: DataTypes.STRING(500), allowNull: true },
+    sourceType: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'manual' },
+  }, {
+    sequelize,
+    modelName: 'SimulationEntry',
+  });
+  return SimulationEntry;
+};

--- a/models/simulationscenario.js
+++ b/models/simulationscenario.js
@@ -1,0 +1,45 @@
+import {Model} from 'sequelize';
+
+export default (sequelize, DataTypes) => {
+  class SimulationScenario extends Model {
+    static associate(models) {
+      this.hasMany(models.SimulationEntry, {
+        foreignKey: 'scenarioId',
+        as: 'entries',
+        onDelete: 'cascade',
+        onUpdate: 'cascade'
+      });
+      this.belongsTo(models.Tenant, {
+        foreignKey: 'tenantId',
+        as: 'tenant'
+      });
+      this.belongsTo(models.User, {
+        foreignKey: 'ownerId',
+        as: 'owner'
+      });
+      this.belongsTo(models.User, {
+        foreignKey: 'lockedBy',
+        as: 'locker'
+      });
+    }
+  };
+  SimulationScenario.init({
+    tenantId: { type: DataTypes.INTEGER, allowNull: false },
+    name: { type: DataTypes.STRING(200), allowNull: false },
+    description: DataTypes.TEXT,
+    baseTerm: { type: DataTypes.INTEGER, allowNull: false },
+    basePeriodFrom: { type: DataTypes.DATEONLY, allowNull: false },
+    basePeriodTo: { type: DataTypes.DATEONLY, allowNull: false },
+    simPeriodFrom: { type: DataTypes.DATEONLY, allowNull: false },
+    simPeriodTo: { type: DataTypes.DATEONLY, allowNull: false },
+    status: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'draft' },
+    ownerId: { type: DataTypes.INTEGER, allowNull: false },
+    visibility: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'private' },
+    lockedAt: { type: DataTypes.DATEONLY, allowNull: true },
+    lockedBy: { type: DataTypes.INTEGER, allowNull: true },
+  }, {
+    sequelize,
+    modelName: 'SimulationScenario',
+  });
+  return SimulationScenario;
+};

--- a/test/simulation/simulation-models.test.mjs
+++ b/test/simulation/simulation-models.test.mjs
@@ -1,0 +1,155 @@
+/**
+ * Simulation models — Issue #229 (E2.1).
+ *
+ * Verifies:
+ *   1. SimulationScenario + SimulationEntry models load and expose the schema
+ *      documented in `docs/stories/epics/E02-simulation/initiative.md`.
+ *   2. Associations are wired (Scenario hasMany Entry, Entry belongsTo Scenario).
+ *   3. tenantId is required on both models (NOT NULL enforced at app layer).
+ *   4. CRUD round-trip on the live test DB (no stub).
+ *
+ * Requires a live, migrated Postgres test DB. Run with: npm test
+ */
+
+import { strict as assert } from 'node:assert';
+import models from '../../models/index.js';
+
+const sequelize = models.sequelize;
+
+describe('Simulation — E2.1 models + migrations', function () {
+  this.timeout(30000);
+
+  describe('1) model schema', function () {
+    it('SimulationScenario exposes documented fields', function () {
+      const attrs = models.SimulationScenario.rawAttributes;
+      for (const f of [
+        'id', 'tenantId', 'name', 'description',
+        'baseTerm', 'basePeriodFrom', 'basePeriodTo',
+        'simPeriodFrom', 'simPeriodTo',
+        'status', 'ownerId', 'visibility',
+        'lockedAt', 'lockedBy', 'createdAt', 'updatedAt',
+      ]) {
+        assert.ok(attrs[f], `missing field SimulationScenario.${f}`);
+      }
+      assert.equal(attrs.tenantId.allowNull, false, 'tenantId must be NOT NULL');
+      assert.equal(attrs.name.allowNull, false, 'name must be NOT NULL');
+      assert.equal(attrs.status.defaultValue, 'draft');
+      assert.equal(attrs.visibility.defaultValue, 'private');
+    });
+
+    it('SimulationEntry exposes documented fields', function () {
+      const attrs = models.SimulationEntry.rawAttributes;
+      for (const f of [
+        'id', 'tenantId', 'scenarioId', 'date',
+        'debitAccount', 'debitSubAccount', 'debitAmount',
+        'creditAccount', 'creditSubAccount', 'creditAmount',
+        'taxRuleId', 'projectId', 'labelId', 'memo', 'sourceType',
+        'createdAt', 'updatedAt',
+      ]) {
+        assert.ok(attrs[f], `missing field SimulationEntry.${f}`);
+      }
+      assert.equal(attrs.tenantId.allowNull, false, 'tenantId must be NOT NULL');
+      assert.equal(attrs.scenarioId.allowNull, false, 'scenarioId must be NOT NULL');
+      assert.equal(attrs.sourceType.defaultValue, 'manual');
+    });
+
+    it('SimulationEntry has NO approvedAt (BR-SIM-001)', function () {
+      const attrs = models.SimulationEntry.rawAttributes;
+      assert.equal(attrs.approvedAt, undefined, 'SimulationEntry must not have approvedAt');
+    });
+  });
+
+  describe('2) associations', function () {
+    it('Scenario hasMany Entry (entries)', function () {
+      const a = models.SimulationScenario.associations;
+      assert.ok(a.entries, 'SimulationScenario.associations.entries must exist');
+      assert.equal(a.entries.foreignKey, 'scenarioId');
+    });
+
+    it('Entry belongsTo Scenario (scenario)', function () {
+      const a = models.SimulationEntry.associations;
+      assert.ok(a.scenario, 'SimulationEntry.associations.scenario must exist');
+      assert.equal(a.scenario.foreignKey, 'scenarioId');
+    });
+  });
+
+  describe('3) CRUD round-trip on test DB', function () {
+    let tenant;
+    let user;
+    let scenario;
+    let entry;
+
+    before(async function () {
+      const stamp = Date.now().toString(36);
+      tenant = await models.Tenant.create({
+        slug: `sim-${stamp}`,
+        name: `sim-tenant-${stamp}`,
+      });
+      user = await models.User.create({
+        name: `sim_user_${stamp}`.slice(0, 20),
+        hashPassword: 'x-hash',
+        legalName: 'Sim',
+        email: `${stamp}@example.com`,
+      });
+    });
+
+    after(async function () {
+      if (entry) await entry.destroy().catch(() => {});
+      if (scenario) await scenario.destroy().catch(() => {});
+      if (user) await user.destroy().catch(() => {});
+      if (tenant) await tenant.destroy().catch(() => {});
+      await sequelize.close();
+    });
+
+    it('saves and reads back a Scenario + Entry', async function () {
+      scenario = await models.SimulationScenario.create({
+        tenantId: tenant.id,
+        name: 'Q3 hiring scenario',
+        description: 'projected +1 engineer',
+        baseTerm: 1,
+        basePeriodFrom: '2026-01-01',
+        basePeriodTo: '2026-06-30',
+        simPeriodFrom: '2026-07-01',
+        simPeriodTo: '2026-09-30',
+        status: 'draft',
+        ownerId: user.id,
+        visibility: 'private',
+      });
+      assert.ok(scenario.id, 'scenario id assigned');
+      assert.equal(scenario.status, 'draft');
+
+      entry = await models.SimulationEntry.create({
+        tenantId: tenant.id,
+        scenarioId: scenario.id,
+        date: '2026-07-15',
+        debitAccount: '5000',
+        debitAmount: 1000.00,
+        creditAccount: '2000',
+        creditAmount: 1000.00,
+        memo: 'projected salary',
+      });
+      assert.ok(entry.id);
+
+      const reloaded = await models.SimulationScenario.findByPk(scenario.id, {
+        include: [{ model: models.SimulationEntry, as: 'entries' }],
+      });
+      assert.equal(reloaded.name, 'Q3 hiring scenario');
+      assert.equal(reloaded.entries.length, 1);
+      assert.equal(reloaded.entries[0].memo, 'projected salary');
+    });
+
+    it('rejects Entry without tenantId', async function () {
+      await assert.rejects(
+        models.SimulationEntry.create({
+          scenarioId: scenario.id,
+          date: '2026-07-15',
+          debitAccount: '5000',
+          debitAmount: 1,
+          creditAccount: '2000',
+          creditAmount: 1,
+        }),
+        /tenantId|notNull/i
+      );
+    });
+  });
+});


### PR DESCRIPTION
Part of epic:simulation (#228)

Closes #229

### Implementation Summary
- 2 migrations: `20260608000000-create-simulation-scenario.cjs`, `20260608000100-create-simulation-entry.cjs`
- 2 models: `SimulationScenario`, `SimulationEntry` (no `approvedAt` per BR-SIM-001)
- Associations: Scenario hasMany Entry, both belongTo Tenant/User
- Indexes: `(tenantId, status)`, `(tenantId, ownerId)` on scenarios; `(scenarioId)`, `(tenantId)` on entries
- `models/index.js` registers both
- `sourceType` defaults to `manual` (E3 sẽ thêm `recurring`)

### Test Report
- **Scope & Cases:** schema field check, association wiring, tenantId NOT NULL, CRUD round-trip
- **Results:** `npx mocha test/simulation/simulation-models.test.mjs` 7/7 passing (1014ms)
- **Smoke Test:** N/A (no route in this issue)
- **Harness:** story 229 → implemented (unit=1)
