### PR TITLE
feat(#268): regenerate API + hash cache + audit log

### DIFF
--- a/libs/simulation/assumption-generator.js
+++ b/libs/simulation/assumption-generator.js
@@ -467,3 +467,89 @@ function _generateEntriesForAssumption(assumption, scenario) {
       return [];
   }
 }
+
+// ---------------------------------------------------------------------------
+// Regenerate (issue #268 — E3.7)
+// ---------------------------------------------------------------------------
+
+import { createHash } from 'node:crypto';
+
+function hashParams(assumption) {
+  const key = JSON.stringify({
+    type: assumption.type,
+    name: assumption.name,
+    parameters: assumption.parameters,
+    startMonth: assumption.startMonth,
+    endMonth: assumption.endMonth,
+    status: assumption.status,
+  });
+  return createHash('sha256').update(key).digest('hex').slice(0, 64);
+}
+
+/**
+ * Regenerate all generated entries for a scenario.
+ *
+ * 1. Hash each active assumption; skip if hash unchanged.
+ * 2. Delete existing entries with sourceType IN ('recurring','formula').
+ * 3. Generate new entries from all active assumptions.
+ * 4. Bulk-insert.
+ * 5. Update each assumption's generatedCount + generatedHash.
+ *
+ * Returns { deletedCount, insertedCount, assumptionCount } for audit.
+ */
+export async function regenerate(tenantId, scenarioId) {
+  const scenario = await getScenario(tenantId, scenarioId);
+  if (!scenario) return { error: 'scenario not found', code: 404 };
+  if (scenario.status === 'locked') return { error: 'scenario is locked', code: 409 };
+
+  const assumptions = await models.SimulationAssumption.findAll({
+    where: { tenantId, scenarioId, status: 'active' },
+    order: [['id', 'ASC']],
+  });
+
+  // Phase 1: identify which assumptions have changed (hash differs)
+  const changed = [];
+  for (const a of assumptions) {
+    const h = hashParams(a);
+    if (h !== a.generatedHash) {
+      changed.push({ assumption: a, hash: h });
+    }
+  }
+
+  // Only delete if something changed — keep manual entries untouched
+  let deleted = 0;
+  if (changed.length > 0) {
+    deleted = await models.SimulationEntry.destroy({
+      where: {
+        tenantId,
+        scenarioId,
+        sourceType: { [models.Sequelize.Op.in]: ['recurring', 'formula'] },
+      },
+    });
+  }
+
+  let insertedCount = 0;
+
+  if (changed.length > 0) {
+    const allEntries = [];
+    for (const { assumption, hash } of changed) {
+      const gen = _generateEntriesForAssumption(assumption, scenario);
+      const count = gen.length;
+
+      for (const e of gen) {
+        e.tenantId = tenantId;
+        e.scenarioId = scenarioId;
+      }
+
+      allEntries.push(...gen);
+      await assumption.update({ generatedCount: count, generatedHash: hash });
+    }
+
+    if (allEntries.length > 0) {
+      await models.SimulationEntry.bulkCreate(allEntries);
+    }
+    insertedCount = allEntries.length;
+  }
+
+  return { deletedCount: deleted, insertedCount, assumptionCount: assumptions.length };
+}

--- a/routes/api_simulation.js
+++ b/routes/api_simulation.js
@@ -38,7 +38,7 @@ import {
   updateAssumption,
   deleteAssumption,
 } from '../libs/simulation/assumption-service.js';
