### PR TITLE
feat(#265): revenue_growth generator (percent/fixed/manual/avg/last)

### DIFF
--- a/libs/simulation/assumption-generator.js
+++ b/libs/simulation/assumption-generator.js
@@ -123,3 +123,124 @@ export function generateRecurringEntries(assumption, scenario) {
 
   return entries;
 }
+
+/**
+ * Generate simulation entries from a revenue_growth assumption.
+ *
+ * growthValue semantics by growthType:
+ *   percent  — base amount (month 1), compounded by .growthRate % each month
+ *   fixed    — base amount (month 1), + .increment each subsequent month
+ *   manual   — array of amounts per month
+ *   avg_last_3m — uses average of last 3 priorRevenues (growthValue ignored)
+ *   last_month  — uses last priorRevenue (growthValue ignored)
+ *
+ * @param {object}  assumption
+ * @param {object}  scenario
+ * @param {number[]} priorRevenues — previous months' revenue (needed for avg/prev based growth)
+ * @returns {object[]} entries
+ */
+export function generateRevenueGrowthEntries(assumption, scenario, priorRevenues = []) {
+  const p = assumption.parameters;
+  const { growthType, growthValue, revenueAccount, counterAccount } = p;
+  const timingDays = p.collectionTimingDays || 0;
+
+  const startDate = maxDate(assumption.startMonth, scenario.simPeriodFrom);
+  const endDate = minDate(assumption.endMonth || scenario.simPeriodTo, scenario.simPeriodTo);
+
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+  const baseY = start.getFullYear();
+  const baseM = start.getMonth() + 1;
+
+  let totalMonths =
+    (end.getFullYear() - baseY) * 12 + (end.getMonth() + 1) - baseM + 1;
+  if (totalMonths < 0) return [];
+
+  const entries = [];
+
+  for (let i = 0; i < totalMonths; i++) {
+    let y = baseY, m = baseM + i;
+    while (m > 12) { m -= 12; y++; }
+    const dateStr = toDateStr(y, m, 1);
+    if (dateStr < startDate || dateStr > endDate) continue;
+
+    let amount;
+    switch (growthType) {
+      case 'percent':
+        // growthValue = base; .growthRate = percentage per month
+        amount = growthValue * Math.pow(1 + (p.growthRate || 0) / 100, i);
+        amount = Math.round(amount);
+        break;
+      case 'fixed':
+        // growthValue = base; .increment = addition per month
+        amount = (growthValue || 0) + (p.increment || 0) * i;
+        break;
+      case 'manual':
+        amount = Array.isArray(growthValue) ? (growthValue[i] || 0) : 0;
+        break;
+      case 'avg_last_3m': {
+        const slice = priorRevenues.slice(-3);
+        amount = slice.length > 0
+          ? Math.round(slice.reduce((s, v) => s + v, 0) / slice.length)
+          : 0;
+        break;
+      }
+      case 'last_month':
+        amount = priorRevenues.length > 0 ? priorRevenues[priorRevenues.length - 1] : 0;
+        break;
+      default:
+        amount = growthValue || 0;
+    }
+
+    if (!amount || amount <= 0) continue;
+
+    // Accrual entry — revenue recognition on the month
+    entries.push({
+      date: dateStr,
+      debitAccount: counterAccount,
+      debitSubAccount: null,
+      debitAmount: amount,
+      creditAccount: revenueAccount,
+      creditSubAccount: null,
+      creditAmount: amount,
+      taxRuleId: p.taxRuleId || null,
+      projectId: p.projectId || null,
+      labelId: null,
+      memo: `${assumption.name} (revenue ${dateStr})`,
+      sourceType: 'formula',
+    });
+
+    // Cash collection entry with timing offset
+    if (timingDays > 0) {
+      const cashDate = addDays(dateStr, timingDays);
+      if (cashDate >= startDate && cashDate <= endDate) {
+        entries.push({
+          date: cashDate,
+          debitAccount: '1000',       // cash
+          debitSubAccount: null,
+          debitAmount: amount,
+          creditAccount: counterAccount,
+          creditSubAccount: null,
+          creditAmount: amount,
+          taxRuleId: null,
+          projectId: null,
+          labelId: null,
+          memo: `${assumption.name} (collection ${cashDate})`,
+          sourceType: 'formula',
+        });
+      }
+    }
+  }
+
+  return entries;
+}
+
+function addDays(dateStr, days) {
+  if (!days) return dateStr;
+  const d = new Date(dateStr);
+  d.setDate(d.getDate() + days);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}

--- a/test/simulation/revenue-growth.test.mjs
+++ b/test/simulation/revenue-growth.test.mjs
@@ -1,0 +1,180 @@
+/**
+ * Revenue growth generator — Issue #265 (E3.4).
+ *
+ * Verifies percent/fixed/manual/avg_last_3m/last_month growth types,
+ * collection timing offset, debit==credit invariant.
+ */
+
+import { strict as assert } from 'node:assert';
+import { generateRevenueGrowthEntries } from '../../libs/simulation/assumption-generator.js';
+
+const SCENARIO = { simPeriodFrom: '2026-01-01', simPeriodTo: '2026-12-31' };
+
+describe('Simulation — E3.4 revenue_growth generator', function () {
+  describe('1) percent growth', function () {
+    it('compounds monthly from base', function () {
+      const a = {
+        name: 'Percent growth', startMonth: '2026-01-01', endMonth: '2026-03-31',
+        parameters: {
+          growthType: 'percent', growthValue: 100000, growthRate: 10,
+          revenueAccount: '4000', counterAccount: '1200',
+        },
+      };
+      const entries = generateRevenueGrowthEntries(a, SCENARIO);
+      // 3 months: 100000, 110000, 121000 (each rounded)
+      assert.equal(entries.length, 3);
+      assert.equal(entries[0].creditAmount, 100000);
+      assert.equal(entries[1].creditAmount, 110000);
+      assert.equal(entries[2].creditAmount, 121000);
+    });
+  });
+
+  describe('2) fixed growth', function () {
+    it('adds increment per month', function () {
+      const a = {
+        name: 'Fixed growth', startMonth: '2026-01-01', endMonth: '2026-03-31',
+        parameters: {
+          growthType: 'fixed', growthValue: 500000, increment: 50000,
+          revenueAccount: '4000', counterAccount: '1200',
+        },
+      };
+      const entries = generateRevenueGrowthEntries(a, SCENARIO);
+      assert.equal(entries.length, 3);
+      assert.equal(entries[0].creditAmount, 500000);
+      assert.equal(entries[1].creditAmount, 550000);
+      assert.equal(entries[2].creditAmount, 600000);
+    });
+  });
+
+  describe('3) manual array', function () {
+    it('uses exact array values', function () {
+      const a = {
+        name: 'Manual', startMonth: '2026-01-01', endMonth: '2026-03-31',
+        parameters: {
+          growthType: 'manual', growthValue: [200000, 300000, 250000],
+          revenueAccount: '4000', counterAccount: '1200',
+        },
+      };
+      const entries = generateRevenueGrowthEntries(a, SCENARIO);
+      assert.equal(entries.length, 3);
+      assert.equal(entries[0].creditAmount, 200000);
+      assert.equal(entries[1].creditAmount, 300000);
+      assert.equal(entries[2].creditAmount, 250000);
+    });
+  });
+
+  describe('4) avg_last_3m', function () {
+    it('averages last 3 prior revenues', function () {
+      const a = {
+        name: 'Avg3m', startMonth: '2026-01-01', endMonth: '2026-01-31',
+        parameters: {
+          growthType: 'avg_last_3m', growthValue: 0,
+          revenueAccount: '4000', counterAccount: '1200',
+        },
+      };
+      const prior = [100000, 120000, 110000]; // avg = 110000
+      const entries = generateRevenueGrowthEntries(a, SCENARIO, prior);
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].creditAmount, 110000);
+    });
+  });
+
+  describe('5) last_month', function () {
+    it('repeats last prior month', function () {
+      const a = {
+        name: 'LastMo', startMonth: '2026-01-01', endMonth: '2026-02-28',
+        parameters: {
+          growthType: 'last_month', growthValue: 0,
+          revenueAccount: '4000', counterAccount: '1200',
+        },
+      };
+      const prior = [50000, 60000, 55000]; // last = 55000
+      const entries = generateRevenueGrowthEntries(a, SCENARIO, prior);
+      assert.equal(entries.length, 2);
+      assert.equal(entries[0].creditAmount, 55000);
+      assert.equal(entries[1].creditAmount, 55000);
+    });
+  });
+
+  describe('6) collection timing (cash entry)', function () {
+    it('offsets cash by collectionTimingDays', function () {
+      const a = {
+        name: 'Timing', startMonth: '2026-01-01', endMonth: '2026-01-31',
+        parameters: {
+          growthType: 'percent', growthValue: 100000, growthRate: 0,
+          revenueAccount: '4000', counterAccount: '1200',
+          collectionTimingDays: 30,
+        },
+      };
+      const entries = generateRevenueGrowthEntries(a, SCENARIO);
+      // 1 accrual + 1 cash entry
+      assert.equal(entries.length, 2);
+      assert.equal(entries[0].date, '2026-01-01');
+      assert.equal(entries[0].creditAccount, '4000'); // revenue
+      assert.equal(entries[1].date, '2026-01-31');
+      assert.equal(entries[1].debitAccount, '1000'); // cash
+    });
+
+    it('no cash entry when timingDays = 0', function () {
+      const a = {
+        name: 'No timing', startMonth: '2026-01-01', endMonth: '2026-01-31',
+        parameters: {
+          growthType: 'percent', growthValue: 100000, growthRate: 0,
+          revenueAccount: '4000', counterAccount: '1200',
+          collectionTimingDays: 0,
+        },
+      };
+      const entries = generateRevenueGrowthEntries(a, SCENARIO);
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].creditAccount, '4000');
+    });
+
+    it('cash date not pushed outside scenario range', function () {
+      const a = {
+        name: 'Dec timing', startMonth: '2026-12-01', endMonth: '2026-12-31',
+        parameters: {
+          growthType: 'percent', growthValue: 100000, growthRate: 0,
+          revenueAccount: '4000', counterAccount: '1200',
+          collectionTimingDays: 60, // pushes to 2026-13-30 → out of bounds
+        },
+      };
+      const entries = generateRevenueGrowthEntries(a, SCENARIO);
+      // accrual still in range; cash pushed out — only 1 accrual entry
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].creditAccount, '4000');
+    });
+  });
+
+  describe('7) invariants', function () {
+    it('every entry debits == credits', function () {
+      const a = {
+        name: 'Balance check', startMonth: '2026-01-01', endMonth: '2026-06-30',
+        parameters: {
+          growthType: 'percent', growthValue: 100000, growthRate: 5,
+          revenueAccount: '4000', counterAccount: '1200',
+          collectionTimingDays: 30,
+        },
+      };
+      const entries = generateRevenueGrowthEntries(a, SCENARIO);
+      assert.ok(entries.length > 0);
+      for (const e of entries) {
+        assert.equal(e.debitAmount, e.creditAmount,
+          `entry ${e.date} not balanced: ${e.debitAmount} vs ${e.creditAmount}`);
+      }
+    });
+
+    it('all entries have sourceType formula', function () {
+      const a = {
+        name: 'Source check', startMonth: '2026-01-01', endMonth: '2026-01-31',
+        parameters: {
+          growthType: 'fixed', growthValue: 100000, increment: 0,
+          revenueAccount: '4000', counterAccount: '1200',
+        },
+      };
+      const entries = generateRevenueGrowthEntries(a, SCENARIO);
+      for (const e of entries) {
+        assert.equal(e.sourceType, 'formula');
+      }
+    });
+  });
+});


### PR DESCRIPTION
Part of epic:forecast

### Test Report
- **Scope:** 5 growth types (percent, fixed, manual, avg_last_3m, last_month), collection timing offset, out-of-bound cash, debit==credit
- **Results:** 10/10 tests pass
- **Smoke:** All generated entries balanced