### PR TITLE
feat(#267): preview API (single assumption + preview-all)

### DIFF
--- a/libs/simulation/assumption-generator.js
+++ b/libs/simulation/assumption-generator.js
@@ -403,3 +403,67 @@ export function generateExpenseFixedEntries(assumption, scenario, salesPerMonth 
 
   return entries;
 }
+
+// ---------------------------------------------------------------------------
+// Preview (issue #267 — E3.6)
+// ---------------------------------------------------------------------------
+
+import models from '../../models/index.js';
+import { getScenario } from './scenario-service.js';
+
+/**
+ * Preview entries from ALL active assumptions in a scenario.
+ * Returns flat array of entry objects (not persisted).
+ */
+export async function previewAll(tenantId, scenarioId) {
+  const scenario = await getScenario(tenantId, scenarioId);
+  if (!scenario) return { error: 'scenario not found', code: 404 };
+
+  const assumptions = await models.SimulationAssumption.findAll({
+    where: { tenantId, scenarioId, status: 'active' },
+    order: [['id', 'ASC']],
+  });
+
+  if (!assumptions.length) return { entries: [], count: 0, assumptionCount: 0 };
+
+  const allEntries = [];
+
+  for (const a of assumptions) {
+    const entries = _generateEntriesForAssumption(a, scenario);
+    allEntries.push(...entries);
+  }
+
+  return { entries: allEntries, count: allEntries.length, assumptionCount: assumptions.length };
+}
+
+/**
+ * Preview entries from a SINGLE assumption.
+ */
+export async function previewAssumption(tenantId, scenarioId, assumptionId) {
+  const scenario = await getScenario(tenantId, scenarioId);
+  if (!scenario) return { error: 'scenario not found', code: 404 };
+
+  const assumption = await models.SimulationAssumption.findOne({
+    where: { id: assumptionId, tenantId, scenarioId },
+  });
+  if (!assumption) return { error: 'assumption not found', code: 404 };
+
+  const entries = _generateEntriesForAssumption(assumption, scenario);
+  return { entries, count: entries.length };
+}
+
+/**
+ * Internal: dispatch to the right generator by assumption.type.
+ */
+function _generateEntriesForAssumption(assumption, scenario) {
+  switch (assumption.type) {
+    case 'recurring':
+      return generateRecurringEntries(assumption, scenario);
+    case 'revenue_growth':
+      return generateRevenueGrowthEntries(assumption, scenario, []);
+    case 'expense_fixed':
+      return generateExpenseFixedEntries(assumption, scenario, []);
+    default:
+      return [];
+  }
+}

--- a/routes/api_simulation.js
+++ b/routes/api_simulation.js
@@ -38,6 +38,7 @@ import {
   updateAssumption,
   deleteAssumption,
 } from '../libs/simulation/assumption-service.js';
+import { previewAssumption, previewAll } from '../libs/simulation/assumption-generator.js';
 import {
   hasSimulationPermission,
   canAccessScenario,
@@ -468,6 +469,35 @@ router.delete('/simulation/scenarios/:id/assumptions/:aid', async (req, res, nex
       entityType: 'SimulationAssumption', entityId: assumptionId, extra: { scenarioId },
     });
     res.json({ result: 'OK' });
+  } catch (err) { next(err); }
+});
+
+// --- Preview (E3.6) ----------------------------------------------------
+
+router.post('/simulation/scenarios/:id/assumptions/:aid/preview', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!canView(actor)) return forbidden(res, 'requires simulation:view');
+    const scenarioId = parseInt(req.params.id, 10);
+    const assumptionId = parseInt(req.params.aid, 10);
+    if (Number.isNaN(scenarioId) || Number.isNaN(assumptionId)) return badRequest(res, 'invalid id');
+    const result = await previewAssumption(tenantId, scenarioId, assumptionId);
+    if (result.code === 404) return notFound(res, result.error);
+    res.json({ result: 'OK', ...result });
+  } catch (err) { next(err); }
+});
+
+router.post('/simulation/scenarios/:id/preview-all', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!canView(actor)) return forbidden(res, 'requires simulation:view');
+    const scenarioId = parseInt(req.params.id, 10);
+    if (Number.isNaN(scenarioId)) return badRequest(res, 'invalid id');
+    const result = await previewAll(tenantId, scenarioId);
+    if (result.code === 404) return notFound(res, result.error);
+    res.json({ result: 'OK', ...result });
   } catch (err) { next(err); }
 });
 

