### PR TITLE
feat(#263): Assumption CRUD API + Ajv JSON schema validate

### DIFF
--- a/libs/simulation/assumption-service.js
+++ b/libs/simulation/assumption-service.js
@@ -1,0 +1,222 @@
+/**
+ * SimulationAssumption CRUD + JSONB validation — Issue #263 (E3.2).
+ *
+ * Each assumption type has a parameter JSON schema. Validation uses Ajv.
+ * CRUD is tenant-scoped — every call receives tenantId.
+ */
+
+import models from '../../models/index.js';
+import Ajv from 'ajv';
+import { getScenario } from './scenario-service.js';
+
+// ---------------------------------------------------------------------------
+// JSON schemas per type
+// ---------------------------------------------------------------------------
+
+const RECURRING_SCHEMA = {
+  type: 'object',
+  required: ['frequency', 'debitAccount', 'creditAccount', 'amount'],
+  properties: {
+    frequency:       { type: 'string', enum: ['monthly', 'quarterly', 'yearly'] },
+    dayOfMonth:      { type: 'integer', minimum: 1, maximum: 31 },
+    debitAccount:    { type: 'string', minLength: 1 },
+    debitSubAccount: {},
+    creditAccount:   { type: 'string', minLength: 1 },
+    creditSubAccount: {},
+    amount:          { type: 'number', exclusiveMinimum: 0 },
+    taxRuleId:       {}, projectId: {}, labelId: {},
+    memo:            { type: 'string' },
+    increaseRule: {
+      type: 'object',
+      required: ['type', 'value'],
+      properties: {
+        type: { type: 'string', enum: ['percent', 'fixed'] },
+        value: { type: 'number' },
+      },
+    },
+  },
+};
+
+const REVENUE_GROWTH_SCHEMA = {
+  type: 'object',
+  required: ['revenueAccount', 'counterAccount', 'growthType', 'growthValue'],
+  properties: {
+    revenueAccount:  { type: 'string', minLength: 1 },
+    counterAccount:  { type: 'string', minLength: 1 },
+    growthType:      { type: 'string', enum: ['percent', 'fixed', 'manual', 'avg_last_3m', 'last_month'] },
+    growthValue:     {},
+    collectionTimingDays: { type: 'integer', enum: [0, 30, 60, 90] },
+    taxRuleId:       {}, projectId: {},
+  },
+};
+
+const EXPENSE_FIXED_SCHEMA = {
+  type: 'object',
+  required: ['expenseAccount', 'counterAccount', 'amountType'],
+  properties: {
+    expenseAccount:  { type: 'string', minLength: 1 },
+    counterAccount:  { type: 'string', minLength: 1 },
+    amountType:      { type: 'string', enum: ['fixed', 'percent_of_sales', 'headcount'] },
+    amount:          { type: 'number' },
+    percentOf:       { type: 'string', enum: ['sales', 'cogs'] },
+    headcount: {
+      type: 'object',
+      required: ['count', 'salaryPerMonth', 'salaryAccount', 'insuranceAccount', 'insurancePct'],
+      properties: {
+        count:             { type: 'integer', minimum: 1 },
+        salaryPerMonth:    { type: 'number', exclusiveMinimum: 0 },
+        salaryAccount:     { type: 'string', minLength: 1 },
+        insuranceAccount:  { type: 'string', minLength: 1 },
+        insurancePct:      { type: 'number', minimum: 0 },
+      },
+    },
+    paymentTimingDays: { type: 'integer', enum: [0, 30, 60] },
+    taxRuleId:         {}, projectId: {},
+  },
+};
+
+const SCHEMAS = {
+  recurring:      RECURRING_SCHEMA,
+  revenue_growth: REVENUE_GROWTH_SCHEMA,
+  expense_fixed:  EXPENSE_FIXED_SCHEMA,
+  expense_pct_of_sales: EXPENSE_FIXED_SCHEMA,
+  expense_headcount:    EXPENSE_FIXED_SCHEMA,
+};
+
+const VALID_TYPES = Object.keys(SCHEMAS);
+
+const ajv = new Ajv({ allErrors: true });
+const VALIDATORS = {};
+for (const [type, schema] of Object.entries(SCHEMAS)) {
+  VALIDATORS[type] = ajv.compile(schema);
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate parameters JSON against the assumption type schema.
+ * Returns { valid, errors }.
+ */
+export function validateParameters(type, parameters) {
+  if (!VALID_TYPES.includes(type)) {
+    return { valid: false, errors: [`unknown type "${type}". allowed: ${VALID_TYPES.join(', ')}`] };
+  }
+  const validate = VALIDATORS[type];
+  const ok = validate(parameters);
+  if (!ok) {
+    const msgs = (validate.errors || []).map(e => `${e.instancePath} ${e.message}`);
+    return { valid: false, errors: msgs };
+  }
+  return { valid: true, errors: [] };
+}
+
+// ---------------------------------------------------------------------------
+// CRUD helpers
+// ---------------------------------------------------------------------------
+
+async function _checkScenario(tenantId, scenarioId) {
+  const scenario = await getScenario(tenantId, scenarioId);
+  if (!scenario) {
+    return { error: 'scenario not found', code: 404 };
+  }
+  if (scenario.status === 'locked') {
+    return { error: 'scenario is locked', code: 409 };
+  }
+  return { scenario };
+}
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+export async function listAssumptions(tenantId, scenarioId) {
+  const chk = await _checkScenario(tenantId, scenarioId);
+  if (chk.error) return chk;
+
+  const rows = await models.SimulationAssumption.findAll({
+    where: { tenantId, scenarioId },
+    order: [['id', 'ASC']],
+  });
+  return { assumptions: rows };
+}
+
+export async function createAssumption(tenantId, scenarioId, data) {
+  const chk = await _checkScenario(tenantId, scenarioId);
+  if (chk.error) return chk;
+
+  const { type, name, parameters, startMonth, endMonth, status } = data;
+
+  if (!type || !name) {
+    return { error: 'type and name are required', code: 400 };
+  }
+  if (!startMonth) {
+    return { error: 'startMonth is required', code: 400 };
+  }
+
+  const v = validateParameters(type, parameters || {});
+  if (!v.valid) return { error: `parameters: ${v.errors.join('; ')}`, code: 400 };
+
+  const assumption = await models.SimulationAssumption.create({
+    tenantId,
+    scenarioId,
+    type,
+    name,
+    parameters: parameters || {},
+    startMonth,
+    endMonth: endMonth || null,
+    status: status || 'active',
+  });
+  return { assumption };
+}
+
+export async function getAssumption(tenantId, scenarioId, assumptionId) {
+  const assumption = await models.SimulationAssumption.findOne({
+    where: { id: assumptionId, tenantId, scenarioId },
+  });
+  if (!assumption) return { error: 'assumption not found', code: 404 };
+  return { assumption };
+}
+
+export async function updateAssumption(tenantId, scenarioId, assumptionId, data) {
+  const chk = await _checkScenario(tenantId, scenarioId);
+  if (chk.error) return chk;
+
+  const assumption = await models.SimulationAssumption.findOne({
+    where: { id: assumptionId, tenantId, scenarioId },
+  });
+  if (!assumption) return { error: 'assumption not found', code: 404 };
+
+  const updatable = ['name', 'parameters', 'startMonth', 'endMonth', 'status'];
+  const patch = {};
+  for (const k of updatable) {
+    if (data[k] !== undefined) patch[k] = data[k];
+  }
+
+  if (patch.startMonth !== undefined && !patch.startMonth) {
+    return { error: 'startMonth cannot be empty', code: 400 };
+  }
+
+  if (patch.parameters !== undefined) {
+    const typeToCheck = data.type || assumption.type;
+    const v = validateParameters(typeToCheck, patch.parameters);
+    if (!v.valid) return { error: `parameters: ${v.errors.join('; ')}`, code: 400 };
+  }
+
+  await assumption.update(patch);
+  return { assumption };
+}
+
+export async function deleteAssumption(tenantId, scenarioId, assumptionId) {
+  const chk = await _checkScenario(tenantId, scenarioId);
+  if (chk.error) return chk;
+
+  const assumption = await models.SimulationAssumption.findOne({
+    where: { id: assumptionId, tenantId, scenarioId },
+  });
+  if (!assumption) return { error: 'assumption not found', code: 404 };
+
+  await assumption.destroy();
+  return { ok: true };
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@roxi/routify": "^2.18.18",
 		"@sveltejs/vite-plugin-svelte": "^3.1.2",
 		"@tinymce/tinymce-svelte": "^3.0.0",
+		"ajv": "^8.20.0",
 		"axios": "^1.7.7",
 		"bcrypt": "^5.0.1",
 		"bootstrap": "^5.0.1",

--- a/routes/api_simulation.js
+++ b/routes/api_simulation.js
@@ -32,6 +32,13 @@ import { simulatedTrialBalance } from '../libs/simulation/trial-balance.js';
 import { comparisonReport } from '../libs/simulation/comparison.js';
 import { buildScenarioExport } from '../libs/simulation/export.js';
 import {
+  listAssumptions,
+  createAssumption,
+  getAssumption,
+  updateAssumption,
+  deleteAssumption,
+} from '../libs/simulation/assumption-service.js';
+import {
   hasSimulationPermission,
   canAccessScenario,
 } from '../libs/auth/permissions.js';
@@ -371,6 +378,96 @@ router.get('/simulation/scenarios/:id/export', async (req, res, next) => {
     res.set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
     res.set('Content-Disposition', `attachment; filename="${out.fileName}"`);
     res.send(Buffer.from(out.buffer));
+  } catch (err) { next(err); }
+});
+
+// --- Assumptions (E3.2) -------------------------------------------------
+
+router.get('/simulation/scenarios/:id/assumptions', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!canView(actor)) return forbidden(res, 'requires simulation:view');
+    const scenarioId = parseInt(req.params.id, 10);
+    if (Number.isNaN(scenarioId)) return badRequest(res, 'invalid id');
+    const result = await listAssumptions(tenantId, scenarioId);
+    if (result.code === 404) return notFound(res, result.error);
+    if (result.error) return badRequest(res, result.error);
+    res.json({ result: 'OK', assumptions: result.assumptions });
+  } catch (err) { next(err); }
+});
+
+router.post('/simulation/scenarios/:id/assumptions', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!canCreate(actor)) return forbidden(res, 'requires simulation:create');
+    const scenarioId = parseInt(req.params.id, 10);
+    if (Number.isNaN(scenarioId)) return badRequest(res, 'invalid id');
+    const result = await createAssumption(tenantId, scenarioId, req.body || {});
+    if (result.code === 404) return notFound(res, result.error);
+    if (result.code === 409) return conflict(res, result.error);
+    if (result.error) return badRequest(res, result.error);
+    await audit({
+      tenantId, actorId: actor.id, action: 'simulation:assumption:create',
+      entityType: 'SimulationAssumption', entityId: result.assumption.id,
+      extra: { scenarioId, type: result.assumption.type },
+    });
+    res.status(201).json({ result: 'OK', assumption: result.assumption });
+  } catch (err) { next(err); }
+});
+
+router.get('/simulation/scenarios/:id/assumptions/:aid', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!canView(actor)) return forbidden(res, 'requires simulation:view');
+    const scenarioId = parseInt(req.params.id, 10);
+    const assumptionId = parseInt(req.params.aid, 10);
+    if (Number.isNaN(scenarioId) || Number.isNaN(assumptionId)) return badRequest(res, 'invalid id');
+    const result = await getAssumption(tenantId, scenarioId, assumptionId);
+    if (result.code === 404) return notFound(res, result.error);
+    res.json({ result: 'OK', assumption: result.assumption });
+  } catch (err) { next(err); }
+});
+
+router.patch('/simulation/scenarios/:id/assumptions/:aid', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!canCreate(actor)) return forbidden(res, 'requires simulation:create');
+    const scenarioId = parseInt(req.params.id, 10);
+    const assumptionId = parseInt(req.params.aid, 10);
+    if (Number.isNaN(scenarioId) || Number.isNaN(assumptionId)) return badRequest(res, 'invalid id');
+    const result = await updateAssumption(tenantId, scenarioId, assumptionId, req.body || {});
+    if (result.code === 404) return notFound(res, result.error);
+    if (result.code === 409) return conflict(res, result.error);
+    if (result.error) return badRequest(res, result.error);
+    await audit({
+      tenantId, actorId: actor.id, action: 'simulation:assumption:update',
+      entityType: 'SimulationAssumption', entityId: assumptionId,
+      diff: req.body || {}, extra: { scenarioId },
+    });
+    res.json({ result: 'OK', assumption: result.assumption });
+  } catch (err) { next(err); }
+});
+
+router.delete('/simulation/scenarios/:id/assumptions/:aid', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!canCreate(actor)) return forbidden(res, 'requires simulation:create');
+    const scenarioId = parseInt(req.params.id, 10);
+    const assumptionId = parseInt(req.params.aid, 10);
+    if (Number.isNaN(scenarioId) || Number.isNaN(assumptionId)) return badRequest(res, 'invalid id');
+    const result = await deleteAssumption(tenantId, scenarioId, assumptionId);
+    if (result.code === 404) return notFound(res, result.error);
+    if (result.code === 409) return conflict(res, result.error);
+    await audit({
+      tenantId, actorId: actor.id, action: 'simulation:assumption:delete',
+      entityType: 'SimulationAssumption', entityId: assumptionId, extra: { scenarioId },
+    });
+    res.json({ result: 'OK' });
   } catch (err) { next(err); }
 });
 

