### PR TITLE
feat(#239): Excel export scenario

### DIFF
--- a/front/svelte/simulation/detail.svelte
+++ b/front/svelte/simulation/detail.svelte
@@ -53,6 +53,18 @@
         <BilingualText primary="ロック解除" secondary="Mở khóa" inline={true} />
       </button>
     {/if}
+    <div class="dropdown">
+      <button class="btn btn-sm btn-outline-success dropdown-toggle" type="button" on:click={() => showExport = !showExport}>
+        <BilingualText primary="Excel出力" secondary="Xuất Excel" inline={true} />
+      </button>
+      {#if showExport}
+        <div class="sim-export-menu">
+          <button class="dropdown-item" on:click={() => exportXlsx('trial-balance')}>試算表 / Bảng cân đối</button>
+          <button class="dropdown-item" on:click={() => exportXlsx('comparison')}>比較 / So sánh</button>
+          <button class="dropdown-item" on:click={() => exportXlsx('full')}>全部 / Đầy đủ (3 sheets)</button>
+        </div>
+      {/if}
+    </div>
   </div>
 
   <ul class="nav nav-tabs sim-tabs" role="tablist">
@@ -434,6 +446,12 @@
   };
 
   const back = () => link('/simulation/scenarios');
+
+  let showExport = false;
+  const exportXlsx = (type) => {
+    showExport = false;
+    window.open(`/api/simulation/scenarios/${scenarioId}/export?type=${type}`, '_blank');
+  };
 </script>
 
 <style>
@@ -454,6 +472,14 @@
   .sim-up { color: #0a7d28; }
   .sim-down { color: #c00000; }
   .sim-placeholder { padding: 2rem; text-align: center; display: flex; gap: 0.5rem; justify-content: center; align-items: center; }
+  .dropdown { position: relative; display: inline-block; }
+  .sim-export-menu {
+    position: absolute; right: 0; top: 100%; z-index: 1000;
+    background: #fff; border: 1px solid #ddd; border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15); min-width: 12rem; padding: 0.25rem 0;
+  }
+  .sim-export-menu .dropdown-item { display: block; width: 100%; text-align: left; padding: 0.35rem 1rem; background: none; border: none; font-size: 0.85rem; cursor: pointer; }
+  .sim-export-menu .dropdown-item:hover { background: #f0f6ff; }
   .sim-form-label { font-size: 0.8rem; margin-bottom: 0.1rem; }
 
   .sim-modal-backdrop {

--- a/libs/simulation/export.js
+++ b/libs/simulation/export.js
@@ -1,0 +1,173 @@
+/**
+ * Simulation Excel export — Issue #239 (E2.11).
+ *
+ * Reuses the E1.7 workbook builder for the trial-balance sheet, then prepends
+ * a SIMULATION badge header and (for type=full) adds Comparison + Entries
+ * sheets. Three export types:
+ *   - trial-balance : 1 sheet (simulated TB)
+ *   - comparison    : 1 sheet (actual vs simulated)
+ *   - full          : Trial Balance + Comparison + Entries
+ *
+ * Header rows on every sheet:
+ *   Row 1: SIMULATION - NOT OFFICIAL ACCOUNTING REPORT
+ *   Row 2: Scenario: <name>, Status: <draft|locked>, Not for tax filing
+ *          (+ locked: <ts> by <user> when applicable)
+ *   Row 3: Generated at <ISO>, by <user>
+ */
+
+import ExcelJS from 'exceljs';
+import models from '../../models/index.js';
+import { simulatedTrialBalance } from './trial-balance.js';
+import { comparisonReport } from './comparison.js';
+import { buildSubtotals } from '../reporting/tb-subtotal.js';
+
+const NUM_FMT = '#,##0;[Red]-#,##0';
+
+function badgeRows(ws, scenario, actorName) {
+  const r1 = ws.getRow(1);
+  r1.getCell(1).value = 'SIMULATION - NOT OFFICIAL ACCOUNTING REPORT';
+  r1.font = { bold: true, color: { argb: 'FFC00000' }, size: 13 };
+  r1.commit();
+
+  const r2 = ws.getRow(2);
+  let line = `Scenario: ${scenario.name}, Status: ${scenario.status}, Not for tax filing`;
+  if (scenario.lockedAt) {
+    const ts = scenario.lockedAt instanceof Date ? scenario.lockedAt.toISOString().slice(0, 16) : String(scenario.lockedAt);
+    line += ` (locked: ${ts}${scenario.lockedBy ? `, by ${scenario.lockedBy}` : ''})`;
+  }
+  r2.getCell(1).value = line;
+  r2.font = { italic: true };
+  r2.commit();
+
+  const r3 = ws.getRow(3);
+  r3.getCell(1).value = `Generated at ${new Date().toISOString()}${actorName ? `, by ${actorName}` : ''}`;
+  r3.font = { color: { argb: 'FF888888' } };
+  r3.commit();
+}
+
+function addTrialBalanceSheet(wb, scenario, tb, actorName) {
+  const ws = wb.addWorksheet('Trial Balance', { views: [{ state: 'normal', showGridLines: false }] });
+  ws.columns = [
+    { width: 14 }, { width: 32 },
+    { width: 16 }, { width: 16 }, { width: 16 }, { width: 16 }, { width: 16 }, { width: 16 }, { width: 16 },
+  ];
+  badgeRows(ws, scenario, actorName);
+  const header = ws.getRow(5);
+  ['科目 / Mã', '科目名 / Tên', '期首借方', '期首貸方', '期間借方', '期間貸方', '期末借方', '期末貸方', '残高'].forEach((h, i) => {
+    header.getCell(i + 1).value = h;
+  });
+  header.font = { bold: true };
+  header.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFEEEEEE' } };
+  header.commit();
+
+  const lines = buildSubtotals(tb.lines || []);
+  let row = 6;
+  for (const l of lines) {
+    const r = ws.getRow(row);
+    const isSub = l.type === 'subtotal';
+    r.getCell(1).value = isSub ? `【${l.level || ''}】` : (l.subCode != null ? `${l.code}-${l.subCode}` : (l.code || ''));
+    r.getCell(2).value = isSub ? (l.name || '') : (l.subName || l.name || '');
+    r.getCell(3).value = l.openingDebit || 0;
+    r.getCell(4).value = l.openingCredit || 0;
+    r.getCell(5).value = l.movementDebit || 0;
+    r.getCell(6).value = l.movementCredit || 0;
+    r.getCell(7).value = l.endingDebit || 0;
+    r.getCell(8).value = l.endingCredit || 0;
+    r.getCell(9).value = l.balance || 0;
+    for (let c = 3; c <= 9; c += 1) { r.getCell(c).numFmt = NUM_FMT; r.getCell(c).alignment = { horizontal: 'right' }; }
+    if (isSub) { r.font = { bold: true }; r.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF3F3F3' } }; }
+    row += 1;
+  }
+}
+
+function addComparisonSheet(wb, scenario, cmp, actorName) {
+  const ws = wb.addWorksheet('Comparison', { views: [{ state: 'normal', showGridLines: false }] });
+  ws.columns = [{ width: 14 }, { width: 32 }, { width: 16 }, { width: 16 }, { width: 16 }, { width: 16 }, { width: 10 }];
+  badgeRows(ws, scenario, actorName);
+  const header = ws.getRow(5);
+  ['科目 / Mã', '科目名 / Tên', '実績 / Thực tế', '調整 / Điều chỉnh', '予測 / Mô phỏng', '差異 / Chênh lệch', '差異%'].forEach((h, i) => {
+    header.getCell(i + 1).value = h;
+  });
+  header.font = { bold: true };
+  header.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFEEEEEE' } };
+  header.commit();
+  let row = 6;
+  for (const l of cmp.lines || []) {
+    const r = ws.getRow(row);
+    r.getCell(1).value = l.subCode != null ? `${l.code}-${l.subCode}` : (l.code || '');
+    r.getCell(2).value = l.name || '';
+    r.getCell(3).value = l.actual.endingBalance || 0;
+    r.getCell(4).value = l.adjustment.endingBalance || 0;
+    r.getCell(5).value = l.simulated.endingBalance || 0;
+    r.getCell(6).value = l.difference || 0;
+    r.getCell(7).value = l.differencePct == null ? '' : Number(l.differencePct.toFixed(1));
+    for (let c = 3; c <= 6; c += 1) { r.getCell(c).numFmt = NUM_FMT; r.getCell(c).alignment = { horizontal: 'right' }; }
+    row += 1;
+  }
+}
+
+function addEntriesSheet(wb, scenario, entries, actorName) {
+  const ws = wb.addWorksheet('Entries', { views: [{ state: 'normal', showGridLines: false }] });
+  ws.columns = [{ width: 12 }, { width: 14 }, { width: 8 }, { width: 16 }, { width: 14 }, { width: 8 }, { width: 16 }, { width: 30 }];
+  badgeRows(ws, scenario, actorName);
+  const header = ws.getRow(5);
+  ['日付 / Ngày', '借方科目', '補助', '借方金額', '貸方科目', '補助', '貸方金額', '摘要 / Diễn giải'].forEach((h, i) => {
+    header.getCell(i + 1).value = h;
+  });
+  header.font = { bold: true };
+  header.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFEEEEEE' } };
+  header.commit();
+  let row = 6;
+  for (const e of entries) {
+    const r = ws.getRow(row);
+    r.getCell(1).value = e.date instanceof Date ? e.date.toISOString().slice(0, 10) : String(e.date).slice(0, 10);
+    r.getCell(2).value = e.debitAccount;
+    r.getCell(3).value = e.debitSubAccount || '';
+    r.getCell(4).value = Number(e.debitAmount) || 0;
+    r.getCell(5).value = e.creditAccount;
+    r.getCell(6).value = e.creditSubAccount || '';
+    r.getCell(7).value = Number(e.creditAmount) || 0;
+    r.getCell(8).value = e.memo || '';
+    r.getCell(4).numFmt = NUM_FMT; r.getCell(7).numFmt = NUM_FMT;
+    row += 1;
+  }
+}
+
+export async function buildScenarioExport(tenantId, scenarioId, type, actorName) {
+  const scenario = await models.SimulationScenario.findOne({ where: { id: scenarioId, tenantId } });
+  if (!scenario) return { error: 'scenario not found', code: 404 };
+
+  const wb = new ExcelJS.Workbook();
+  wb.creator = 'kaikei';
+  wb.created = new Date();
+
+  const wantTb = type === 'trial-balance' || type === 'full';
+  const wantCmp = type === 'comparison' || type === 'full';
+  const wantEntries = type === 'full';
+
+  if (wantTb) {
+    const tb = await simulatedTrialBalance(tenantId, scenarioId, { reportType: 'combined' });
+    if (tb.error) return tb;
+    addTrialBalanceSheet(wb, scenario, tb.result, actorName);
+  }
+  if (wantCmp) {
+    const cmp = await comparisonReport(tenantId, scenarioId, { reportType: 'combined' });
+    if (cmp.error) return cmp;
+    addComparisonSheet(wb, scenario, cmp.result, actorName);
+  }
+  if (wantEntries) {
+    const entries = await models.SimulationEntry.findAll({
+      where: { tenantId, scenarioId },
+      order: [['date', 'ASC'], ['id', 'ASC']],
+    });
+    addEntriesSheet(wb, scenario, entries, actorName);
+  }
+  if (wb.worksheets.length === 0) {
+    return { error: 'invalid export type', code: 400 };
+  }
+
+  const buffer = await wb.xlsx.writeBuffer();
+  const stamp = scenario.name.replace(/[^a-zA-Z0-9]/g, '_').slice(0, 20);
+  const fileName = `simulation_${stamp}_${scenarioId}_${type}.xlsx`;
+  return { buffer, fileName };
+}

--- a/routes/api_simulation.js
+++ b/routes/api_simulation.js
@@ -30,6 +30,7 @@ import {
 } from '../libs/simulation/entry-validator.js';
 import { simulatedTrialBalance } from '../libs/simulation/trial-balance.js';
 import { comparisonReport } from '../libs/simulation/comparison.js';
+import { buildScenarioExport } from '../libs/simulation/export.js';
 
 const router = express.Router();
 
@@ -324,6 +325,34 @@ router.get('/simulation/scenarios/:id/comparison', async (req, res, next) => {
       return badRequest(res, out.error);
     }
     res.json({ result: 'OK', ...out.result });
+  } catch (err) { next(err); }
+});
+
+router.get('/simulation/scenarios/:id/export', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    // Export requires at least view; accountant/admin/manager/tax can export.
+    if (!actor) return forbidden(res, 'export requires authentication');
+    const scenarioId = parseInt(req.params.id, 10);
+    if (Number.isNaN(scenarioId)) return badRequest(res, 'invalid id');
+    const type = req.query.type || 'trial-balance';
+    if (!['trial-balance', 'comparison', 'full'].includes(type)) {
+      return badRequest(res, 'type must be trial-balance|comparison|full');
+    }
+    const actorName = actor.legalName || actor.name || String(actor.id);
+    const out = await buildScenarioExport(tenantId, scenarioId, type, actorName);
+    if (out.error) {
+      if (out.code === 404) return notFound(res, out.error);
+      return badRequest(res, out.error);
+    }
+    await models.AuditEvent.create({
+      tenantId, actorId: actor.id, action: 'simulation:scenario:export',
+      payload: { entityType: 'SimulationScenario', entityId: scenarioId, type },
+    });
+    res.set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.set('Content-Disposition', `attachment; filename="${out.fileName}"`);
+    res.send(Buffer.from(out.buffer));
   } catch (err) { next(err); }
 });
 

--- a/test/simulation/export.test.mjs
+++ b/test/simulation/export.test.mjs
@@ -1,0 +1,99 @@
+/**
+ * Simulation export — Issue #239 (E2.11).
+ *
+ * Verifies buildScenarioExport produces a valid xlsx buffer with the
+ * SIMULATION badge header and the requested sheets.
+ */
+
+import { strict as assert } from 'node:assert';
+import ExcelJS from 'exceljs';
+import models from '../../models/index.js';
+import { buildScenarioExport } from '../../libs/simulation/export.js';
+
+describe('Simulation — E2.11 export', function () {
+  this.timeout(30000);
+
+  let tenant;
+  let otherTenant;
+  let user;
+  let fy;
+  let accountClass;
+  let da;
+  let ca;
+  let scenario;
+
+  before(async function () {
+    const stamp = Date.now().toString(36);
+    tenant = await models.Tenant.create({ slug: `s2x-${stamp}`, name: `S2X ${stamp}` });
+    otherTenant = await models.Tenant.create({ slug: `s2x-${stamp}-b`, name: `S2X B ${stamp}` });
+    user = await models.User.create({
+      name: `s2x_u_${stamp}`.slice(0, 20), hashPassword: 'x', legalName: 'XU', email: `${stamp}-x@example.com`,
+    });
+    fy = await models.FiscalYear.create({ tenantId: tenant.id, term: 1, startDate: '2026-01-01', endDate: '2026-12-31' });
+    accountClass = await models.AccountClass.create({ tenantId: tenant.id, major: 'Asset', middle: 'Cash', minor: 'Bank', field: 1 });
+    da = await models.Account.create({ tenantId: tenant.id, accountCode: '10200000', name: 'Cash', accountClassId: accountClass.id });
+    ca = await models.Account.create({ tenantId: tenant.id, accountCode: '20200000', name: 'A/P', accountClassId: accountClass.id });
+    scenario = await models.SimulationScenario.create({
+      tenantId: tenant.id, name: 'export scenario', baseTerm: 1,
+      basePeriodFrom: '2026-01-01', basePeriodTo: '2026-12-31',
+      simPeriodFrom: '2026-07-01', simPeriodTo: '2026-09-30',
+      status: 'locked', ownerId: user.id, visibility: 'private',
+      lockedAt: new Date('2026-06-01T10:00:00Z'), lockedBy: user.id,
+    });
+    await models.SimulationEntry.create({
+      tenantId: tenant.id, scenarioId: scenario.id, date: '2026-08-15',
+      debitAccount: '10200000', debitAmount: 500, creditAccount: '20200000', creditAmount: 500, memo: 'projected',
+    });
+  });
+
+  after(async function () {
+    if (scenario) { await models.SimulationEntry.destroy({ where: { scenarioId: scenario.id } }); await scenario.destroy(); }
+    if (da) await da.destroy();
+    if (ca) await ca.destroy();
+    if (accountClass) await accountClass.destroy();
+    if (fy) await fy.destroy();
+    if (user) await user.destroy();
+    if (tenant) await tenant.destroy();
+    if (otherTenant) await otherTenant.destroy();
+  });
+
+  async function loadWb(buffer) {
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(buffer);
+    return wb;
+  }
+
+  it('trial-balance export has badge header + Trial Balance sheet', async function () {
+    const out = await buildScenarioExport(tenant.id, scenario.id, 'trial-balance', 'XU');
+    assert.equal(out.error, undefined);
+    assert.ok(out.buffer);
+    assert.match(out.fileName, /simulation_.*_trial-balance\.xlsx/);
+    const wb = await loadWb(out.buffer);
+    const ws = wb.getWorksheet('Trial Balance');
+    assert.ok(ws, 'Trial Balance sheet exists');
+    assert.match(String(ws.getRow(1).getCell(1).value), /SIMULATION - NOT OFFICIAL/);
+    assert.match(String(ws.getRow(2).getCell(1).value), /Status: locked/);
+    assert.match(String(ws.getRow(2).getCell(1).value), /locked:/);
+  });
+
+  it('comparison export has Comparison sheet', async function () {
+    const out = await buildScenarioExport(tenant.id, scenario.id, 'comparison', 'XU');
+    assert.equal(out.error, undefined);
+    const wb = await loadWb(out.buffer);
+    assert.ok(wb.getWorksheet('Comparison'), 'Comparison sheet exists');
+  });
+
+  it('full export has 3 sheets', async function () {
+    const out = await buildScenarioExport(tenant.id, scenario.id, 'full', 'XU');
+    assert.equal(out.error, undefined);
+    const wb = await loadWb(out.buffer);
+    assert.ok(wb.getWorksheet('Trial Balance'));
+    assert.ok(wb.getWorksheet('Comparison'));
+    assert.ok(wb.getWorksheet('Entries'));
+  });
+
+  it('returns 404 for cross-tenant scenario', async function () {
+    const out = await buildScenarioExport(otherTenant.id, scenario.id, 'full', 'XU');
+    assert.equal(out.code, 404);
+  });
+});


### PR DESCRIPTION
Part of epic:simulation (#228)

Closes #239

### Implementation Summary
- `libs/simulation/export.js` — buildScenarioExport(type): trial-balance | comparison | full
- SIMULATION badge header (rows 1-3): badge + scenario/status/locked-ts + generated by
- full = 3 sheets (Trial Balance + Comparison + Entries)
- New route `GET /api/simulation/scenarios/:id/export?type=...` (audit logged)
- Export dropdown button trong detail header

### Test Report
- `npx mocha test/simulation/export.test.mjs` → 4/4 passing (badge, locked ts, 3 sheets, cross-tenant 404)
- All sim tests: 51/51 passing
- `npm run build` → exit 0, 29.25s

### Harness
- Story 239: implemented (integration=1)