### PR TITLE
feat(#321): TB v2 separate expand column and bilingual subtotal badges

### DIFF
--- a/front/svelte/reports/trial-balance-list.svelte
+++ b/front/svelte/reports/trial-balance-list.svelte
@@ -3,9 +3,8 @@
 
   Renders one row per line in the v2 contract (account | subAccount |
   subtotal), with a synthetic 'parent' row above each cluster of
-  subAccount rows (大/中/小/勘定/補助科目). Expand/collapse is per account:
-  the parent row carries a [+/-] button that toggles visibility of its
-  subAccount children via the `expanded` set.
+  subAccount rows (大/中/小/勘定/補助科目). Expand/collapse lives in a
+  dedicated narrow column (chevron); the code column shows account codes only.
 
   Indent comes from the `indentClass(line)` helper in
   libs/reporting/tb-hierarchy.js, mapped to .tb-indent-0..4 in the
@@ -24,10 +23,11 @@
   {@const showMovement = reportType === 'movement' || reportType === 'combined'}
   {@const showEnding = reportType === 'balance' || reportType === 'combined'}
   {@const showBalance = reportType === 'balance' || reportType === 'combined' || reportType === 'movement'}
-  {@const colCount = 2 + (showOpening ? 2 : 0) + (showMovement ? 2 : 0) + (showEnding ? 2 : 0) + (showBalance ? 1 : 0)}
+  {@const colCount = 3 + (showOpening ? 2 : 0) + (showMovement ? 2 : 0) + (showEnding ? 2 : 0) + (showBalance ? 1 : 0)}
 <table class="table table-bordered table-sm tb-v2-table">
   <thead class="tb-v2-thead">
     <tr>
+      <th scope="col" class="tb-col-expand" aria-label="expand"></th>
       <th scope="col" class="tb-col-code"><BilingualText primary="科目" secondary="Mã" /></th>
       <th scope="col" class="tb-col-name"><BilingualText key="account_name" /></th>
       {#if showOpening}
@@ -55,26 +55,33 @@
           class:tb-warning-row={(l.warningCodes || []).some((c) => c === 'TB-W005')}
           class={indentClass(l)}
           on:click={() => onRowClick(l)}>
-        <td class="tb-col-code">
-          {#if l.type === 'subtotal'}
-            <span class="tb-subtotal-label">【{l.level}】</span>
-          {:else if l.type === 'parent'}
+        <td class="tb-col-expand">
+          {#if l.type === 'parent'}
             <button type="button"
-              class="btn btn-sm btn-link tb-toggle p-0 me-1"
+              class="btn btn-sm btn-link tb-toggle p-0"
               aria-label={isExpanded(l.code) ? 'collapse' : 'expand'}
-              on:click={() => onToggle(l.code)}>
-              {isExpanded(l.code) ? '−' : '+'}
+              aria-expanded={isExpanded(l.code)}
+              on:click|stopPropagation={() => onToggle(l.code)}>
+              <i class="bi {isExpanded(l.code) ? 'bi-chevron-down' : 'bi-chevron-right'}" aria-hidden="true"></i>
             </button>
-            <span class="tb-code-text">{l.code}</span>
-          {:else if l.subCode != null}
-            {l.code}-{l.subCode}
-          {:else}
-            {l.code}
+          {/if}
+        </td>
+        <td class="tb-col-code" class:tb-code-parent={l.type === 'parent'} class:tb-code-sub={l.type === 'subAccount'}>
+          {#if l.type !== 'subtotal' && l.code != null}
+            {#if l.subCode != null}
+              {l.code}-{l.subCode}
+            {:else}
+              {l.code}
+            {/if}
           {/if}
         </td>
         <td class="tb-col-name">
           {#if l.type === 'subtotal'}
+            {@const lvl = subtotalLevelLabel(l.level)}
             {@const dn = pickDisplayName({ name: l.name, nameVi: l.nameVi, code: l.code }, languageMode)}
+            <span class="tb-subtotal-badge">
+              <BilingualText primary={lvl.primary} secondary={lvl.secondary} stacked={false} />
+            </span>
             <strong>{dn.primary}</strong>
             {#if dn.secondary}<span class="tb-name-vi"> / {dn.secondary}</span>{/if}
           {:else if l.type === 'parent'}
@@ -136,6 +143,15 @@
 
   const isExpanded = (code) => code != null && expanded.has(code);
 
+  const SUBTOTAL_LEVEL_LABELS = {
+    major: { primary: '大計', secondary: 'Tổng cấp lớn' },
+    middle: { primary: '中計', secondary: 'Tổng cấp trung' },
+    minor: { primary: '小計', secondary: 'Tổng cấp nhỏ' },
+  };
+
+  const subtotalLevelLabel = (level) =>
+    SUBTOTAL_LEVEL_LABELS[level] || { primary: level || '', secondary: null };
+
   const keyFor = (l) => {
     if (l.type === 'subtotal') return `subtotal:${l.level}:${l.major}:${l.middle}:${l.minor}`;
     if (l.type === 'parent') return `parent:${l.code}`;
@@ -167,23 +183,48 @@
     opacity: 1;
   }
   .tb-v2-thead th.tb-col-num { white-space: normal; text-align: right; }
+  .tb-col-expand {
+    width: 1.75rem;
+    min-width: 1.75rem;
+    max-width: 1.75rem;
+    padding: 0.25rem 0.15rem;
+    text-align: center;
+    vertical-align: middle;
+  }
+  .tb-v2-thead th.tb-col-expand { padding: 0.25rem; }
   .tb-col-num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
   .tb-col-code { font-family: monospace; word-break: break-all; max-width: 11rem; min-width: 6rem; }
+  .tb-code-parent { font-weight: 600; }
+  .tb-code-sub { color: #555; }
   .tb-col-name { min-width: 14rem; }
   .tb-col-balance { font-weight: 500; }
   .tb-balance-negative { color: #c00000; }
   .tb-subtotal { background: #f3f3f3; }
   .tb-subtotal .tb-col-num { font-weight: 600; }
-  .tb-subtotal-label { color: #666; font-size: 0.8rem; }
+  .tb-subtotal-badge {
+    display: inline-block;
+    margin-right: 0.4rem;
+    padding: 0.05rem 0.35rem;
+    border-radius: 0.2rem;
+    background: #e2e2e2;
+    color: #444;
+    font-size: 0.75rem;
+    font-weight: 600;
+    vertical-align: baseline;
+  }
+  .tb-subtotal-badge :global(.bilingual-secondary) {
+    color: #666;
+    font-weight: 500;
+  }
   .tb-sub-name { color: #555; }
   .tb-sub-name-vi, .tb-name-vi { color: #777; font-size: 0.85em; }
 
   /* 5-level indent: 大/中/小/勘定/補助 */
-  .tb-indent-0 td.tb-col-code { padding-left: 0.5rem; }
-  .tb-indent-1 td.tb-col-code { padding-left: 1.25rem; }
-  .tb-indent-2 td.tb-col-code { padding-left: 2.0rem; }
-  .tb-indent-3 td.tb-col-code { padding-left: 2.75rem; }
-  .tb-indent-4 td.tb-col-code { padding-left: 3.75rem; }
+  .tb-indent-0 td.tb-col-expand { padding-left: 0.25rem; }
+  .tb-indent-1 td.tb-col-expand { padding-left: 0.75rem; }
+  .tb-indent-2 td.tb-col-expand { padding-left: 1.25rem; }
+  .tb-indent-3 td.tb-col-expand { padding-left: 1.75rem; }
+  .tb-indent-4 td.tb-col-expand { padding-left: 2.25rem; }
   .tb-indent-3 td.tb-col-name,
   .tb-indent-4 td.tb-col-name { padding-left: 0.5rem; }
 
@@ -191,16 +232,17 @@
   .tb-parent .tb-col-name { font-weight: 600; }
   .tb-parent .tb-col-num { font-weight: 500; }
   .tb-toggle {
-    display: inline-block;
-    width: 1.4em;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
     line-height: 1;
-    font-weight: 600;
     color: #555;
     text-decoration: none;
-    font-family: monospace;
   }
   .tb-toggle:hover { color: #000; }
-  .tb-code-text { font-family: monospace; }
+  .tb-toggle .bi { font-size: 0.85rem; }
   .tb-clickable { cursor: pointer; }
   .tb-clickable:hover { background: #f0f6ff; }
   .tb-warning-row { background: #fde7e7; }


### PR DESCRIPTION
## Summary

- Thêm cột expand hẹp với chevron (Bootstrap Icons)
- Cột Mã chỉ hiển thị mã số; subtotal để trống
- Badge song ngữ 大計/中計/小計 ở cột Tên cho dòng tổng

Part of epic #320

## Test plan

- [x] `npm run build` ✅
- [ ] Smoke: mở `/reports/trial-balance` — parent có chevron, subtotal badge, mã thống nhất
