### PR TITLE
fix(#323): TB drill-down modal data timing, locale keys, backdrop dismiss

### DIFF
--- a/front/javascripts/locales/en.json
+++ b/front/javascripts/locales/en.json
@@ -342,6 +342,8 @@
   "language_pair_vi_ja": "Vietnamese / Japanese",
   "language_select": "Select Language Pair",
   "ledger": "Ledger",
+  "open_full_ledger": "Open full ledger",
+  "tb_drill_missing_context": "Missing fiscal term or account",
   "legal_name": "Legal Name",
   "legal_name_label": "Legal Name",
   "liabilities_section": "Liabilities",

--- a/front/javascripts/locales/ja.json
+++ b/front/javascripts/locales/ja.json
@@ -67,6 +67,8 @@
   "item_class_name": "種別名",
   "journal": "仕訳日記帳",
   "ledger": "元帳",
+  "open_full_ledger": "元帳を開く",
+  "tb_drill_missing_context": "会計年度または勘定科目が指定されていません",
   "bank_ledger": "銀行元帳",
   "trial_balance": "残高試算表",
   "trial_balance_v2": "試算表",

--- a/front/javascripts/locales/vi.json
+++ b/front/javascripts/locales/vi.json
@@ -67,6 +67,8 @@
   "item_class_name": "Tên loại",
   "journal": "Sổ nhật ký",
   "ledger": "Sổ cái",
+  "open_full_ledger": "Mở sổ cái đầy đủ",
+  "tb_drill_missing_context": "Thiếu kỳ kế toán hoặc mã tài khoản",
   "bank_ledger": "Sổ cái ngân hàng",
   "trial_balance": "Bảng cân đối số dư",
   "trial_balance_v2": "Bảng cân đối thử",

--- a/front/svelte/reports/trial-balance-drilldown.svelte
+++ b/front/svelte/reports/trial-balance-drilldown.svelte
@@ -6,8 +6,7 @@
   /api/ledger/:term/:account[/:subAccount]?from=&to= and shows them in
   a compact table. Phase 1: modal. Phase 2: viewport-wide → side panel.
 
-  Closing on ESC / outside-click is handled by bootstrap's Modal class
-  (data-bs-backdrop="static" set on the .modal element).
+  Closing on ESC / outside-click uses Bootstrap Modal default backdrop.
 
   Props (bindable via the parent):
     term          — FiscalYear.term, comes from status.fy.term
@@ -19,15 +18,15 @@
   Methods:
     open() / close()
 -->
-<div class="modal" bind:this={modalEl} tabindex="-1" data-bs-backdrop="static">
+<div class="modal" bind:this={modalEl} tabindex="-1">
   <div class="modal-dialog modal-xl modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">
           <BilingualText key="ledger" inline={true} />
-          {#if accountCode}
+          {#if viewCode ?? accountCode}
             <span class="tb-drill-account">
-              / {accountCode}{subCode != null ? '-' + subCode : ''}{accountName ? ' ' + accountName : ''}
+              / {viewCode ?? accountCode}{(viewSub ?? subCode) != null ? '-' + (viewSub ?? subCode) : ''}{(viewName ?? accountName) ? ' ' + (viewName ?? accountName) : ''}
             </span>
           {/if}
         </h5>
@@ -37,6 +36,8 @@
       <div class="modal-body">
         {#if loading}
           <p class="text-muted">...</p>
+        {:else if errorKey}
+          <p class="text-danger"><BilingualText key={errorKey} inline={true} /></p>
         {:else if error}
           <p class="text-danger">{error}</p>
         {:else}
@@ -116,10 +117,23 @@
   let lines = [];
   let loading = false;
   let error = null;
+  let errorKey = null;
+  /** Snapshot for the active modal session (avoids prop timing on open()). */
+  let viewTerm = null;
+  let viewCode = null;
+  let viewSub = null;
+  let viewName = null;
 
-  export const open = async () => {
-    if (!term || !accountCode) {
-      error = 'missing term or account';
+  export const open = async (overrides = {}) => {
+    viewTerm = overrides.term ?? term;
+    viewCode = overrides.accountCode ?? accountCode;
+    viewSub = overrides.subCode !== undefined ? overrides.subCode : subCode;
+    viewName = overrides.accountName ?? accountName;
+    error = null;
+    errorKey = null;
+
+    if (!viewTerm || !viewCode) {
+      errorKey = 'tb_drill_missing_context';
       modal?.show();
       return;
     }
@@ -129,17 +143,26 @@
 
   export const close = () => {
     modal?.hide();
+  };
+
+  const resetState = () => {
     lines = [];
     error = null;
+    errorKey = null;
+    viewTerm = null;
+    viewCode = null;
+    viewSub = null;
+    viewName = null;
   };
 
   const load = async () => {
     loading = true;
     error = null;
+    errorKey = null;
     try {
-      const path = subCode != null
-        ? `/api/ledger/${term}/${accountCode}/${subCode}`
-        : `/api/ledger/${term}/${accountCode}`;
+      const path = viewSub != null
+        ? `/api/ledger/${viewTerm}/${viewCode}/${viewSub}`
+        : `/api/ledger/${viewTerm}/${viewCode}`;
       const r = await axios.get(path);
       lines = r.data || [];
     } catch (e) {
@@ -156,9 +179,8 @@
   };
 
   const counterAccountLabel = (l) => {
-    // For a debit-side entry on our account, the counter is creditAccount.
-    // For a credit-side entry, the counter is debitAccount.
-    if (l.debitAccount === accountCode) {
+    const code = viewCode ?? accountCode;
+    if (l.debitAccount === code) {
       return l.creditAccount + (l.creditSubAccount ? '-' + l.creditSubAccount : '');
     }
     return l.debitAccount + (l.debitSubAccount ? '-' + l.debitSubAccount : '');
@@ -176,14 +198,16 @@
     return `${dt.getFullYear()}-${String(dt.getMonth()+1).padStart(2,'0')}-${String(dt.getDate()).padStart(2,'0')}`;
   };
 
-  $: fullLedgerHref = accountCode
-    ? (subCode != null
-        ? `/ledger/${term}/${accountCode}/${subCode}`
-        : `/ledger/${term}/${accountCode}`)
+  $: fullLedgerHref = (viewCode ?? accountCode) && (viewTerm ?? term)
+    ? ((viewSub ?? subCode) != null
+        ? `/ledger/${viewTerm ?? term}/${viewCode ?? accountCode}/${viewSub ?? subCode}`
+        : `/ledger/${viewTerm ?? term}/${viewCode ?? accountCode}`)
     : '#';
 
   onMount(() => {
     modal = new Modal(modalEl);
+    modalEl.addEventListener('hidden.bs.modal', resetState);
+    return () => modalEl.removeEventListener('hidden.bs.modal', resetState);
   });
 </script>
 

--- a/front/svelte/reports/trial-balance.svelte
+++ b/front/svelte/reports/trial-balance.svelte
@@ -644,7 +644,12 @@
     } else {
       return;
     }
-    drilldown?.open();
+    drilldown?.open({
+      term: status?.fy?.term,
+      accountCode: drillAccount.code,
+      subCode: drillAccount.subCode,
+      accountName: drillAccount.name,
+    });
   };
 
   const formatInt = (n) => {


### PR DESCRIPTION
## Summary

- Fix race: `open()` nhận `{ term, accountCode, ... }` trực tiếp từ parent
- Thêm locale `open_full_ledger`, `tb_drill_missing_context` (ja/vi/en)
- Bỏ `data-bs-backdrop="static"` — click ngoài / ESC đóng modal

Part of epic #320

## Test plan

- [x] `npm run build` ✅
- [ ] Click row TB → modal load entries
- [ ] Nút hiển thị 元帳を開く / Mở sổ cái đầy đủ
- [ ] Click backdrop → modal đóng