--- a/test/simulation/preview-api.test.mjs
+++ b/test/simulation/preview-api.test.mjs
@@ -1,0 +1,114 @@
+/**
+ * Preview API — Issue #267 (E3.6).
+ *
+ * Verifies previewAssumption (1 assumption → entries) and previewAll
+ * (all active assumptions → pooled entries). Neither writes to DB.
+ */
+
+import { strict as assert } from 'node:assert';
+import {
+  previewAssumption,
+  previewAll,
+} from '../../libs/simulation/assumption-generator.js';
+import { createAssumption, deleteAssumption } from '../../libs/simulation/assumption-service.js';
+import models from '../../models/index.js';
+
+describe('Simulation — E3.6 Preview API', function () {
+  this.timeout(30000);
+
+  let tenant, user, scenario, assumption;
+
+  before(async function () {
+    const stamp = Date.now().toString(36);
+    tenant = await models.Tenant.create({
+      slug: `prv-${stamp}`, name: `prv-tenant-${stamp}`,
+    });
+    user = await models.User.create({
+      name: `prv_user_${stamp}`.slice(0, 20),
+      hashPassword: 'x-hash', legalName: 'Prv', email: `${stamp}@prv.example.com`,
+    });
+    scenario = await models.SimulationScenario.create({
+      tenantId: tenant.id, name: 'Preview test scenario',
+      baseTerm: 1, basePeriodFrom: '2026-01-01', basePeriodTo: '2026-06-30',
+      simPeriodFrom: '2026-07-01', simPeriodTo: '2026-12-31',
+      ownerId: user.id,
+    });
+  });
+
+  after(async function () {
+    await models.SimulationAssumption.destroy({ where: { tenantId: tenant.id }, force: true });
+    if (scenario) await scenario.destroy().catch(() => {});
+    if (user) await user.destroy().catch(() => {});
+    if (tenant) await tenant.destroy().catch(() => {});
+  });
+
+  it('preview 1 recurring assumption returns correct entry count', async function () {
+    const r = await createAssumption(tenant.id, scenario.id, {
+      type: 'recurring', name: 'Monthly salary',
+      parameters: {
+        frequency: 'monthly', dayOfMonth: 15,
+        debitAccount: '5000', creditAccount: '2000', amount: 300000,
+      },
+      startMonth: '2026-07-01',
+      endMonth: '2026-12-31',
+    });
+    assumption = r.assumption;
+
+    const preview = await previewAssumption(tenant.id, scenario.id, assumption.id);
+    assert.ok(preview.entries, preview.error);
+    // Jul-Dec = 6 monthly entries
+    assert.equal(preview.count, 6);
+    assert.equal(preview.entries[0].date, '2026-07-15');
+    assert.equal(preview.entries[0].sourceType, 'recurring');
+    // All balanced
+    for (const e of preview.entries) {
+      assert.equal(e.debitAmount, e.creditAmount);
+    }
+  });
+
+  it('previewAll pools multiple assumptions', async function () {
+    // Already have 1 recurring. Add a revenue_growth.
+    await createAssumption(tenant.id, scenario.id, {
+      type: 'revenue_growth', name: 'Revenue 5% growth',
+      parameters: {
+        growthType: 'percent', growthValue: 1000000, growthRate: 5,
+        revenueAccount: '4000', counterAccount: '1200',
+      },
+      startMonth: '2026-07-01',
+      endMonth: '2026-12-31',
+    });
+
+    const result = await previewAll(tenant.id, scenario.id);
+    assert.ok(result.entries, result.error);
+    assert.equal(result.assumptionCount, 2);
+    // recurring: 6 months, revenue: 6 months = 12 entries
+    assert.equal(result.count, 12);
+  });
+
+  it('previewAll with no assumptions returns empty', async function () {
+    // Create a new scenario with no assumptions
+    const empty = await models.SimulationScenario.create({
+      tenantId: tenant.id, name: 'Empty scenario',
+      baseTerm: 1, basePeriodFrom: '2026-01-01', basePeriodTo: '2026-06-30',
+      simPeriodFrom: '2026-07-01', simPeriodTo: '2026-12-31',
+      ownerId: user.id,
+    });
+    const result = await previewAll(tenant.id, empty.id);
+    assert.equal(result.assumptionCount, 0);
+    assert.equal(result.count, 0);
+    await empty.destroy();
+  });
+
+  it('preview does not write to DB', async function () {
+    // Count SimulationEntries before and after preview
+    const before = await models.SimulationEntry.count({ where: { tenantId: tenant.id } });
+    await previewAll(tenant.id, scenario.id);
+    const after = await models.SimulationEntry.count({ where: { tenantId: tenant.id } });
+    assert.equal(after, before, 'preview must not persist entries');
+  });
+
+  it('preview returns 404 for nonexistent scenario', async function () {
+    const result = await previewAll(tenant.id, 999999);
+    assert.equal(result.code, 404);
+  });
+});


### PR DESCRIPTION
Part of epic:forecast

### Test Report
- **Scope:** preview 1 assumption, preview-all pools multiple, no DB writes, 404 on missing scenario, empty scenario returns 0
- **Results:** 5/5 tests pass, npm run build OK (29.26s)
- **Smoke:** Preview never persists entries