### PR TITLE
feat(#241): audit log helper + entity index

### DIFF
--- a/libs/audit.js
+++ b/libs/audit.js
@@ -1,0 +1,72 @@
+/**
+ * Audit helper — Issue #241 (E2.13).
+ *
+ * Single entry point for writing AuditEvent rows. Used by simulation routes
+ * (and reusable elsewhere). Records to the shared AuditEvents table; the
+ * (entityType, entityId) lives inside the JSONB payload and is indexed by
+ * migration 20260608000200.
+ *
+ *   await audit({ tenantId, actorId, action, entityType, entityId, diff, reason, extra })
+ *
+ * When a Sequelize `transaction` is supplied it is threaded through so the
+ * audit row commits/rolls back with the caller's work.
+ */
+
+import models from '../models/index.js';
+
+export async function audit({
+  tenantId,
+  actorId = null,
+  action,
+  entityType = null,
+  entityId = null,
+  diff = undefined,
+  reason = undefined,
+  extra = undefined,
+  term = undefined,
+  transaction = undefined,
+}) {
+  if (tenantId == null) throw new Error('audit: tenantId is required');
+  if (!action) throw new Error('audit: action is required');
+
+  const payload = {};
+  if (entityType != null) payload.entityType = entityType;
+  if (entityId != null) payload.entityId = entityId;
+  if (diff !== undefined) payload.diff = diff;
+  if (reason !== undefined) payload.reason = reason;
+  if (extra !== undefined) Object.assign(payload, extra);
+
+  return models.AuditEvent.create(
+    {
+      tenantId,
+      actorId,
+      action,
+      term: term ?? null,
+      payload,
+    },
+    transaction ? { transaction } : undefined
+  );
+}
+
+/**
+ * Query a single entity's audit history (newest first).
+ */
+export async function auditHistory(entityType, entityId) {
+  const { Op } = models.Sequelize;
+  const rows = await models.AuditEvent.findAll({
+    where: {
+      [Op.and]: [
+        models.sequelize.where(
+          models.sequelize.json("payload.entityType"),
+          entityType
+        ),
+        models.sequelize.where(
+          models.sequelize.json("payload.entityId"),
+          String(entityId)
+        ),
+      ],
+    },
+    order: [['createdAt', 'DESC']],
+  });
+  return rows;
+}

--- a/migrations/20260608000200-add-audit-event-entity-idx.cjs
+++ b/migrations/20260608000200-add-audit-event-entity-idx.cjs
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * E2.13 — add a query index on AuditEvents for (entityType, entityId).
+ *
+ * AuditEvents.payload is JSONB and carries `entityType` / `entityId` for
+ * simulation events (and closing, etc). To query a scenario's full history
+ * by (entityType, entityId) efficiently, add a btree index on the extracted
+ * JSONB text values. Idempotent: checks pg_indexes first.
+ */
+module.exports = {
+  async up(queryInterface) {
+    const [rows] = await queryInterface.sequelize.query(
+      `SELECT 1 FROM pg_indexes
+       WHERE schemaname = 'public'
+         AND tablename = 'AuditEvents'
+         AND indexname = 'audit_events_entity_idx'
+       LIMIT 1;`
+    );
+    if (rows.length === 0) {
+      await queryInterface.sequelize.query(
+        `CREATE INDEX "audit_events_entity_idx"
+         ON "AuditEvents" (
+           (payload->>'entityType'),
+           (payload->>'entityId')
+         );`
+      );
+    }
+  },
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(
+      `DROP INDEX IF EXISTS "audit_events_entity_idx";`
+    );
+  },
+};

--- a/routes/api_simulation.js
+++ b/routes/api_simulation.js
@@ -35,6 +35,7 @@ import {
   hasSimulationPermission,
   canAccessScenario,
 } from '../libs/auth/permissions.js';
+import { audit } from '../libs/audit.js';
 
 const router = express.Router();
 
