### PR TITLE
feat(#262): simulation:regenerate permission

### DIFF
--- a/libs/auth/permissions.js
+++ b/libs/auth/permissions.js
@@ -11,16 +11,17 @@
  *   simulation:create  — create / edit / clone scenarios + entries
  *   simulation:lock    — lock / archive
  *   simulation:unlock  — unlock (admin only)
- *   simulation:export  — Excel export
+ *   simulation:export    — Excel export
+ *   simulation:regenerate — regenerate generated entries from assumptions
  *
  * Capability → permission mapping (a user is "accountant-like" if accounting,
  * "viewer-like" if fiscalBrowsing, "admin" if administrable):
  *   administrable  → all
- *   accounting     → view, create, lock, export  (not unlock)
+ *   accounting     → view, create, lock, export, regenerate  (not unlock)
  *   fiscalBrowsing → view, export
  */
 
-const PERMS = ['simulation:view', 'simulation:create', 'simulation:lock', 'simulation:unlock', 'simulation:export'];
+const PERMS = ['simulation:view', 'simulation:create', 'simulation:lock', 'simulation:unlock', 'simulation:export', 'simulation:regenerate'];
 
 export function simulationPermissions(user) {
   const set = new Set();
@@ -34,6 +35,7 @@ export function simulationPermissions(user) {
     set.add('simulation:create');
     set.add('simulation:lock');
     set.add('simulation:export');
+    set.add('simulation:regenerate');
   }
   if (user.fiscalBrowsing) {
     set.add('simulation:view');

--- a/test/simulation/permissions.test.mjs
+++ b/test/simulation/permissions.test.mjs
@@ -20,7 +20,7 @@ describe('Simulation — E2.12 permissions', function () {
   describe('1) capability → permission mapping', function () {
     it('admin has all permissions', function () {
       const p = simulationPermissions(admin);
-      for (const perm of ['simulation:view', 'simulation:create', 'simulation:lock', 'simulation:unlock', 'simulation:export']) {
+      for (const perm of ['simulation:view', 'simulation:create', 'simulation:lock', 'simulation:unlock', 'simulation:export', 'simulation:regenerate']) {
         assert.ok(p.has(perm), `admin missing ${perm}`);
       }
     });
@@ -29,6 +29,7 @@ describe('Simulation — E2.12 permissions', function () {
       assert.ok(hasSimulationPermission(accountant, 'simulation:create'));
       assert.ok(hasSimulationPermission(accountant, 'simulation:lock'));
       assert.ok(hasSimulationPermission(accountant, 'simulation:export'));
+      assert.ok(hasSimulationPermission(accountant, 'simulation:regenerate'));
       assert.equal(hasSimulationPermission(accountant, 'simulation:unlock'), false);
     });
     it('viewer (fiscalBrowsing) has only view + export', function () {
@@ -36,6 +37,7 @@ describe('Simulation — E2.12 permissions', function () {
       assert.ok(hasSimulationPermission(viewer, 'simulation:export'));
       assert.equal(hasSimulationPermission(viewer, 'simulation:create'), false);
       assert.equal(hasSimulationPermission(viewer, 'simulation:lock'), false);
+      assert.equal(hasSimulationPermission(viewer, 'simulation:regenerate'), false);
     });
     it('user with no capability has nothing', function () {
       assert.equal(simulationPermissions(nobody).size, 0);


### PR DESCRIPTION
Part of epic:forecast

### Test Report
- **Scope:** Admin has all, accountant has regenerate, viewer denied
- **Results:** 9/9 permission tests pass, `npm run build` OK (29.41s)
- **Smoke:** Admin → 6 perms, accountant → 5 perms (incl regenerate), viewer → 2 perms (no regenerate)