-import { previewAssumption, previewAll } from '../libs/simulation/assumption-generator.js';
+import { previewAssumption, previewAll, regenerate } from '../libs/simulation/assumption-generator.js';
 import {
   hasSimulationPermission,
   canAccessScenario,
@@ -75,6 +75,7 @@ const canLock = (actor) => hasSimulationPermission(actor, 'simulation:lock');
 const canUnlock = (actor) => hasSimulationPermission(actor, 'simulation:unlock');
 const canView = (actor) => hasSimulationPermission(actor, 'simulation:view');
 const canExport = (actor) => hasSimulationPermission(actor, 'simulation:export');
+const canRegenerate = (actor) => hasSimulationPermission(actor, 'simulation:regenerate');
 
 router.get('/simulation/scenarios', async (req, res, next) => {
   try {
@@ -497,6 +498,31 @@ router.post('/simulation/scenarios/:id/preview-all', async (req, res, next) => {
     if (Number.isNaN(scenarioId)) return badRequest(res, 'invalid id');
     const result = await previewAll(tenantId, scenarioId);
     if (result.code === 404) return notFound(res, result.error);
+    res.json({ result: 'OK', ...result });
+  } catch (err) { next(err); }
+});
+
+// --- Regenerate (E3.7) -------------------------------------------------
+
+router.post('/simulation/scenarios/:id/regenerate', async (req, res, next) => {
+  try {
+    const tenantId = req.currentTenantId;
+    const actor = getActor(req);
+    if (!canRegenerate(actor)) return forbidden(res, 'requires simulation:regenerate');
+    const scenarioId = parseInt(req.params.id, 10);
+    if (Number.isNaN(scenarioId)) return badRequest(res, 'invalid id');
+    const result = await regenerate(tenantId, scenarioId);
+    if (result.code === 404) return notFound(res, result.error);
+    if (result.code === 409) return conflict(res, result.error);
+    await audit({
+      tenantId, actorId: actor.id, action: 'simulation:regenerate',
+      entityType: 'SimulationScenario', entityId: scenarioId,
+      extra: {
+        deletedCount: result.deletedCount,
+        insertedCount: result.insertedCount,
+        assumptionCount: result.assumptionCount,
+      },
+    });
     res.json({ result: 'OK', ...result });
   } catch (err) { next(err); }
 });

--- a/test/simulation/regenerate.test.mjs
+++ b/test/simulation/regenerate.test.mjs
@@ -1,0 +1,133 @@
+/**
+ * Regenerate API — Issue #268 (E3.7).
+ *
+ * Verifies:
+ *   1. Regenerate deletes only generated entries (recurring/formula), keeps manual.
+ *   2. New entries inserted from active assumptions.
+ *   3. Hash cache: unchanged params → skip delete+insert.
+ *   4. Locked scenario rejected.
+ *   5. generatedCount / generatedHash updated.
+ */
+
+import { strict as assert } from 'node:assert';
+import { regenerate, previewAll } from '../../libs/simulation/assumption-generator.js';
+import { createAssumption } from '../../libs/simulation/assumption-service.js';
+import models from '../../models/index.js';
+
+describe('Simulation — E3.7 Regenerate', function () {
+  this.timeout(30000);
+
+  let tenant, user, scenario;
+
+  before(async function () {
+    const stamp = Date.now().toString(36);
+    tenant = await models.Tenant.create({
+      slug: `rgn-${stamp}`, name: `rgn-tenant-${stamp}`,
+    });
+    user = await models.User.create({
+      name: `rgn_user_${stamp}`.slice(0, 20),
+      hashPassword: 'x-hash', legalName: 'Rgn', email: `${stamp}@rgn.example.com`,
+    });
+    scenario = await models.SimulationScenario.create({
+      tenantId: tenant.id, name: 'Regen test scenario',
+      baseTerm: 1, basePeriodFrom: '2026-01-01', basePeriodTo: '2026-06-30',
+      simPeriodFrom: '2026-07-01', simPeriodTo: '2026-09-30',
+      ownerId: user.id,
+    });
+  });
+
+  after(async function () {
+    await models.SimulationEntry.destroy({ where: { tenantId: tenant.id }, force: true });
+    await models.SimulationAssumption.destroy({ where: { tenantId: tenant.id }, force: true });
+    if (scenario) await scenario.destroy().catch(() => {});
+    if (user) await user.destroy().catch(() => {});
+    if (tenant) await tenant.destroy().catch(() => {});
+  });
+
+  it('regenerate inserts entries from active assumptions', async function () {
+    await createAssumption(tenant.id, scenario.id, {
+      type: 'recurring', name: 'Monthly rent',
+      parameters: {
+        frequency: 'monthly', dayOfMonth: 1,
+        debitAccount: '5000', creditAccount: '2000', amount: 100000,
+      },
+      startMonth: '2026-07-01', endMonth: '2026-09-30',
+    });
+
+    const result = await regenerate(tenant.id, scenario.id);
+
+    assert.equal(result.deletedCount, 0, 'no prior entries to delete');
+    assert.equal(result.insertedCount, 3); // Jul, Aug, Sep
+    assert.equal(result.assumptionCount, 1);
+
+    // Verify entries exist in DB
+    const entries = await models.SimulationEntry.findAll({
+      where: { tenantId: tenant.id, scenarioId: scenario.id },
+    });
+    assert.equal(entries.length, 3);
+    assert.equal(entries[0].sourceType, 'recurring');
+  });
+
+  it('manual entries survive regenerate', async function () {
+    // Create a manual entry
+    const manual = await models.SimulationEntry.create({
+      tenantId: tenant.id, scenarioId: scenario.id,
+      date: '2026-07-15',
+      debitAccount: '5000', debitAmount: 5000,
+      creditAccount: '2000', creditAmount: 5000,
+      sourceType: 'manual', memo: 'manual entry',
+    });
+
+    const result = await regenerate(tenant.id, scenario.id);
+    assert.ok(result.insertedCount >= 0);
+
+    // Manual entry should still exist
+    const manualCheck = await models.SimulationEntry.findByPk(manual.id);
+    assert.ok(manualCheck, 'manual entry must survive regenerate');
+    assert.equal(manualCheck.sourceType, 'manual');
+
+    // Generated entries should exist (re-created)
+    const generated = await models.SimulationEntry.findAll({
+      where: { tenantId: tenant.id, scenarioId: scenario.id, sourceType: 'recurring' },
+    });
+    assert.ok(generated.length > 0, 'generated entries must be re-created after regenerate');
+  });
+
+  it('hash cache: unchanged params skip regenerate', async function () {
+    const genCount = await models.SimulationEntry.count({
+      where: { tenantId: tenant.id, scenarioId: scenario.id, sourceType: 'recurring' },
+    });
+
+    const result = await regenerate(tenant.id, scenario.id);
+    // Entry count should not change (hash matched, skipped)
+    const afterCount = await models.SimulationEntry.count({
+      where: { tenantId: tenant.id, scenarioId: scenario.id, sourceType: 'recurring' },
+    });
+    assert.equal(afterCount, genCount, 'entry count unchanged when hash matches');
+  });
+
+  it('updated assumption triggers re-insert with new count', async function () {
+    const all = await models.SimulationAssumption.findAll({
+      where: { tenantId: tenant.id, scenarioId: scenario.id },
+    });
+    const a = all[0];
+    // Change params to break hash
+    await a.update({ startMonth: '2026-08-01' });
+
+    const result = await regenerate(tenant.id, scenario.id);
+    assert.ok(result.deletedCount >= 0);
+    assert.ok(result.insertedCount >= 0);
+    // Aug + Sep = 2 entries now
+    const entries = await models.SimulationEntry.findAll({
+      where: { tenantId: tenant.id, scenarioId: scenario.id, sourceType: 'recurring' },
+    });
+    assert.equal(entries.length, 2);
+  });
+
+  it('locked scenario rejects regenerate', async function () {
+    await scenario.update({ status: 'locked' });
+    const result = await regenerate(tenant.id, scenario.id);
+    assert.equal(result.code, 409);
+    await scenario.update({ status: 'draft' });
+  });
+});


### PR DESCRIPTION
Part of epic:forecast

### Test Report
- **Scope:** Regenerate inserts entries from generations, manual entries survive, hash cache skips unchanged, changed params trigger re-insert, locked scenario 409
- **Results:** 5/5 tests pass
- **Smoke:** Manual entries never touched, generated entries re-created correctly