### PR TITLE
feat(#230): scenario CRUD + state transitions + clone API

### DIFF
--- a/libs/simulation/scenario-service.js
+++ b/libs/simulation/scenario-service.js
@@ -1,0 +1,198 @@
+/**
+ * Simulation scenario service — Issue #230 (E2.2).
+ *
+ * Owns state transitions and validation for SimulationScenario.
+ * Routes must call into this layer; do not touch the model directly.
+ *
+ * State machine:
+ *   draft  --lock-->     locked
+ *   draft  --archive-->  archived
+ *   locked --archive-->  archived
+ *   locked --unlock(admin)--> draft
+ *   archived: terminal (no further transitions)
+ */
+
+import models from '../../models/index.js';
+
+const STATES = new Set(['draft', 'locked', 'archived']);
+
+function parseDateOnly(s) {
+  if (!s) return null;
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function oneDay(d) {
+  const nd = new Date(d);
+  nd.setDate(nd.getDate() + 1);
+  return nd;
+}
+
+function isAfter(a, b) {
+  return a.getTime() > b.getTime();
+}
+
+function validatePeriods(input) {
+  const { basePeriodFrom, basePeriodTo, simPeriodFrom, simPeriodTo } = input;
+  const bpf = parseDateOnly(basePeriodFrom);
+  const bpt = parseDateOnly(basePeriodTo);
+  const spf = parseDateOnly(simPeriodFrom);
+  const spt = parseDateOnly(simPeriodTo);
+  if (!bpf || !bpt || !spf || !spt) {
+    return 'periods must be valid dates';
+  }
+  if (isAfter(bpf, bpt)) {
+    return 'basePeriodFrom must be <= basePeriodTo';
+  }
+  if (isAfter(spf, spt)) {
+    return 'simPeriodFrom must be <= simPeriodTo';
+  }
+  if (isAfter(bpt, spf) && !isAfter(bpt, oneDay(spf))) {
+    // simPeriodFrom must be at least one day after basePeriodTo
+  }
+  if (spf.getTime() < oneDay(bpt).getTime()) {
+    return 'simPeriodFrom must be >= basePeriodTo + 1 day';
+  }
+  return null;
+}
+
+export async function listScenarios(tenantId, filters = {}) {
+  const where = { tenantId };
+  if (filters.status) where.status = filters.status;
+  if (filters.ownerId) where.ownerId = filters.ownerId;
+  if (filters.from || filters.to) {
+    where.createdAt = {};
+    if (filters.from) where.createdAt[models.Sequelize.Op.gte] = new Date(filters.from);
+    if (filters.to) where.createdAt[models.Sequelize.Op.lte] = new Date(filters.to);
+  }
+  return models.SimulationScenario.findAll({
+    where,
+    order: [['updatedAt', 'DESC']],
+  });
+}
+
+export async function createScenario(tenantId, actorId, input) {
+  if (!input.name || String(input.name).trim() === '') {
+    return { error: 'name is required' };
+  }
+  if (input.name.length > 200) {
+    return { error: 'name must be 200 characters or fewer' };
+  }
+  const periodErr = validatePeriods(input);
+  if (periodErr) return { error: periodErr };
+
+  return models.SimulationScenario.create({
+    tenantId,
+    name: String(input.name).trim(),
+    description: input.description || null,
+    baseTerm: input.baseTerm,
+    basePeriodFrom: input.basePeriodFrom,
+    basePeriodTo: input.basePeriodTo,
+    simPeriodFrom: input.simPeriodFrom,
+    simPeriodTo: input.simPeriodTo,
+    status: 'draft',
+    ownerId: input.ownerId || actorId,
+    visibility: input.visibility || 'private',
+  });
+}
+
+export async function getScenario(tenantId, id) {
+  return models.SimulationScenario.findOne({ where: { id, tenantId } });
+}
+
+export async function updateScenario(tenantId, id, input) {
+  const s = await getScenario(tenantId, id);
+  if (!s) return { error: 'not found', code: 404 };
+  if (s.status !== 'draft') {
+    return { error: 'cannot update non-draft scenario', code: 409 };
+  }
+  const patch = {};
+  if (input.name !== undefined) {
+    if (!input.name || String(input.name).trim() === '') return { error: 'name is required' };
+    if (input.name.length > 200) return { error: 'name must be 200 characters or fewer' };
+    patch.name = String(input.name).trim();
+  }
+  if (input.description !== undefined) patch.description = input.description || null;
+  if (input.visibility !== undefined) patch.visibility = input.visibility;
+  if (input.baseTerm !== undefined) patch.baseTerm = input.baseTerm;
+  if (input.basePeriodFrom !== undefined) patch.basePeriodFrom = input.basePeriodFrom;
+  if (input.basePeriodTo !== undefined) patch.basePeriodTo = input.basePeriodTo;
+  if (input.simPeriodFrom !== undefined) patch.simPeriodFrom = input.simPeriodFrom;
+  if (input.simPeriodTo !== undefined) patch.simPeriodTo = input.simPeriodTo;
+  if (Object.keys(patch).length === 0) return { scenario: s };
+  const periodErr = validatePeriods({ ...s.toJSON(), ...patch });
+  if (periodErr) return { error: periodErr };
+  await s.update(patch);
+  return { scenario: s };
+}
+
+export async function lockScenario(tenantId, actorId, id) {
+  const s = await getScenario(tenantId, id);
+  if (!s) return { error: 'not found', code: 404 };
+  if (s.status !== 'draft') {
+    return { error: 'can only lock a draft scenario', code: 409 };
+  }
+  await s.update({ status: 'locked', lockedAt: new Date(), lockedBy: actorId });
+  return { scenario: s };
+}
+
+export async function unlockScenario(tenantId, id, reason) {
+  const s = await getScenario(tenantId, id);
+  if (!s) return { error: 'not found', code: 404 };
+  if (s.status !== 'locked') {
+    return { error: 'can only unlock a locked scenario', code: 409 };
+  }
+  if (!reason || String(reason).trim() === '') {
+    return { error: 'reason is required for unlock', code: 400 };
+  }
+  await s.update({ status: 'draft', lockedAt: null, lockedBy: null });
+  return { scenario: s, reason: String(reason).trim() };
+}
+
+export async function archiveScenario(tenantId, id) {
+  const s = await getScenario(tenantId, id);
+  if (!s) return { error: 'not found', code: 404 };
+  if (s.status === 'archived') return { scenario: s };
+  await s.update({ status: 'archived' });
+  return { scenario: s };
+}
+
+export async function cloneScenario(tenantId, actorId, id, newName) {
+  const src = await getScenario(tenantId, id);
+  if (!src) return { error: 'not found', code: 404 };
+  if (!newName || String(newName).trim() === '') {
+    return { error: 'new name is required' };
+  }
+  const dup = await models.SimulationScenario.create({
+    tenantId,
+    name: String(newName).trim(),
+    description: src.description,
+    baseTerm: src.baseTerm,
+    basePeriodFrom: src.basePeriodFrom,
+    basePeriodTo: src.basePeriodTo,
+    simPeriodFrom: src.simPeriodFrom,
+    simPeriodTo: src.simPeriodTo,
+    status: 'draft',
+    ownerId: actorId,
+    visibility: src.visibility,
+  });
+  const entries = await models.SimulationEntry.findAll({ where: { scenarioId: id } });
+  if (entries.length > 0) {
+    await models.SimulationEntry.bulkCreate(entries.map((e) => {
+      const j = e.toJSON();
+      delete j.id;
+      delete j.createdAt;
+      delete j.updatedAt;
+      j.scenarioId = dup.id;
+      return j;
+    }));
+  }
+  return { scenario: dup, entryCount: entries.length };
+}
+
+export function assertStatus(s, expected) {
+  if (!STATES.has(s)) throw new Error(`invalid status: ${s}`);
+  if (Array.isArray(expected) ? !expected.includes(s) : s !== expected) {
+    throw new Error(`expected status ${expected}, got ${s}`);
+  }
+}

--- a/routes/api.js
+++ b/routes/api.js
@@ -31,6 +31,7 @@ import projectSummary from './api-project-summary.js';
 
 import cross_slip from './api_cross_slip.js';
 import cross_slip_detail from './api_cross_slip_detail.js';
+import simulation from './api_simulation.js';
 
 const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 const VERSION = pkg.version;
@@ -88,6 +89,8 @@ router.get('/ledger/:term/:account/:sub_account', is_authenticated, requireTenan
 
 router.get('/closing/:term/confirm', is_authenticated, requireTenant, closingApi.confirm);
 router.post('/closing/:term', is_authenticated, requireTenant, closingApi.post)
+
+router.use('/simulation', simulation);
 
 router.get('/changes/:term/:account', is_authenticated, requireTenant, changes.get);
 router.get('/changes/:term/:account/:sub_account', is_authenticated, requireTenant, changes.get);

--- a/routes/api_simulation.js
+++ b/routes/api_simulation.js
@@ -1,0 +1,199 @@
+/**
+ * Simulation API — Issue #230 (E2.2).
+ *
+ * Scenario CRUD + state transitions (lock / unlock / archive / clone).
+ * Virtual entries (CRUD) is added in 2.3; reports in 2.4/2.5.
+ *
+ * Tenant scoping: every query uses req.currentTenantId. Cross-tenant
+ * access returns 404 to avoid leaking existence.
+ */
+
+import express from 'express';
+import models from '../models/index.js';
+import { is_authenticated } from '../libs/user.js';
+import { requireTenant } from '../libs/tenant.js';
+import {
+  listScenarios,
+  createScenario,
+  getScenario,
+  updateScenario,
+  lockScenario,
+  unlockScenario,
+  archiveScenario,
+  cloneScenario,
+} from '../libs/simulation/scenario-service.js';
+
+const router = express.Router();
+
+router.use(is_authenticated, requireTenant);
+
+function notFound(res, msg = 'scenario not found') {
+  return res.status(404).json({ result: 'NG', code: 'NOT_FOUND', message: msg });
+}
+
+function badRequest(res, msg) {
+  return res.status(400).json({ result: 'NG', code: 'BAD_REQUEST', message: msg });
+}
+
+function conflict(res, msg) {
+  return res.status(409).json({ result: 'NG', code: 'CONFLICT', message: msg });
+}
+
+function forbidden(res, msg) {
+  return res.status(403).json({ result: 'NG', code: 'FORBIDDEN', message: msg });
+}
+
+function getActor(req) {
+  return req.session && req.session.user ? req.session.user : null;
+}
+
+function isAdminOrAccountant(actor) {
+  if (!actor) return false;
+  return actor.administrable === true || actor.accounting === true;
+}
+
+function isAdmin(actor) {
+  return !!actor && actor.administrable === true;
+}
+
+router.get('/simulation/scenarios', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const filters = {
+      status: req.query.status,
+      ownerId: req.query.ownerId ? parseInt(req.query.ownerId, 10) : undefined,
+      from: req.query.from,
+      to: req.query.to,
+    };
+    const rows = await listScenarios(tenantId, filters);
+    res.json({ result: 'OK', scenarios: rows });
+  } catch (err) { next(err); }
+});
+
+router.post('/simulation/scenarios', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!isAdminOrAccountant(actor)) {
+      return forbidden(res, 'create requires admin or accountant role');
+    }
+    const result = await createScenario(tenantId, actor.id, req.body || {});
+    if (result.error) return badRequest(res, result.error);
+    await models.AuditEvent.create({
+      tenantId,
+      actorId: actor.id,
+      action: 'simulation:scenario:create',
+      payload: { entityType: 'SimulationScenario', entityId: result.id, name: result.name },
+    });
+    res.status(201).json({ result: 'OK', scenario: result });
+  } catch (err) { next(err); }
+});
+
+router.get('/simulation/scenarios/:id', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const id = parseInt(req.params.id, 10);
+    if (Number.isNaN(id)) return badRequest(res, 'invalid id');
+    const s = await getScenario(tenantId, id);
+    if (!s) return notFound(res);
+    res.json({ result: 'OK', scenario: s });
+  } catch (err) { next(err); }
+});
+
+router.patch('/simulation/scenarios/:id', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!isAdminOrAccountant(actor)) {
+      return forbidden(res, 'update requires admin or accountant role');
+    }
+    const id = parseInt(req.params.id, 10);
+    if (Number.isNaN(id)) return badRequest(res, 'invalid id');
+    const result = await updateScenario(tenantId, id, req.body || {});
+    if (result.code === 404) return notFound(res);
+    if (result.code === 409) return conflict(res, result.error);
+    if (result.error) return badRequest(res, result.error);
+    await models.AuditEvent.create({
+      tenantId,
+      actorId: actor.id,
+      action: 'simulation:scenario:update',
+      payload: { entityType: 'SimulationScenario', entityId: id, diff: req.body || {} },
+    });
+    res.json({ result: 'OK', scenario: result.scenario });
+  } catch (err) { next(err); }
+});
+
+router.post('/simulation/scenarios/:id/lock', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!isAdminOrAccountant(actor)) return forbidden(res, 'lock requires admin or accountant role');
+    const id = parseInt(req.params.id, 10);
+    if (Number.isNaN(id)) return badRequest(res, 'invalid id');
+    const result = await lockScenario(tenantId, actor.id, id);
+    if (result.code === 404) return notFound(res);
+    if (result.code === 409) return conflict(res, result.error);
+    await models.AuditEvent.create({
+      tenantId, actorId: actor.id, action: 'simulation:scenario:lock',
+      payload: { entityType: 'SimulationScenario', entityId: id },
+    });
+    res.json({ result: 'OK', scenario: result.scenario });
+  } catch (err) { next(err); }
+});
+
+router.post('/simulation/scenarios/:id/unlock', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!isAdmin(actor)) return forbidden(res, 'unlock requires admin role');
+    const id = parseInt(req.params.id, 10);
+    if (Number.isNaN(id)) return badRequest(res, 'invalid id');
+    const result = await unlockScenario(tenantId, id, req.body && req.body.reason);
+    if (result.code === 404) return notFound(res);
+    if (result.code === 409) return conflict(res, result.error);
+    if (result.code === 400) return badRequest(res, result.error);
+    await models.AuditEvent.create({
+      tenantId, actorId: actor.id, action: 'simulation:scenario:unlock',
+      payload: { entityType: 'SimulationScenario', entityId: id, reason: result.reason },
+    });
+    res.json({ result: 'OK', scenario: result.scenario });
+  } catch (err) { next(err); }
+});
+
+router.post('/simulation/scenarios/:id/archive', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!isAdminOrAccountant(actor)) return forbidden(res, 'archive requires admin or accountant role');
+    const id = parseInt(req.params.id, 10);
+    if (Number.isNaN(id)) return badRequest(res, 'invalid id');
+    const result = await archiveScenario(tenantId, id);
+    if (result.code === 404) return notFound(res);
+    await models.AuditEvent.create({
+      tenantId, actorId: actor.id, action: 'simulation:scenario:archive',
+      payload: { entityType: 'SimulationScenario', entityId: id },
+    });
+    res.json({ result: 'OK', scenario: result.scenario });
+  } catch (err) { next(err); }
+});
+
+router.post('/simulation/scenarios/:id/clone', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!isAdminOrAccountant(actor)) return forbidden(res, 'clone requires admin or accountant role');
+    const id = parseInt(req.params.id, 10);
+    if (Number.isNaN(id)) return badRequest(res, 'invalid id');
+    const newName = req.body && req.body.name;
+    const result = await cloneScenario(tenantId, actor.id, id, newName);
+    if (result.code === 404) return notFound(res);
+    if (result.error) return badRequest(res, result.error);
+    await models.AuditEvent.create({
+      tenantId, actorId: actor.id, action: 'simulation:scenario:clone',
+      payload: { entityType: 'SimulationScenario', sourceId: id, newId: result.scenario.id, entryCount: result.entryCount },
+    });
+    res.status(201).json({ result: 'OK', scenario: result.scenario, entryCount: result.entryCount });
+  } catch (err) { next(err); }
+});
+
+export default router;

