### PR TITLE
feat(#232): simulated trial balance API

### DIFF
--- a/libs/reporting/trial-balance-v2.js
+++ b/libs/reporting/trial-balance-v2.js
@@ -118,6 +118,7 @@ export async function trialBalanceV2(params, deps) {
     hideZero = false,
     includeUnapproved = false,
     languagePair = null,
+    entrySources = null,
   } = params || {};
 
   if (tenantId == null) {
@@ -137,12 +138,14 @@ export async function trialBalanceV2(params, deps) {
   // and detail fetch include the final day.
   const fetchEnd = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate() + 1);
 
+  const sources = entrySources || [actualEntrySource(deps, tenantId, startDate, fetchEnd)];
+
   const engineResult = await balanceEngine(
     {
       tenantId,
       term,
       period: { from: startDate, to: endDate },
-      entrySources: [actualEntrySource(deps, tenantId, startDate, fetchEnd)],
+      entrySources: sources,
       options: { subAccount: true, includeUnapproved },
     },
     deps,
@@ -272,6 +275,7 @@ export async function trialBalanceV2(params, deps) {
       generatedAt: new Date(),
       warnings: banners,
       totals,
+      entrySourceNames: sources.map((s) => s.name),
       filters: {
         accountClassIds: Array.from(classIdFilter),
         hideZero: !!hideZero,

--- a/libs/simulation/trial-balance.js
+++ b/libs/simulation/trial-balance.js
@@ -1,0 +1,100 @@
+/**
+ * Simulated trial balance — Issue #232 (E2.4).
+ *
+ * Calls `trialBalanceV2` (E1) with two entry sources:
+ *   - 'actual'      — approved CrossSlipDetail rows (reuse actualEntrySource)
+ *   - 'simulation'  — SimulationEntry rows for the given scenario
+ *
+ * Response shape: same v2 contract, plus meta.scenario* and
+ * meta.entrySourceNames = ['actual','simulation'].
+ *
+ * Tenant scoping: scenario must belong to tenantId; cross-tenant returns 404.
+ */
+
+import models from '../../models/index.js';
+import { trialBalanceV2, actualEntrySource } from '../reporting/trial-balance-v2.js';
+
+function simulationEntrySource(deps, tenantId, scenarioId, fetchStart, fetchEnd) {
+  return {
+    name: 'simulation',
+    fetch: async () => {
+      const rows = await deps.SimulationEntry.findAll({
+        where: {
+          tenantId,
+          scenarioId,
+          date: {
+            [deps.Sequelize.Op.gte]: fetchStart,
+            [deps.Sequelize.Op.lt]: fetchEnd,
+          },
+        },
+      });
+      return rows.map((r) => ({
+        debitAccount: r.debitAccount,
+        debitSubAccount: r.debitSubAccount,
+        debitAmount: r.debitAmount,
+        creditAccount: r.creditAccount,
+        creditSubAccount: r.creditSubAccount,
+        creditAmount: r.creditAmount,
+        approvedAt: 'simulation',
+      }));
+    },
+  };
+}
+
+function resolveSimPeriod(deps, tenantId, scenario) {
+  const fy = scenario.baseTerm
+    ? null
+    : null; // baseTerm drives the FiscalYear; sim period drives the entry fetch window.
+  const start = scenario.basePeriodFrom instanceof Date
+    ? scenario.basePeriodFrom
+    : new Date(scenario.basePeriodFrom);
+  const end = scenario.basePeriodTo instanceof Date
+    ? scenario.basePeriodTo
+    : new Date(scenario.basePeriodTo);
+  return { startDate: start, endDate: end, fetchStart: start, fetchEnd: new Date(end.getTime() + 24 * 60 * 60 * 1000) };
+}
+
+export async function simulatedTrialBalance(tenantId, scenarioId, params = {}) {
+  const scenario = await models.SimulationScenario.findOne({ where: { id: scenarioId, tenantId } });
+  if (!scenario) return { error: 'scenario not found', code: 404 };
+
+  const { startDate, endDate, fetchStart, fetchEnd } = resolveSimPeriod(models, tenantId, scenario);
+  const actualSrc = actualEntrySource(models, tenantId, startDate, fetchEnd);
+  const simSrc = simulationEntrySource(models, tenantId, scenarioId, fetchStart, fetchEnd);
+
+  const out = await trialBalanceV2(
+    {
+      tenantId,
+      term: scenario.baseTerm,
+      reportType: params.reportType || 'balance',
+      month: params.month || null,
+      accountClassIds: params.accountClassIds || [],
+      hideZero: !!params.hideZero,
+      includeUnapproved: false,
+      languagePair: params.languagePair || null,
+      entrySources: [actualSrc, simSrc],
+    },
+    models,
+  );
+
+  // Augment meta with scenario-specific fields.
+  out.meta.scenarioId = scenario.id;
+  out.meta.scenarioName = scenario.name;
+  out.meta.scenarioStatus = scenario.status;
+  out.meta.simulationBadge = 'SIMULATION - NOT OFFICIAL ACCOUNTING REPORT';
+
+  // SIM-W001: simulation total should balance. Validate invariant.
+  const t = out.meta.totals;
+  if (t && (t.movementDebit !== t.movementCredit)) {
+    out.meta.warnings = [
+      ...(out.meta.warnings || []),
+      {
+        code: 'SIM-W001',
+        severity: 'error',
+        message: 'Simulated TB total is unbalanced — entry validator should prevent this',
+      },
+    ];
+  }
+
+  return { result: out };
+}

--- a/routes/api_simulation.js
+++ b/routes/api_simulation.js
@@ -28,6 +28,7 @@ import {
   updateEntry,
   deleteEntry,
 } from '../libs/simulation/entry-validator.js';
+import { simulatedTrialBalance } from '../libs/simulation/trial-balance.js';
 
 const router = express.Router();
 
@@ -272,6 +273,34 @@ router.delete('/simulation/scenarios/:id/entries/:eid', async (req, res, next) =
     });
     res.json({ result: 'OK' });
   } catch (err) { next(err); }
+});
+
+// --- Simulated trial balance (E2.4) ---------------------------------------
+
+router.get('/simulation/scenarios/:id/trial-balance', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const scenarioId = parseInt(req.params.id, 10);
+    if (Number.isNaN(scenarioId)) return badRequest(res, 'invalid id');
+    const params = {
+      reportType: req.query.reportType,
+      month: req.query.month,
+      accountClassIds: req.query.accountClassIds
+        ? String(req.query.accountClassIds).split(',').map((s) => parseInt(s, 10))
+        : [],
+      hideZero: req.query.hideZero === 'true',
+      languagePair: req.query.languagePair ? JSON.parse(req.query.languagePair) : null,
+    };
+    const out = await simulatedTrialBalance(tenantId, scenarioId, params);
+    if (out.error) {
+      if (out.code === 404) return notFound(res, out.error);
+      return badRequest(res, out.error);
+    }
+    res.json({ result: 'OK', ...out.result });
+  } catch (err) {
+    if (err.status) return res.status(err.status).json({ result: 'NG', message: err.message });
+    next(err);
+  }
 });
 
 export default router;