--- a/test/simulation/assumption-crud.test.mjs
+++ b/test/simulation/assumption-crud.test.mjs
@@ -1,0 +1,192 @@
+/**
+ * SimulationAssumption CRUD + JSONB validation — Issue #263 (E3.2).
+ *
+ * Verifies:
+ *   1. JSONB parameter validation per type (recurring, revenue_growth, expense_fixed).
+ *   2. CRUD round-trip on test DB (list / create / get / update / delete).
+ *   3. Locked scenario rejection (409).
+ *   4. Unknown type rejection.
+ */
+
+import { strict as assert } from 'node:assert';
+import {
+  validateParameters,
+  listAssumptions,
+  createAssumption,
+  getAssumption,
+  updateAssumption,
+  deleteAssumption,
+} from '../../libs/simulation/assumption-service.js';
+import models from '../../models/index.js';
+
+describe('Simulation — E3.2 Assumption CRUD + schema', function () {
+  this.timeout(30000);
+
+  describe('1) JSONB parameter validation', function () {
+    it('rejects unknown type', function () {
+      const v = validateParameters('bogus', {});
+      assert.equal(v.valid, false);
+      assert.ok(v.errors[0].includes('unknown type'), v.errors.join(', '));
+    });
+
+    it('rejects recurring missing required fields', function () {
+      const v = validateParameters('recurring', {});
+      assert.equal(v.valid, false);
+    });
+
+    it('accepts valid recurring parameters', function () {
+      const v = validateParameters('recurring', {
+        frequency: 'monthly',
+        debitAccount: '5000',
+        creditAccount: '2000',
+        amount: 300000,
+        dayOfMonth: 15,
+      });
+      assert.equal(v.valid, true, JSON.stringify(v.errors));
+    });
+
+    it('accepts valid revenue_growth parameters', function () {
+      const v = validateParameters('revenue_growth', {
+        revenueAccount: '4000',
+        counterAccount: '2000',
+        growthType: 'percent',
+        growthValue: 5,
+        collectionTimingDays: 30,
+      });
+      assert.equal(v.valid, true, JSON.stringify(v.errors));
+    });
+
+    it('rejects revenue_growth with invalid growthType', function () {
+      const v = validateParameters('revenue_growth', {
+        revenueAccount: '4000',
+        counterAccount: '2000',
+        growthType: 'invalid_type',
+        growthValue: 5,
+      });
+      assert.equal(v.valid, false, 'should reject invalid growthType');
+    });
+
+    it('accepts valid expense_fixed parameters', function () {
+      const v = validateParameters('expense_fixed', {
+        expenseAccount: '5000',
+        counterAccount: '2000',
+        amountType: 'fixed',
+        amount: 100000,
+        paymentTimingDays: 30,
+      });
+      assert.equal(v.valid, true, JSON.stringify(v.errors));
+    });
+
+    it('accepts expense_fixed headcount parameters', function () {
+      const v = validateParameters('expense_fixed', {
+        expenseAccount: '5000',
+        counterAccount: '2000',
+        amountType: 'headcount',
+        headcount: {
+          count: 5,
+          salaryPerMonth: 400000,
+          salaryAccount: '5000',
+          insuranceAccount: '5001',
+          insurancePct: 15,
+        },
+      });
+      assert.equal(v.valid, true, JSON.stringify(v.errors));
+    });
+  });
+
+  describe('2) CRUD round-trip on test DB', function () {
+    let tenant, user, scenario;
+
+    before(async function () {
+      const stamp = Date.now().toString(36);
+      tenant = await models.Tenant.create({
+        slug: `asu-${stamp}`, name: `asu-tenant-${stamp}`,
+      });
+      user = await models.User.create({
+        name: `asu_user_${stamp}`.slice(0, 20),
+        hashPassword: 'x-hash', legalName: 'Asu', email: `${stamp}@asu.example.com`,
+      });
+      scenario = await models.SimulationScenario.create({
+        tenantId: tenant.id, name: 'ASU test scenario',
+        baseTerm: 1, basePeriodFrom: '2026-01-01', basePeriodTo: '2026-06-30',
+        simPeriodFrom: '2026-07-01', simPeriodTo: '2026-12-31',
+        ownerId: user.id,
+      });
+    });
+
+    after(async function () {
+      await models.SimulationAssumption.destroy({ where: { tenantId: tenant.id }, force: true });
+      if (scenario) await scenario.destroy().catch(() => {});
+      if (user) await user.destroy().catch(() => {});
+      if (tenant) await tenant.destroy().catch(() => {});
+    });
+
+    it('creates an assumption', async function () {
+      const r = await createAssumption(tenant.id, scenario.id, {
+        type: 'recurring', name: 'Monthly salary',
+        parameters: { frequency: 'monthly', debitAccount: '5000', creditAccount: '2000', amount: 300000 },
+        startMonth: '2026-07-01',
+      });
+      assert.ok(r.assumption, r.error);
+      assert.equal(r.assumption.name, 'Monthly salary');
+      assert.equal(r.assumption.status, 'active');
+    });
+
+    it('lists assumptions', async function () {
+      const r = await listAssumptions(tenant.id, scenario.id);
+      assert.ok(Array.isArray(r.assumptions));
+      assert.ok(r.assumptions.length >= 1);
+    });
+
+    it('gets single assumption', async function () {
+      const all = await listAssumptions(tenant.id, scenario.id);
+      const r = await getAssumption(tenant.id, scenario.id, all.assumptions[0].id);
+      assert.ok(r.assumption);
+      assert.equal(r.assumption.name, 'Monthly salary');
+    });
+
+    it('updates assumption', async function () {
+      const all = await listAssumptions(tenant.id, scenario.id);
+      const id = all.assumptions[0].id;
+      const r = await updateAssumption(tenant.id, scenario.id, id, {
+        name: 'Updated salary',
+        parameters: { frequency: 'quarterly', debitAccount: '5000', creditAccount: '2000', amount: 900000 },
+      });
+      assert.ok(r.assumption);
+      assert.equal(r.assumption.name, 'Updated salary');
+      assert.deepEqual(r.assumption.parameters.frequency, 'quarterly');
+    });
+
+    it('deletes assumption', async function () {
+      // create a fresh one to delete
+      const created = await createAssumption(tenant.id, scenario.id, {
+        type: 'recurring', name: 'to-delete',
+        parameters: { frequency: 'monthly', debitAccount: '5000', creditAccount: '2000', amount: 1000 },
+        startMonth: '2026-07-01',
+      });
+      const r = await deleteAssumption(tenant.id, scenario.id, created.assumption.id);
+      assert.ok(r.ok);
+
+      const gone = await getAssumption(tenant.id, scenario.id, created.assumption.id);
+      assert.ok(gone.code === 404);
+    });
+
+    it('rejects locked scenario', async function () {
+      await scenario.update({ status: 'locked' });
+      const r = await createAssumption(tenant.id, scenario.id, {
+        type: 'recurring', name: 'should fail',
+        parameters: { frequency: 'monthly', debitAccount: '5000', creditAccount: '2000', amount: 1000 },
+        startMonth: '2026-07-01',
+      });
+      assert.equal(r.code, 409);
+      await scenario.update({ status: 'draft' });
+    });
+
+    it('rejects creation without type', async function () {
+      const r = await createAssumption(tenant.id, scenario.id, {
+        name: 'no type', parameters: {}, startMonth: '2026-07-01',
+      });
+      assert.ok(r.error);
+    });
+  });
+});


### PR DESCRIPTION
Part of epic:forecast

### Test Report
- **Scope:** JSONB validation 3 types, CRUD 5 operations, locked scenario rejection, tenant scoping
- **Results:** 14/14 tests pass, npm run build OK (28.97s)
- **Smoke:** Ajv validates recurring/revenue_growth/expense_fixed; CRUD round-trip on test DB