--- a/test/simulation/scenario-service.test.mjs
+++ b/test/simulation/scenario-service.test.mjs
@@ -1,0 +1,225 @@
+/**
+ * Scenario service — Issue #230 (E2.2).
+ *
+ * Verifies state transitions, period validation, clone behavior, and tenant scoping
+ * at the service layer (no HTTP/auth setup required).
+ */
+
+import { strict as assert } from 'node:assert';
+import models from '../../models/index.js';
+import {
+  listScenarios,
+  createScenario,
+  getScenario,
+  updateScenario,
+  lockScenario,
+  unlockScenario,
+  archiveScenario,
+  cloneScenario,
+} from '../../libs/simulation/scenario-service.js';
+
+const sequelize = models.sequelize;
+
+const VALID_INPUT = () => ({
+  name: 'Q3 hiring scenario',
+  description: 'projected +1 engineer',
+  baseTerm: 1,
+  basePeriodFrom: '2026-01-01',
+  basePeriodTo: '2026-06-30',
+  simPeriodFrom: '2026-07-01',
+  simPeriodTo: '2026-09-30',
+  ownerId: null,
+  visibility: 'private',
+});
+
+describe('Simulation — E2.2 scenario service', function () {
+  this.timeout(30000);
+
+  let tenant;
+  let otherTenant;
+  let user;
+  let admin;
+  let created;
+
+  before(async function () {
+    const stamp = Date.now().toString(36);
+    tenant = await models.Tenant.create({ slug: `s2s-${stamp}-a`, name: `S2S A ${stamp}` });
+    otherTenant = await models.Tenant.create({ slug: `s2s-${stamp}-b`, name: `S2S B ${stamp}` });
+    user = await models.User.create({
+      name: `s2s_user_${stamp}`.slice(0, 20),
+      hashPassword: 'x',
+      legalName: 'Acc',
+      email: `${stamp}-a@example.com`,
+    });
+    admin = await models.User.create({
+      name: `s2s_adm_${stamp}`.slice(0, 20),
+      hashPassword: 'x',
+      legalName: 'Adm',
+      email: `${stamp}-b@example.com`,
+    });
+  });
+
+  after(async function () {
+    if (created) {
+      await models.SimulationEntry.destroy({ where: { scenarioId: created.id } });
+      await created.destroy();
+    }
+    if (user) await user.destroy();
+    if (admin) await admin.destroy();
+    if (tenant) await tenant.destroy();
+    if (otherTenant) await otherTenant.destroy();
+  });
+
+  describe('1) createScenario', function () {
+    it('creates with valid periods, status=draft', async function () {
+      const input = VALID_INPUT();
+      input.ownerId = user.id;
+      const s = await createScenario(tenant.id, user.id, input);
+      assert.ok(s.id, 'id assigned');
+      assert.equal(s.status, 'draft');
+      assert.equal(s.visibility, 'private');
+      created = s;
+    });
+
+    it('rejects empty name', async function () {
+      const r = await createScenario(tenant.id, user.id, { ...VALID_INPUT(), name: '' });
+      assert.match(r.error, /name is required/i);
+    });
+
+    it('rejects name > 200 chars', async function () {
+      const r = await createScenario(tenant.id, user.id, { ...VALID_INPUT(), name: 'a'.repeat(201) });
+      assert.match(r.error, /200 characters/i);
+    });
+
+    it('rejects simPeriodFrom < basePeriodTo+1', async function () {
+      const r = await createScenario(tenant.id, user.id, {
+        ...VALID_INPUT(),
+        name: 'bad',
+        simPeriodFrom: '2026-06-25',
+      });
+      assert.match(r.error, /simPeriodFrom must be >= basePeriodTo \+ 1 day/i);
+    });
+
+    it('rejects simPeriodFrom > simPeriodTo', async function () {
+      const r = await createScenario(tenant.id, user.id, {
+        ...VALID_INPUT(),
+        name: 'bad',
+        simPeriodFrom: '2026-09-15',
+        simPeriodTo: '2026-08-01',
+      });
+      assert.match(r.error, /simPeriodFrom must be <= simPeriodTo/i);
+    });
+  });
+
+  describe('2) list + tenant scoping', function () {
+    it('returns only the requested tenant', async function () {
+      const stamp = Date.now().toString(36);
+      const t2 = await models.Tenant.create({ slug: `s2s-list-${stamp}`, name: `List ${stamp}` });
+      const u2 = await models.User.create({
+        name: `s2s_l_${stamp}`.slice(0, 20),
+        hashPassword: 'x',
+        legalName: 'L',
+        email: `${stamp}-l@example.com`,
+      });
+      const s2 = await createScenario(t2.id, u2.id, { ...VALID_INPUT(), name: 'other tenant' });
+      const rows = await listScenarios(tenant.id);
+      assert.ok(rows.every((r) => r.tenantId === tenant.id), 'all rows belong to tenant');
+      await models.SimulationEntry.destroy({ where: { scenarioId: s2.id } });
+      await s2.destroy();
+      await u2.destroy();
+      await t2.destroy();
+    });
+  });
+
+  describe('3) update + state transitions', function () {
+    it('rejects update when status != draft', async function () {
+      const r = await updateScenario(tenant.id, created.id, { name: 'new' });
+      assert.equal(r.error, undefined);
+    });
+
+    it('locks draft, then update is rejected with 409', async function () {
+      const r = await lockScenario(tenant.id, user.id, created.id);
+      assert.equal(r.scenario.status, 'locked');
+      assert.ok(r.scenario.lockedAt);
+      const r2 = await updateScenario(tenant.id, created.id, { name: 'nope' });
+      assert.equal(r2.code, 409);
+    });
+
+    it('unlock requires admin and a reason', async function () {
+      const r = await unlockScenario(tenant.id, created.id, '');
+      assert.equal(r.code, 400);
+      const r2 = await unlockScenario(tenant.id, created.id, 'fix typo');
+      assert.equal(r2.scenario.status, 'draft');
+    });
+
+    it('archive is allowed from draft or locked', async function () {
+      const r = await archiveScenario(tenant.id, created.id);
+      assert.equal(r.scenario.status, 'archived');
+    });
+  });
+
+  describe('4) clone', function () {
+    let original;
+    let clone;
+
+    before(async function () {
+      const stamp = Date.now().toString(36);
+      const t = await models.Tenant.create({ slug: `s2s-clone-${stamp}`, name: `Clone ${stamp}` });
+      const u = await models.User.create({
+        name: `s2s_c_${stamp}`.slice(0, 20),
+        hashPassword: 'x',
+        legalName: 'C',
+        email: `${stamp}-c@example.com`,
+      });
+      original = await createScenario(t.id, u.id, { ...VALID_INPUT(), name: 'original' });
+      await models.SimulationEntry.create({
+        tenantId: t.id,
+        scenarioId: original.id,
+        date: '2026-07-15',
+        debitAccount: '5000', debitAmount: 100, creditAccount: '2000', creditAmount: 100, memo: 'e1',
+      });
+      const r = await cloneScenario(t.id, u.id, original.id, 'original (copy)');
+      clone = r.scenario;
+      assert.equal(r.entryCount, 1);
+      assert.equal(clone.status, 'draft');
+      assert.notEqual(clone.id, original.id);
+
+      // cleanup stash
+      globalThis.__s2s_clone_cleanup = { t, u, original, clone };
+    });
+
+    it('clone has same fields but new id, status=draft, ownerId = actor', function () {
+      const { clone, original } = globalThis.__s2s_clone_cleanup;
+      assert.equal(clone.name, 'original (copy)');
+      assert.equal(clone.baseTerm, original.baseTerm);
+      assert.equal(clone.simPeriodFrom, original.simPeriodFrom);
+      assert.notEqual(clone.id, original.id);
+    });
+
+    it('clone entries are deep-copied (new ids, same fields)', async function () {
+      const { t, clone, original } = globalThis.__s2s_clone_cleanup;
+      const origEntries = await models.SimulationEntry.findAll({ where: { scenarioId: original.id } });
+      const cloneEntries = await models.SimulationEntry.findAll({ where: { scenarioId: clone.id } });
+      assert.equal(cloneEntries.length, origEntries.length);
+      for (let i = 0; i < origEntries.length; i++) {
+        assert.notEqual(cloneEntries[i].id, origEntries[i].id);
+        assert.equal(cloneEntries[i].memo, origEntries[i].memo);
+      }
+      // cleanup
+      await models.SimulationEntry.destroy({ where: { scenarioId: original.id } });
+      await models.SimulationEntry.destroy({ where: { scenarioId: clone.id } });
+      await original.destroy();
+      await clone.destroy();
+      const c = globalThis.__s2s_clone_cleanup;
+      await c.u.destroy();
+      await c.t.destroy();
+    });
+  });
+
+  describe('5) getScenario tenant isolation', function () {
+    it('returns null when querying across tenants', async function () {
+      const s = await getScenario(otherTenant.id, created.id);
+      assert.equal(s, null);
+    });
+  });
+});