--- a/test/simulation/simulated-tb.test.mjs
+++ b/test/simulation/simulated-tb.test.mjs
@@ -1,0 +1,113 @@
+/**
+ * Simulated trial balance — Issue #232 (E2.4).
+ *
+ * Verifies the simulated TB API:
+ *   1. Returns 404 for missing/cross-tenant scenario
+ *   2. Returns v2 shape with meta.scenarioId, scenarioName, scenarioStatus
+ *   3. meta.entrySourceNames = ['actual','simulation']
+ *   4. SIM-W001 NOT raised when entries are balanced
+ *   5. movementDebit === movementCredit invariant holds
+ */
+
+import { strict as assert } from 'node:assert';
+import models from '../../models/index.js';
+import { simulatedTrialBalance } from '../../libs/simulation/trial-balance.js';
+
+describe('Simulation — E2.4 simulated trial balance', function () {
+  this.timeout(30000);
+
+  let tenant;
+  let otherTenant;
+  let user;
+  let fy;
+  let accountClass;
+  let debitAccount;
+  let creditAccount;
+  let scenario;
+
+  before(async function () {
+    const stamp = Date.now().toString(36);
+    tenant = await models.Tenant.create({ slug: `s2tb-${stamp}-a`, name: `S2TB A ${stamp}` });
+    otherTenant = await models.Tenant.create({ slug: `s2tb-${stamp}-b`, name: `S2TB B ${stamp}` });
+    user = await models.User.create({
+      name: `s2tb_u_${stamp}`.slice(0, 20),
+      hashPassword: 'x',
+      legalName: 'TB',
+      email: `${stamp}-tb@example.com`,
+    });
+    fy = await models.FiscalYear.create({
+      tenantId: tenant.id, term: 1,
+      startDate: '2026-01-01', endDate: '2026-12-31',
+    });
+    accountClass = await models.AccountClass.create({
+      tenantId: tenant.id, major: 'Expense', middle: 'Salary', minor: 'Engineer', field: 5,
+    });
+    debitAccount = await models.Account.create({
+      tenantId: tenant.id, accountCode: '5000', name: 'Salary expense', accountClassId: accountClass.id,
+    });
+    creditAccount = await models.Account.create({
+      tenantId: tenant.id, accountCode: '2000', name: 'Cash', accountClassId: accountClass.id,
+    });
+    scenario = await models.SimulationScenario.create({
+      tenantId: tenant.id, name: 'sim tb scenario', baseTerm: 1,
+      basePeriodFrom: '2026-01-01', basePeriodTo: '2026-12-31',
+      simPeriodFrom: '2026-07-01', simPeriodTo: '2026-09-30',
+      status: 'draft', ownerId: user.id, visibility: 'private',
+    });
+    // One virtual entry.
+    await models.SimulationEntry.create({
+      tenantId: tenant.id, scenarioId: scenario.id,
+      date: '2026-08-15',
+      debitAccount: '5000', debitAmount: 500,
+      creditAccount: '2000', creditAmount: 500,
+      memo: 'projected',
+    });
+  });
+
+  after(async function () {
+    if (scenario) {
+      await models.SimulationEntry.destroy({ where: { scenarioId: scenario.id } });
+      await scenario.destroy();
+    }
+    if (debitAccount) await debitAccount.destroy();
+    if (creditAccount) await creditAccount.destroy();
+    if (accountClass) await accountClass.destroy();
+    if (fy) await fy.destroy();
+    if (user) await user.destroy();
+    if (tenant) await tenant.destroy();
+    if (otherTenant) await otherTenant.destroy();
+  });
+
+  it('returns v2 shape with scenario meta + entry source names', async function () {
+    const r = await simulatedTrialBalance(tenant.id, scenario.id, { reportType: 'combined' });
+    assert.equal(r.error, undefined);
+    assert.equal(r.result.version, 2);
+    assert.equal(r.result.meta.scenarioId, scenario.id);
+    assert.equal(r.result.meta.scenarioName, 'sim tb scenario');
+    assert.equal(r.result.meta.scenarioStatus, 'draft');
+    assert.deepEqual(r.result.meta.entrySourceNames, ['actual', 'simulation']);
+    assert.match(r.result.meta.simulationBadge, /SIMULATION/);
+  });
+
+  it('SIM-W001 not raised (entries are balanced)', async function () {
+    const r = await simulatedTrialBalance(tenant.id, scenario.id, { reportType: 'combined' });
+    const warns = (r.result.meta.warnings || []).map((w) => w.code || w);
+    assert.equal(warns.includes('SIM-W001'), false, `unexpected SIM-W001; got ${JSON.stringify(warns)}`);
+  });
+
+  it('global D === C invariant holds', async function () {
+    const r = await simulatedTrialBalance(tenant.id, scenario.id, { reportType: 'combined' });
+    const t = r.result.meta.totals;
+    assert.equal(t.movementDebit, t.movementCredit, 'simulated TB must balance');
+  });
+
+  it('returns 404 for cross-tenant scenario lookup', async function () {
+    const r = await simulatedTrialBalance(otherTenant.id, scenario.id, { reportType: 'balance' });
+    assert.equal(r.code, 404);
+  });
+
+  it('returns 404 for missing scenario', async function () {
+    const r = await simulatedTrialBalance(tenant.id, 999999, { reportType: 'balance' });
+    assert.equal(r.code, 404);
+  });
+});


### PR DESCRIPTION
Part of epic:simulation (#228)

Closes #232

### Implementation Summary
- Refactored `trialBalanceV2` (E1) to accept `entrySources` as parameter (additive — default = actual only)
- `libs/simulation/trial-balance.js` — builds 2 entrySources (actual + simulation), calls `trialBalanceV2`
- New route: `GET /api/simulation/scenarios/:id/trial-balance`
- Response shape: v2 contract + `meta.scenarioId`, `scenarioName`, `scenarioStatus`, `entrySourceNames`, `simulationBadge`
- SIM-W001: warns if simulated TB is unbalanced (entries are pre-validated, so should not raise)

### Test Report
- `npx mocha test/simulation/simulated-tb.test.mjs` → 5/5 passing
- Combined 2.1+2.2+2.3+2.4: 41/41 passing
- Refactor verified: `test/integration/tb-v2-reconciliation.test.mjs` 11/11 still passing
- Cross-tenant: returns 404
- Invariant: `movementDebit === movementCredit`

### Harness
- Story 232: implemented (unit=1)