### PR TITLE
feat(#266): expense_fixed generator (fixed/percent/headcount)

### DIFF
--- a/libs/simulation/assumption-generator.js
+++ b/libs/simulation/assumption-generator.js
@@ -244,3 +244,162 @@ function addDays(dateStr, days) {
   const day = String(d.getDate()).padStart(2, '0');
   return `${y}-${m}-${day}`;
 }
+
+/**
+ * Generate simulation entries from an expense_fixed assumption.
+ *
+ * amountType semantics:
+ *   fixed            — .amount each month
+ *   percent_of_sales — .percentOf * salesPerMonth
+ *   headcount        — 1 assumption → 2 entries per month (salary + insurance)
+ *
+ * Headcount: salary entry = count × salaryPerMonth
+ *            insurance entry = count × salaryPerMonth × insurancePct / 100
+ *
+ * Payment timing shifts the cash entry by .paymentTimingDays days.
+ *
+ * @param {object}   assumption
+ * @param {object}   scenario
+ * @param {number[]} salesPerMonth — monthly sales (needed for percent_of_sales type)
+ * @returns {object[]} entries
+ */
+export function generateExpenseFixedEntries(assumption, scenario, salesPerMonth = []) {
+  const p = assumption.parameters;
+  const { expenseAccount, counterAccount, amountType } = p;
+  const timingDays = p.paymentTimingDays || 0;
+
+  const startDate = maxDate(assumption.startMonth, scenario.simPeriodFrom);
+  const endDate = minDate(assumption.endMonth || scenario.simPeriodTo, scenario.simPeriodTo);
+
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+  const baseY = start.getFullYear();
+  const baseM = start.getMonth() + 1;
+
+  let totalMonths =
+    (end.getFullYear() - baseY) * 12 + (end.getMonth() + 1) - baseM + 1;
+  if (totalMonths < 0) return [];
+
+  const entries = [];
+
+  for (let i = 0; i < totalMonths; i++) {
+    let y = baseY, m = baseM + i;
+    while (m > 12) { m -= 12; y++; }
+    const dateStr = toDateStr(y, m, 1);
+    if (dateStr < startDate || dateStr > endDate) continue;
+
+    let amount;
+    switch (amountType) {
+      case 'fixed':
+        amount = p.amount || 0;
+        break;
+      case 'percent_of_sales':
+        amount = Math.round((salesPerMonth[i] || 0) * (p.percentOfValue || 0) / 100);
+        break;
+      case 'headcount':
+        if (p.headcount) {
+          const h = p.headcount;
+          const salaryAmount = Math.round(h.count * h.salaryPerMonth);
+          const insuranceAmount = Math.round(salaryAmount * h.insurancePct / 100);
+
+          // Salary accrual
+          entries.push({
+            date: dateStr,
+            debitAccount: h.salaryAccount,
+            debitSubAccount: null,
+            debitAmount: salaryAmount,
+            creditAccount: counterAccount,
+            creditSubAccount: null,
+            creditAmount: salaryAmount,
+            taxRuleId: p.taxRuleId || null,
+            projectId: p.projectId || null,
+            labelId: null,
+            memo: `${assumption.name} (salary ${dateStr})`,
+            sourceType: 'formula',
+          });
+
+          // Insurance accrual
+          entries.push({
+            date: dateStr,
+            debitAccount: h.insuranceAccount,
+            debitSubAccount: null,
+            debitAmount: insuranceAmount,
+            creditAccount: counterAccount,
+            creditSubAccount: null,
+            creditAmount: insuranceAmount,
+            taxRuleId: p.taxRuleId || null,
+            projectId: p.projectId || null,
+            labelId: null,
+            memo: `${assumption.name} (insurance ${dateStr})`,
+            sourceType: 'formula',
+          });
+
+          // Cash payment (both salary + insurance) with timing offset
+          const totalOut = salaryAmount + insuranceAmount;
+          if (timingDays > 0) {
+            const payDate = addDays(dateStr, timingDays);
+            if (payDate >= startDate && payDate <= endDate) {
+              entries.push({
+                date: payDate,
+                debitAccount: counterAccount,
+                debitSubAccount: null,
+                debitAmount: totalOut,
+                creditAccount: '1000', // cash
+                creditSubAccount: null,
+                creditAmount: totalOut,
+                taxRuleId: null,
+                projectId: null,
+                labelId: null,
+                memo: `${assumption.name} (payment ${payDate})`,
+                sourceType: 'formula',
+              });
+            }
+          }
+        }
+        continue; // headcount handles all entries for this month
+      default:
+        amount = 0;
+    }
+
+    if (!amount || amount <= 0) continue;
+
+    // Accrual entry
+    entries.push({
+      date: dateStr,
+      debitAccount: expenseAccount,
+      debitSubAccount: null,
+      debitAmount: amount,
+      creditAccount: counterAccount,
+      creditSubAccount: null,
+      creditAmount: amount,
+      taxRuleId: p.taxRuleId || null,
+      projectId: p.projectId || null,
+      labelId: null,
+      memo: `${assumption.name} (expense ${dateStr})`,
+      sourceType: 'formula',
+    });
+
+    // Cash payment with timing offset
+    if (timingDays > 0) {
+      const payDate = addDays(dateStr, timingDays);
+      if (payDate >= startDate && payDate <= endDate) {
+        entries.push({
+          date: payDate,
+          debitAccount: counterAccount,
+          debitSubAccount: null,
+          debitAmount: amount,
+          creditAccount: '1000', // cash
+          creditSubAccount: null,
+          creditAmount: amount,
+          taxRuleId: null,
+          projectId: null,
+          labelId: null,
+          memo: `${assumption.name} (payment ${payDate})`,
+          sourceType: 'formula',
+        });
+      }
+    }
+  }
+
+  return entries;
+}

--- a/test/simulation/expense-fixed.test.mjs
+++ b/test/simulation/expense-fixed.test.mjs
@@ -1,0 +1,159 @@
+/**
+ * Expense fixed generator — Issue #266 (E3.5).
+ *
+ * Verifies fixed / percent_of_sales / headcount types,
+ * payment timing offset, debit==credit invariant.
+ */
+
+import { strict as assert } from 'node:assert';
+import { generateExpenseFixedEntries } from '../../libs/simulation/assumption-generator.js';
+
+const SCENARIO = { simPeriodFrom: '2026-01-01', simPeriodTo: '2026-12-31' };
+
+describe('Simulation — E3.5 expense_fixed generator', function () {
+  describe('1) fixed amount', function () {
+    it('constant amount each month', function () {
+      const a = {
+        name: 'Fixed rent', startMonth: '2026-01-01', endMonth: '2026-03-31',
+        parameters: {
+          amountType: 'fixed', amount: 200000,
+          expenseAccount: '5000', counterAccount: '2000',
+        },
+      };
+      const entries = generateExpenseFixedEntries(a, SCENARIO);
+      assert.equal(entries.length, 3);
+      assert.equal(entries[0].debitAmount, 200000);
+      assert.equal(entries[1].debitAmount, 200000);
+      assert.equal(entries[2].debitAmount, 200000);
+    });
+  });
+
+  describe('2) percent_of_sales', function () {
+    it('calculates % of monthly sales', function () {
+      const a = {
+        name: 'Commission', startMonth: '2026-01-01', endMonth: '2026-03-31',
+        parameters: {
+          amountType: 'percent_of_sales', percentOfValue: 10,
+          expenseAccount: '5000', counterAccount: '2000',
+        },
+      };
+      const sales = [1000000, 2000000, 1500000];
+      const entries = generateExpenseFixedEntries(a, SCENARIO, sales);
+      assert.equal(entries.length, 3);
+      assert.equal(entries[0].debitAmount, 100000);  // 10% of 1M
+      assert.equal(entries[1].debitAmount, 200000);  // 10% of 2M
+      assert.equal(entries[2].debitAmount, 150000);  // 10% of 1.5M
+    });
+
+    it('handles missing sales as 0', function () {
+      const a = {
+        name: 'Zero sales', startMonth: '2026-01-01', endMonth: '2026-01-31',
+        parameters: {
+          amountType: 'percent_of_sales', percentOfValue: 10,
+          expenseAccount: '5000', counterAccount: '2000',
+        },
+      };
+      const entries = generateExpenseFixedEntries(a, SCENARIO, []);
+      assert.equal(entries.length, 0); // 0 sales → 0 amount → skipped
+    });
+  });
+
+  describe('3) headcount', function () {
+    it('1 assumption → 2 entries per month (salary + insurance)', function () {
+      const a = {
+        name: 'Team salary', startMonth: '2026-01-01', endMonth: '2026-01-31',
+        parameters: {
+          amountType: 'headcount',
+          expenseAccount: '5000', counterAccount: '2000',
+          headcount: {
+            count: 5,
+            salaryPerMonth: 400000,
+            salaryAccount: '5100',
+            insuranceAccount: '5200',
+            insurancePct: 15,
+          },
+        },
+      };
+      const entries = generateExpenseFixedEntries(a, SCENARIO);
+      // 2 entries: salary + insurance
+      assert.equal(entries.length, 2);
+      // Salary: 5 * 400000 = 2000000
+      const salaryEntry = entries.find(e => e.memo.includes('salary'));
+      assert.ok(salaryEntry);
+      assert.equal(salaryEntry.debitAccount, '5100');
+      assert.equal(salaryEntry.debitAmount, 2000000);
+      assert.equal(salaryEntry.creditAmount, 2000000);
+      // Insurance: 2000000 * 15% = 300000
+      const insEntry = entries.find(e => e.memo.includes('insurance'));
+      assert.ok(insEntry);
+      assert.equal(insEntry.debitAccount, '5200');
+      assert.equal(insEntry.debitAmount, 300000);
+      assert.equal(insEntry.creditAmount, 300000);
+    });
+
+    it('headcount + paymentTimingDays → 3 entries per month', function () {
+      const a = {
+        name: 'Team w/ payment', startMonth: '2026-01-01', endMonth: '2026-01-31',
+        parameters: {
+          amountType: 'headcount',
+          expenseAccount: '5000', counterAccount: '2000',
+          paymentTimingDays: 30,
+          headcount: {
+            count: 2,
+            salaryPerMonth: 300000,
+            salaryAccount: '5100',
+            insuranceAccount: '5200',
+            insurancePct: 15,
+          },
+        },
+      };
+      const entries = generateExpenseFixedEntries(a, SCENARIO);
+      // salary + insurance + cash payment
+      assert.equal(entries.length, 3);
+      const payment = entries.find(e => e.memo.startsWith('Team w/ payment (payment'));
+      assert.ok(payment);
+      assert.equal(payment.date, '2026-01-31');
+      // salary 600k + insurance 90k = 690k total cash out
+      assert.equal(payment.creditAmount, 690000);
+    });
+  });
+
+  describe('4) payment timing offset', function () {
+    it('adds cash entry with timingDays offset', function () {
+      const a = {
+        name: 'Deferred pay', startMonth: '2026-01-01', endMonth: '2026-01-31',
+        parameters: {
+          amountType: 'fixed', amount: 50000,
+          expenseAccount: '5000', counterAccount: '2000',
+          paymentTimingDays: 30,
+        },
+      };
+      const entries = generateExpenseFixedEntries(a, SCENARIO);
+      // 1 accrual + 1 cash
+      assert.equal(entries.length, 2);
+      assert.equal(entries[0].date, '2026-01-01');
+      assert.equal(entries[0].debitAccount, '5000'); // expense
+      assert.equal(entries[1].date, '2026-01-31');
+      assert.equal(entries[1].creditAccount, '1000'); // cash
+    });
+  });
+
+  describe('5) invariants', function () {
+    it('every entry debits == credits', function () {
+      const a = {
+        name: 'Balance check', startMonth: '2026-01-01', endMonth: '2026-06-30',
+        parameters: {
+          amountType: 'fixed', amount: 100000,
+          expenseAccount: '5000', counterAccount: '2000',
+          paymentTimingDays: 30,
+        },
+      };
+      const entries = generateExpenseFixedEntries(a, SCENARIO);
+      assert.ok(entries.length > 0);
+      for (const e of entries) {
+        assert.equal(e.debitAmount, e.creditAmount,
+          `entry ${e.date} (${e.memo}) not balanced: ${e.debitAmount} vs ${e.creditAmount}`);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Part of epic:forecast

### Test Report
- **Scope:** Fixed amount, percent_of_sales, headcount (salary + insurance), payment timing offset, debit==credit
- **Results:** 7/7 tests pass
- **Smoke:** Headcount 1 assumption → 2 entries (salary + insurance)