@@ -94,11 +95,11 @@ router.post('/simulation/scenarios', async (req, res, next) => {
     }
     const result = await createScenario(tenantId, actor.id, req.body || {});
     if (result.error) return badRequest(res, result.error);
-    await models.AuditEvent.create({
+    await audit({
       tenantId,
       actorId: actor.id,
       action: 'simulation:scenario:create',
-      payload: { entityType: 'SimulationScenario', entityId: result.id, name: result.name },
+      entityType: 'SimulationScenario', entityId: result.id, extra: { name: result.name },
     });
     res.status(201).json({ result: 'OK', scenario: result });
   } catch (err) { next(err); }
@@ -131,11 +132,11 @@ router.patch('/simulation/scenarios/:id', async (req, res, next) => {
     if (result.code === 404) return notFound(res);
     if (result.code === 409) return conflict(res, result.error);
     if (result.error) return badRequest(res, result.error);
-    await models.AuditEvent.create({
+    await audit({
       tenantId,
       actorId: actor.id,
       action: 'simulation:scenario:update',
-      payload: { entityType: 'SimulationScenario', entityId: id, diff: req.body || {} },
+      entityType: 'SimulationScenario', entityId: id, diff: req.body || {},
     });
     res.json({ result: 'OK', scenario: result.scenario });
   } catch (err) { next(err); }
@@ -151,9 +152,9 @@ router.post('/simulation/scenarios/:id/lock', async (req, res, next) => {
     const result = await lockScenario(tenantId, actor.id, id);
     if (result.code === 404) return notFound(res);
     if (result.code === 409) return conflict(res, result.error);
-    await models.AuditEvent.create({
+    await audit({
       tenantId, actorId: actor.id, action: 'simulation:scenario:lock',
-      payload: { entityType: 'SimulationScenario', entityId: id },
+      entityType: 'SimulationScenario', entityId: id,
     });
     res.json({ result: 'OK', scenario: result.scenario });
   } catch (err) { next(err); }
@@ -170,9 +171,9 @@ router.post('/simulation/scenarios/:id/unlock', async (req, res, next) => {
     if (result.code === 404) return notFound(res);
     if (result.code === 409) return conflict(res, result.error);
     if (result.code === 400) return badRequest(res, result.error);
-    await models.AuditEvent.create({
+    await audit({
       tenantId, actorId: actor.id, action: 'simulation:scenario:unlock',
-      payload: { entityType: 'SimulationScenario', entityId: id, reason: result.reason },
+      entityType: 'SimulationScenario', entityId: id, reason: result.reason,
     });
     res.json({ result: 'OK', scenario: result.scenario });
   } catch (err) { next(err); }
@@ -187,9 +188,9 @@ router.post('/simulation/scenarios/:id/archive', async (req, res, next) => {
     if (Number.isNaN(id)) return badRequest(res, 'invalid id');
     const result = await archiveScenario(tenantId, id);
     if (result.code === 404) return notFound(res);
-    await models.AuditEvent.create({
+    await audit({
       tenantId, actorId: actor.id, action: 'simulation:scenario:archive',
-      payload: { entityType: 'SimulationScenario', entityId: id },
+      entityType: 'SimulationScenario', entityId: id,
     });
     res.json({ result: 'OK', scenario: result.scenario });
   } catch (err) { next(err); }
@@ -206,9 +207,10 @@ router.post('/simulation/scenarios/:id/clone', async (req, res, next) => {
     const result = await cloneScenario(tenantId, actor.id, id, newName);
     if (result.code === 404) return notFound(res);
     if (result.error) return badRequest(res, result.error);
-    await models.AuditEvent.create({
+    await audit({
       tenantId, actorId: actor.id, action: 'simulation:scenario:clone',
-      payload: { entityType: 'SimulationScenario', sourceId: id, newId: result.scenario.id, entryCount: result.entryCount },
+      entityType: 'SimulationScenario', entityId: result.scenario.id,
+      extra: { sourceId: id, entryCount: result.entryCount },
     });
     res.status(201).json({ result: 'OK', scenario: result.scenario, entryCount: result.entryCount });
   } catch (err) { next(err); }
@@ -242,9 +244,9 @@ router.post('/simulation/scenarios/:id/entries', async (req, res, next) => {
     if (result.code === 404) return notFound(res, result.error);
     if (result.code === 409) return conflict(res, result.error);
     if (result.error) return badRequest(res, result.error);
-    await models.AuditEvent.create({
+    await audit({
       tenantId, actorId: actor.id, action: 'simulation:entry:create',
-      payload: { entityType: 'SimulationEntry', entityId: result.id, scenarioId },
+      entityType: 'SimulationEntry', entityId: result.id, extra: { scenarioId },
     });
     res.status(201).json({ result: 'OK', entry: result });
   } catch (err) { next(err); }
@@ -262,9 +264,9 @@ router.patch('/simulation/scenarios/:id/entries/:eid', async (req, res, next) =>
     if (result.code === 404) return notFound(res, result.error);
     if (result.code === 409) return conflict(res, result.error);
     if (result.error) return badRequest(res, result.error);
-    await models.AuditEvent.create({
+    await audit({
       tenantId, actorId: actor.id, action: 'simulation:entry:update',
-      payload: { entityType: 'SimulationEntry', entityId: entryId, scenarioId, diff: req.body || {} },
+      entityType: 'SimulationEntry', entityId: entryId, diff: req.body || {}, extra: { scenarioId },
     });
     res.json({ result: 'OK', entry: result.entry });
   } catch (err) { next(err); }
@@ -281,9 +283,9 @@ router.delete('/simulation/scenarios/:id/entries/:eid', async (req, res, next) =
     const result = await deleteEntry(tenantId, scenarioId, entryId);
     if (result.code === 404) return notFound(res, result.error);
     if (result.code === 409) return conflict(res, result.error);
-    await models.AuditEvent.create({
+    await audit({
       tenantId, actorId: actor.id, action: 'simulation:entry:delete',
-      payload: { entityType: 'SimulationEntry', entityId: entryId, scenarioId },
+      entityType: 'SimulationEntry', entityId: entryId, extra: { scenarioId },
     });
     res.json({ result: 'OK' });
   } catch (err) { next(err); }
@@ -362,9 +364,9 @@ router.get('/simulation/scenarios/:id/export', async (req, res, next) => {
       if (out.code === 404) return notFound(res, out.error);
       return badRequest(res, out.error);
     }
-    await models.AuditEvent.create({
+    await audit({
       tenantId, actorId: actor.id, action: 'simulation:scenario:export',
-      payload: { entityType: 'SimulationScenario', entityId: scenarioId, type },
+      entityType: 'SimulationScenario', entityId: scenarioId, extra: { type },
     });
     res.set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
     res.set('Content-Disposition', `attachment; filename="${out.fileName}"`);

--- a/test/simulation/audit.test.mjs
+++ b/test/simulation/audit.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * Audit helper + history — Issue #241 (E2.13).
+ *
+ * Verifies the shared audit() writer and auditHistory() query for simulation
+ * events keyed by (entityType, entityId) in the JSONB payload.
+ */
+
+import { strict as assert } from 'node:assert';
+import models from '../../models/index.js';
+import { audit, auditHistory } from '../../libs/audit.js';
+
+describe('Simulation — E2.13 audit log', function () {
+  this.timeout(30000);
+
+  let tenant;
+  let scenarioId;
+
+  before(async function () {
+    const stamp = Date.now().toString(36);
+    tenant = await models.Tenant.create({ slug: `s2aud-${stamp}`, name: `S2AUD ${stamp}` });
+    scenarioId = 900000 + Math.floor((Date.now() % 90000));
+  });
+
+  after(async function () {
+    await models.AuditEvent.destroy({ where: { tenantId: tenant.id } });
+    if (tenant) await tenant.destroy();
+  });
+
+  it('audit() requires tenantId and action', async function () {
+    await assert.rejects(() => audit({ action: 'x' }), /tenantId is required/);
+    await assert.rejects(() => audit({ tenantId: tenant.id }), /action is required/);
+  });
+
+  it('writes a scenario create event with entity payload', async function () {
+    const ev = await audit({
+      tenantId: tenant.id,
+      actorId: 1,
+      action: 'simulation:scenario:create',
+      entityType: 'SimulationScenario',
+      entityId: scenarioId,
+      diff: { name: 'test' },
+    });
+    assert.ok(ev.id);
+    assert.equal(ev.payload.entityType, 'SimulationScenario');
+    assert.equal(ev.payload.entityId, scenarioId);
+    assert.deepEqual(ev.payload.diff, { name: 'test' });
+  });
+
+  it('unlock event records reason', async function () {
+    const ev = await audit({
+      tenantId: tenant.id,
+      actorId: 1,
+      action: 'simulation:scenario:unlock',
+      entityType: 'SimulationScenario',
+      entityId: scenarioId,
+      reason: 'correction',
+    });
+    assert.equal(ev.payload.reason, 'correction');
+  });
+
+  it('auditHistory returns all events for the entity, newest first', async function () {
+    await audit({
+      tenantId: tenant.id, actorId: 1, action: 'simulation:entry:create',
+      entityType: 'SimulationEntry', entityId: 555,
+    });
+    const hist = await auditHistory('SimulationScenario', scenarioId);
+    assert.ok(hist.length >= 2, `expected >=2 scenario events, got ${hist.length}`);
+    // all returned rows belong to the scenario
+    for (const ev of hist) {
+      assert.equal(ev.payload.entityType, 'SimulationScenario');
+      assert.equal(String(ev.payload.entityId), String(scenarioId));
+    }
+    // newest first
+    for (let i = 1; i < hist.length; i++) {
+      assert.ok(new Date(hist[i - 1].createdAt) >= new Date(hist[i].createdAt));
+    }
+  });
+});


### PR DESCRIPTION
Part of epic:simulation (#228)

Closes #241

### Implementation Summary
- `migrations/20260608000200-add-audit-event-entity-idx.cjs` — JSONB index on (payload->>'entityType', payload->>'entityId'), idempotent
- `libs/audit.js` — `audit({...})` writer (transaction-aware) + `auditHistory(entityType, entityId)` query
- Refactored all 10 route audit calls to use the helper
- 9 action codes: scenario create/update/clone/lock/unlock/archive/export + entry create/update/delete
- unlock records reason; clone records sourceId + entryCount

### Test Report
- `npx mocha test/simulation/audit.test.mjs` → 4/4 passing
- Migration applied clean on test DB (up)
- All sim tests: 64/64

### Harness
- Story 241: implemented (unit=1, integration=1)