### PR TITLE
fix(#300): redirect closing to /reports/trial-balance instead of legacy /trial-balance

### DIFF
--- a/front/svelte/closing/closing-confirm.svelte
+++ b/front/svelte/closing/closing-confirm.svelte
@@ -104,7 +104,7 @@ const runClosing = async () => {
   try {
     const res = await axios.post(`/api/closing/${term}`, { plResetAcknowledged });
     if (res.data && res.data.code === 0) {
-      link(`/trial-balance?closed=${term}`);
+      link(`/reports/trial-balance?closed=${term}`);
     } else {
       submitError = res.data?.message || 'Closing failed.';
     }


### PR DESCRIPTION
Part of #290