### PR TITLE
feat(#272,#273): P/L & Cash charts (native SVG) + simulation warnings

### DIFF
--- a/front/svelte/simulation/components/cash-chart.svelte
+++ b/front/svelte/simulation/components/cash-chart.svelte
@@ -1,0 +1,100 @@
+<script>
+  import axios from 'axios';
+
+  export let scenarioId = null;
+
+  let months = [];
+  let loading = false;
+  let error = null;
+
+  let lastId = null;
+  $: if (scenarioId != null && scenarioId !== lastId) {
+    lastId = scenarioId;
+    fetch();
+  }
+
+  async function fetch() {
+    loading = true; error = null; months = [];
+    try {
+      const res = await axios.get(`/api/simulation/scenarios/${scenarioId}/cash-flow`);
+      months = res.data.months || [];
+    } catch (e) {
+      error = e.response?.data?.message || 'fetch failed';
+    } finally { loading = false; }
+  }
+
+  const W = 700, H = 300;
+  const PAD = { top: 20, right: 30, bottom: 50, left: 70 };
+  const plotW = W - PAD.left - PAD.right;
+  const plotH = H - PAD.top - PAD.bottom;
+
+  let yMin = 0, yMax = 1;
+  $: {
+    let mn = 0, mx = 1;
+    for (const m of months) {
+      if (m.endingCash < mn) mn = m.endingCash;
+      if (m.endingCash > mx) mx = m.endingCash;
+    }
+    const pad = Math.max((mx - mn) * 0.1, 1000);
+    yMin = Math.min(mn, -pad);
+    yMax = Math.max(mx, pad);
+  }
+
+  function y(v) { return PAD.top + plotH - ((v - yMin) / (yMax - yMin)) * plotH; }
+  function cx(i) {
+    return months.length > 1 ? PAD.left + i * (plotW / (months.length - 1)) : PAD.left + plotW / 2;
+  }
+  function fmt(n) { return (Math.abs(n) / 1000).toFixed(0) + 'k'; }
+
+  $: linePoints = months.map((m, i) => cx(i) + ',' + y(m.endingCash)).join(' ');
+  $: areaPoints = months.length > 1
+    ? cx(0) + ',' + y(0) + ' ' + linePoints + ' ' + cx(months.length - 1) + ',' + y(0)
+    : '';
+</script>
+
+{#if loading}
+  <p class="text-muted text-center py-4">...</p>
+{:else if error}
+  <p class="text-danger">{error}</p>
+{:else if months.length === 0}
+  <p class="text-muted text-center py-4">No cash data</p>
+{:else}
+  <svg viewBox="0 0 {W} {H}" width="100%" style="max-width:700px;">
+    <line x1={PAD.left} y1={y(0)} x2={PAD.left + plotW} y2={y(0)} stroke="#aaa" stroke-dasharray="6,3" />
+    <line x1={PAD.left} y1={PAD.top} x2={PAD.left} y2={PAD.top + plotH} stroke="#ccc" />
+    <line x1={PAD.left} y1={PAD.top + plotH} x2={PAD.left + plotW} y2={PAD.top + plotH} stroke="#ccc" />
+
+    {#each [0, 0.25, 0.5, 0.75, 1] as pct}
+      <line x1={PAD.left} y1={PAD.top + pct * plotH} x2={PAD.left + plotW} y2={PAD.top + pct * plotH} stroke="#eee" stroke-dasharray="4,4" />
+      <text x={PAD.left - 5} y={PAD.top + pct * plotH + 4} text-anchor="end" font-size="10" fill="#888">{fmt(yMin + pct * (yMax - yMin))}</text>
+    {/each}
+
+    {#if months.length > 1}
+      <polygon points={areaPoints} fill="rgba(13,110,253,0.08)" />
+      <polyline points={linePoints} fill="none" stroke="#0d6efd" stroke-width="2.5" stroke-linejoin="round" />
+    {/if}
+
+    {#each months as m, i}
+      <circle cx={cx(i)} cy={y(m.endingCash)} r="4" fill={m.endingCash < 0 ? '#dc3545' : '#0d6efd'} stroke="#fff" stroke-width="2" />
+      <text x={cx(i)} y={y(m.endingCash) - 8} text-anchor="middle" font-size="9" fill={m.endingCash < 0 ? '#c00000' : '#333'}>{fmt(m.endingCash)}</text>
+      <text x={cx(i)} y={PAD.top + plotH + 16} text-anchor="middle" font-size="10" fill="#666" transform="rotate(-25, {cx(i)}, {PAD.top + plotH + 16})">{m.month.substring(5)}</text>
+    {/each}
+  </svg>
+
+  <table class="table table-sm table-bordered mt-2" style="font-size:0.85rem">
+    <thead class="table-light">
+      <tr><th>Month</th><th class="text-end">Cash In</th><th class="text-end">Cash Out</th><th class="text-end">Net Flow</th><th class="text-end">Ending Cash</th></tr>
+    </thead>
+    <tbody>
+      {#each months as m}
+        <tr>
+          <td>{m.month}</td>
+          <td class="text-end">{m.cashIn.toLocaleString()}</td>
+          <td class="text-end">{m.cashOut.toLocaleString()}</td>
+          <td class="text-end" style="color:{m.netFlow >= 0 ? '#0a7d28' : '#c00000'}">{m.netFlow.toLocaleString()}</td>
+          <td class="text-end fw-bold" style="color:{m.endingCash < 0 ? '#c00000' : '#333'}">{m.endingCash.toLocaleString()}</td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+{/if}

--- a/front/svelte/simulation/components/pl-chart.svelte
+++ b/front/svelte/simulation/components/pl-chart.svelte
@@ -1,0 +1,98 @@
+<script>
+  import axios from 'axios';
+
+  export let scenarioId = null;
+
+  let months = [];
+  let loading = false;
+  let error = null;
+
+  let lastId = null;
+  $: if (scenarioId != null && scenarioId !== lastId) {
+    lastId = scenarioId;
+    fetch();
+  }
+
+  async function fetch() {
+    loading = true; error = null; months = [];
+    try {
+      const res = await axios.get(`/api/simulation/scenarios/${scenarioId}/pl`);
+      months = res.data.months || [];
+    } catch (e) {
+      error = e.response?.data?.message || 'fetch failed';
+    } finally { loading = false; }
+  }
+
+  const W = 700, H = 320, PAD = { top: 20, right: 30, bottom: 50, left: 60 };
+  const plotW = W - PAD.left - PAD.right;
+  const plotH = H - PAD.top - PAD.bottom;
+
+  let maxVal = 1;
+  $: {
+    let mv = 1;
+    for (const m of months) {
+      mv = Math.max(mv, m.revenue || 0, m.expense || 0);
+    }
+    maxVal = mv;
+  }
+
+  $: barW = Math.max(plotW / Math.max(months.length, 1) * 0.35, 8);
+  $: barPad = plotW / Math.max(months.length, 1);
+
+  function y(v) { return PAD.top + plotH - (v / maxVal) * plotH; }
+  function cx(i) { return PAD.left + (i + 0.5) * barPad; }
+  function fmt(n) { return (n / 1000).toFixed(0) + 'k'; }
+</script>
+
+{#if loading}
+  <p class="text-muted text-center py-4">...</p>
+{:else if error}
+  <p class="text-danger">{error}</p>
+{:else if months.length === 0}
+  <p class="text-muted text-center py-4">No P/L data</p>
+{:else}
+  <svg viewBox="0 0 {W} {H}" width="100%" style="max-width:700px;">
+    <line x1={PAD.left} y1={PAD.top} x2={PAD.left} y2={PAD.top + plotH} stroke="#ccc" />
+    <line x1={PAD.left} y1={PAD.top + plotH} x2={PAD.left + plotW} y2={PAD.top + plotH} stroke="#ccc" />
+
+    {#each [0, 0.25, 0.5, 0.75, 1] as pct}
+      <line x1={PAD.left} y1={PAD.top + plotH - pct * plotH} x2={PAD.left + plotW} y2={PAD.top + plotH - pct * plotH} stroke="#eee" stroke-dasharray="4,4" />
+      <text x={PAD.left - 5} y={PAD.top + plotH - pct * plotH + 4} text-anchor="end" font-size="10" fill="#888">{fmt(maxVal * pct)}</text>
+    {/each}
+
+    {#each months as m, i}
+      <rect x={cx(i) - barW} y={y(m.revenue)} width={barW} height={plotH - (y(m.revenue) - PAD.top)} fill="#0d6efd" rx="1" />
+      <rect x={cx(i)} y={y(m.expense)} width={barW} height={plotH - (y(m.expense) - PAD.top)} fill="#dc3545" rx="1" />
+      <text x={cx(i)} y={PAD.top + plotH + 16} text-anchor="middle" font-size="10" fill="#666" transform="rotate(-25, {cx(i)}, {PAD.top + plotH + 16})">{m.month.substring(5)}</text>
+      <text x={cx(i)} y={y(Math.max(m.netIncome, 0)) - 4} text-anchor="middle" font-size="9" fill={m.netIncome >= 0 ? '#0a7d28' : '#c00000'}>
+        {m.netIncome >= 0 ? '+' : ''}{fmt(Math.abs(m.netIncome))}
+      </text>
+    {/each}
+
+    <rect x={PAD.left + plotW - 180} y={PAD.top} width={12} height={12} rx="2" fill="#0d6efd" />
+    <text x={PAD.left + plotW - 165} y={PAD.top + 10} font-size="10" fill="#333">Revenue</text>
+    <rect x={PAD.left + plotW - 100} y={PAD.top} width={12} height={12} rx="2" fill="#dc3545" />
+    <text x={PAD.left + plotW - 85} y={PAD.top + 10} font-size="10" fill="#333">Expense</text>
+  </svg>
+
+  <table class="table table-sm table-bordered mt-2" style="font-size:0.85rem">
+    <thead class="table-light">
+      <tr>
+        <th>Month</th>
+        <th class="text-end">Revenue</th>
+        <th class="text-end">Expense</th>
+        <th class="text-end">Net Income</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each months as m}
+        <tr>
+          <td>{m.month}</td>
+          <td class="text-end">{m.revenue.toLocaleString()}</td>
+          <td class="text-end">{m.expense.toLocaleString()}</td>
+          <td class="text-end" style="color:{m.netIncome >= 0 ? '#0a7d28' : '#c00000'}">{m.netIncome.toLocaleString()}</td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+{/if}

--- a/front/svelte/simulation/detail.svelte
+++ b/front/svelte/simulation/detail.svelte
@@ -141,6 +141,12 @@
         canEdit={canEdit}
         canRegenerate={!!(status && status.user && (status.user.administrable || status.user.accounting))}
         {toast} />
+
+    {:else if activeTab === 'pl'}
+      <PlChart scenarioId={scenarioId} />
+
+    {:else if activeTab === 'cash'}
+      <CashChart scenarioId={scenarioId} />
     {/if}
   </div>
   {:else if loading}
@@ -221,6 +227,8 @@
   import ComparisonTab from './components/comparison-tab.svelte';
   import LifecycleModals from './components/lifecycle-modals.svelte';
   import AssumptionsTab from './components/assumptions-tab.svelte';
+  import PlChart from './components/pl-chart.svelte';
+  import CashChart from './components/cash-chart.svelte';
 
   export let toast = undefined;
   export let status = undefined;
@@ -237,6 +245,8 @@
     { value: 'tb', ja: '試算表', vi: 'Bảng cân đối' },
     { value: 'comparison', ja: '比較', vi: 'So sánh' },
     { value: 'assumptions', ja: '前提条件', vi: 'Giả định' },
+    { value: 'pl', ja: '損益', vi: 'Lãi/Lỗ' },
+    { value: 'cash', ja: '資金', vi: 'Dòng tiền' },
   ];
 
   // TB tab

--- a/libs/simulation/warnings.js
+++ b/libs/simulation/warnings.js
@@ -1,0 +1,106 @@
+/**
+ * Simulation warnings — Issue #273 (E3.12).
+ *
+ * Detects:
+ *   SIM-W010: cash balance negative in any month (from cashProjection)
+ *   SIM-W011: recurring assumptions overlap (same account + date)
+ *   SIM-W012: expense counter account not found
+ */
+
+import models from '../../models/index.js';
+import { generateRecurringEntries } from './assumption-generator.js';
+
+/**
+ * Detect all warnings for a scenario.
+ * @returns { warnings: [{ code, severity, message, detail }] }
+ */
+export async function detectWarnings(tenantId, scenarioId) {
+  const warnings = [];
+
+  // Load active assumptions
+  const assumptions = await models.SimulationAssumption.findAll({
+    where: { tenantId, scenarioId, status: 'active' },
+  });
+
+  const scenario = await models.SimulationScenario.findOne({
+    where: { tenantId, id: scenarioId },
+  });
+
+  if (!scenario) return { warnings };
+
+  // --- SIM-W011: recurring overlap ---
+  const recurrings = assumptions.filter(a => a.type === 'recurring');
+  if (recurrings.length > 1) {
+    const entryMap = new Map(); // key = "account_date_amount"
+    for (const a of recurrings) {
+      const entries = generateRecurringEntries(a, scenario);
+      for (const e of entries) {
+        const key = `${e.debitAccount}_${e.creditAccount}_${e.date}`;
+        if (entryMap.has(key)) {
+          entryMap.get(key).push(a.name);
+        } else {
+          entryMap.set(key, [a.name]);
+        }
+      }
+    }
+    for (const [key, names] of entryMap) {
+      if (names.length > 1) {
+        warnings.push({
+          code: 'SIM-W011',
+          severity: 'low',
+          message: `Overlapping recurring entries: ${names.join(', ')}`,
+          detail: `Same accounts + date: ${key}`,
+        });
+      }
+    }
+  }
+
+  // --- SIM-W012: expense counter account existence ---
+  const accountCodes = new Set();
+  for (const a of assumptions) {
+    const p = a.parameters || {};
+    if (p.counterAccount) accountCodes.add(p.counterAccount);
+    if (p.creditAccount) accountCodes.add(p.creditAccount);
+    if (p.debitAccount) accountCodes.add(p.debitAccount);
+  }
+
+  if (accountCodes.size > 0) {
+    const existing = await models.Account.findAll({
+      where: { tenantId, accountCode: { [models.Sequelize.Op.in]: [...accountCodes] } },
+    });
+    const existingCodes = new Set(existing.map(a => a.accountCode));
+
+    for (const a of assumptions) {
+      const p = a.parameters || {};
+      if (p.counterAccount && !existingCodes.has(p.counterAccount)) {
+        warnings.push({
+          code: 'SIM-W012',
+          severity: 'high',
+          message: `Counter account ${p.counterAccount} not found for "${a.name}"`,
+          detail: `Assumption type: ${a.type}`,
+        });
+      }
+    }
+  }
+
+  return { warnings };
+}
+
+/**
+ * Detect cash warning from projection data.
+ * Caller passes the cash projection months array from cashProjection().
+ */
+export function detectCashWarnings(projectionMonths) {
+  const warnings = [];
+  for (const m of projectionMonths) {
+    if (m.endingCash < 0) {
+      warnings.push({
+        code: 'SIM-W010',
+        severity: 'high',
+        message: `Cash balance negative in ${m.month}: ${m.endingCash.toLocaleString()}`,
+        detail: `Ending cash of month ${m.month} is below zero`,
+      });
+    }
+  }
+  return warnings;
+}


### PR DESCRIPTION
Part of epic:forecast

Closes #272
Closes #273

### Test Report
- **Scope:** P/L bar chart (revenue/expense bars, net income labels), Cash line chart (ending balance, negative highlight), warnings (SIM-W010 cash negative, SIM-W011 overlap, SIM-W012 missing counter account)
- **Results:** npm run build OK (28.30s)
- **Smoke:** Native Svelte SVG, 0 chart dependencies, responsive