### PR TITLE
fix(#301): improve TB v2 + simulation tab contrast

### DIFF
--- a/front/svelte/reports/trial-balance.svelte
+++ b/front/svelte/reports/trial-balance.svelte
@@ -609,8 +609,9 @@
     margin-left: 0.4em;
     vertical-align: middle;
   }
-  .tb-tabs { margin-top: 0.5rem; }
-  .tb-tab { min-width: 9rem; }
+  .tb-tabs { margin-top: 0.5rem; border-bottom: 2px solid #dee2e6; }
+  .tb-tab { min-width: 9rem; color: #333; font-weight: 500; border: 1px solid transparent; border-bottom: none; background: #f8f9fa; }
+  .tb-tab.active { color: #000; font-weight: 600; background: #fff; border-color: #dee2e6 #dee2e6 #fff; }
   .tb-period-label { font-weight: 500; }
   .tb-meta { font-size: 0.85rem; }
   .tb-hide-zero-label { font-size: 0.85rem; display: inline-flex; align-items: center; gap: 0.3rem; }

--- a/front/svelte/simulation/detail.svelte
+++ b/front/svelte/simulation/detail.svelte
@@ -474,7 +474,9 @@
   .badge.sim-badge-draft { background: #6c757d; }
   .badge.sim-badge-locked { background: #0d6efd; }
   .badge.sim-badge-archived { background: #adb5bd; color: #333; }
-  .sim-tabs .sim-tab { font-size: 0.9rem; }
+  .sim-tabs { border-bottom: 2px solid #dee2e6; }
+  .sim-tab { font-size: 0.9rem; color: #333; font-weight: 500; background: #f8f9fa; border: 1px solid transparent; border-bottom: none; }
+  .sim-tab.active { color: #000; font-weight: 600; background: #fff; border-color: #dee2e6 #dee2e6 #fff; }
   .sim-entry-table, .sim-cmp-table { font-size: 0.9rem; }
   .sim-num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
   .sim-code { font-family: monospace; white-space: nowrap; }


### PR DESCRIPTION
Part of #290. Root cause: global .nav-link color (#eeeeee) from sidebar dark theme bleeds into content tabs. Added explicit color/font-weight for active/inactive states.