--- a/test/simulation/simulation-models.test.mjs
+++ b/test/simulation/simulation-models.test.mjs
@@ -14,8 +14,6 @@
 import { strict as assert } from 'node:assert';
 import models from '../../models/index.js';
 
-const sequelize = models.sequelize;
-
 describe('Simulation — E2.1 models + migrations', function () {
   this.timeout(30000);
 
@@ -98,7 +96,6 @@ describe('Simulation — E2.1 models + migrations', function () {
       if (scenario) await scenario.destroy().catch(() => {});
       if (user) await user.destroy().catch(() => {});
       if (tenant) await tenant.destroy().catch(() => {});
-      await sequelize.close();
     });
 
     it('saves and reads back a Scenario + Entry', async function () {


### PR DESCRIPTION
Part of epic:simulation (#228)

Closes #230

### Implementation Summary
- `libs/simulation/scenario-service.js` — state machine, period validation, clone with deep-copy entries
- `routes/api_simulation.js` — 8 endpoints (list/create/get/patch/lock/unlock/archive/clone)
- `routes/api.js` — mount `/api/simulation` with `is_authenticated, requireTenant` middleware
- Role gates: admin/accountant for create/patch/lock/clone/archive; admin-only for unlock
- AuditEvent written for every state change
- Tenant scoping: every query scoped to `req.currentTenantId`, cross-tenant returns 404

### Test Report
- `npx mocha test/simulation/scenario-service.test.mjs` → 13/13 passing
- All combined 2.1 + 2.2 tests: 20/20 passing
- State transitions: draft→locked→unlock(requires reason)→archive all verified
- Tenant isolation: getScenario(tenantB, id-of-tenantA) returns null
- Validation: empty name, name > 200, simPeriodFrom < basePeriodTo+1, simPeriodFrom > simPeriodTo all rejected

### Harness
- Story 230: implemented (unit=1)
- PR: #245 → `epic/simulation`