### PR TITLE
epic(tb-ux-polish): TB code column UX + drill-down modal fixes

### DIFF
--- a/front/javascripts/locales/en.json
+++ b/front/javascripts/locales/en.json
@@ -342,6 +342,8 @@
   "language_pair_vi_ja": "Vietnamese / Japanese",
   "language_select": "Select Language Pair",
   "ledger": "Ledger",
+  "open_full_ledger": "Open full ledger",
+  "tb_drill_missing_context": "Missing fiscal term or account",
   "legal_name": "Legal Name",
   "legal_name_label": "Legal Name",
   "liabilities_section": "Liabilities",

--- a/front/javascripts/locales/ja.json
+++ b/front/javascripts/locales/ja.json
@@ -67,6 +67,8 @@
   "item_class_name": "種別名",
   "journal": "仕訳日記帳",
   "ledger": "元帳",
+  "open_full_ledger": "元帳を開く",
+  "tb_drill_missing_context": "会計年度または勘定科目が指定されていません",
   "bank_ledger": "銀行元帳",
   "trial_balance": "残高試算表",
   "trial_balance_v2": "試算表",

--- a/front/javascripts/locales/vi.json
+++ b/front/javascripts/locales/vi.json
@@ -67,6 +67,8 @@
   "item_class_name": "Tên loại",
   "journal": "Sổ nhật ký",
   "ledger": "Sổ cái",
+  "open_full_ledger": "Mở sổ cái đầy đủ",
+  "tb_drill_missing_context": "Thiếu kỳ kế toán hoặc mã tài khoản",
   "bank_ledger": "Sổ cái ngân hàng",
   "trial_balance": "Bảng cân đối số dư",
   "trial_balance_v2": "Bảng cân đối thử",

--- a/front/svelte/reports/trial-balance-drilldown.svelte
+++ b/front/svelte/reports/trial-balance-drilldown.svelte
@@ -6,8 +6,7 @@
   /api/ledger/:term/:account[/:subAccount]?from=&to= and shows them in
   a compact table. Phase 1: modal. Phase 2: viewport-wide → side panel.
 
-  Closing on ESC / outside-click is handled by bootstrap's Modal class
-  (data-bs-backdrop="static" set on the .modal element).
+  Closing on ESC / outside-click uses Bootstrap Modal default backdrop.
 
   Props (bindable via the parent):
     term          — FiscalYear.term, comes from status.fy.term
@@ -19,15 +18,15 @@
   Methods:
     open() / close()
 -->
-<div class="modal" bind:this={modalEl} tabindex="-1" data-bs-backdrop="static">
+<div class="modal" bind:this={modalEl} tabindex="-1">
   <div class="modal-dialog modal-xl modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">
           <BilingualText key="ledger" inline={true} />
-          {#if accountCode}
+          {#if viewCode ?? accountCode}
             <span class="tb-drill-account">
-              / {accountCode}{subCode != null ? '-' + subCode : ''}{accountName ? ' ' + accountName : ''}
+              / {viewCode ?? accountCode}{(viewSub ?? subCode) != null ? '-' + (viewSub ?? subCode) : ''}{(viewName ?? accountName) ? ' ' + (viewName ?? accountName) : ''}
             </span>
           {/if}
         </h5>
@@ -37,6 +36,8 @@
       <div class="modal-body">
         {#if loading}
           <p class="text-muted">...</p>
+        {:else if errorKey}
+          <p class="text-danger"><BilingualText key={errorKey} inline={true} /></p>
         {:else if error}
           <p class="text-danger">{error}</p>
         {:else}
@@ -116,10 +117,23 @@
   let lines = [];
   let loading = false;
   let error = null;
+  let errorKey = null;
+  /** Snapshot for the active modal session (avoids prop timing on open()). */
+  let viewTerm = null;
+  let viewCode = null;
+  let viewSub = null;
+  let viewName = null;
 
-  export const open = async () => {
-    if (!term || !accountCode) {
-      error = 'missing term or account';
+  export const open = async (overrides = {}) => {
+    viewTerm = overrides.term ?? term;
+    viewCode = overrides.accountCode ?? accountCode;
+    viewSub = overrides.subCode !== undefined ? overrides.subCode : subCode;
+    viewName = overrides.accountName ?? accountName;
+    error = null;
+    errorKey = null;
+
+    if (!viewTerm || !viewCode) {
+      errorKey = 'tb_drill_missing_context';
       modal?.show();
       return;
     }
@@ -129,17 +143,26 @@
 
   export const close = () => {
     modal?.hide();
+  };
+
+  const resetState = () => {
     lines = [];
     error = null;
+    errorKey = null;
+    viewTerm = null;
+    viewCode = null;
+    viewSub = null;
+    viewName = null;
   };
 
   const load = async () => {
     loading = true;
     error = null;
+    errorKey = null;
     try {
-      const path = subCode != null
-        ? `/api/ledger/${term}/${accountCode}/${subCode}`
-        : `/api/ledger/${term}/${accountCode}`;
+      const path = viewSub != null
+        ? `/api/ledger/${viewTerm}/${viewCode}/${viewSub}`
+        : `/api/ledger/${viewTerm}/${viewCode}`;
       const r = await axios.get(path);
       lines = r.data || [];
     } catch (e) {
@@ -156,9 +179,8 @@
   };
 
   const counterAccountLabel = (l) => {
-    // For a debit-side entry on our account, the counter is creditAccount.
-    // For a credit-side entry, the counter is debitAccount.
-    if (l.debitAccount === accountCode) {
+    const code = viewCode ?? accountCode;
+    if (l.debitAccount === code) {
       return l.creditAccount + (l.creditSubAccount ? '-' + l.creditSubAccount : '');
     }
     return l.debitAccount + (l.debitSubAccount ? '-' + l.debitSubAccount : '');
@@ -176,14 +198,16 @@
     return `${dt.getFullYear()}-${String(dt.getMonth()+1).padStart(2,'0')}-${String(dt.getDate()).padStart(2,'0')}`;
   };
 
-  $: fullLedgerHref = accountCode
-    ? (subCode != null
-        ? `/ledger/${term}/${accountCode}/${subCode}`
-        : `/ledger/${term}/${accountCode}`)
+  $: fullLedgerHref = (viewCode ?? accountCode) && (viewTerm ?? term)
+    ? ((viewSub ?? subCode) != null
+        ? `/ledger/${viewTerm ?? term}/${viewCode ?? accountCode}/${viewSub ?? subCode}`
+        : `/ledger/${viewTerm ?? term}/${viewCode ?? accountCode}`)
     : '#';
 
   onMount(() => {
     modal = new Modal(modalEl);
+    modalEl.addEventListener('hidden.bs.modal', resetState);
+    return () => modalEl.removeEventListener('hidden.bs.modal', resetState);
   });
 </script>
 

--- a/front/svelte/reports/trial-balance-list.svelte
+++ b/front/svelte/reports/trial-balance-list.svelte
@@ -3,9 +3,8 @@
 
   Renders one row per line in the v2 contract (account | subAccount |
   subtotal), with a synthetic 'parent' row above each cluster of
-  subAccount rows (大/中/小/勘定/補助科目). Expand/collapse is per account:
-  the parent row carries a [+/-] button that toggles visibility of its
-  subAccount children via the `expanded` set.
+  subAccount rows (大/中/小/勘定/補助科目). Expand/collapse lives in a
+  dedicated narrow column (chevron); the code column shows account codes only.
 
   Indent comes from the `indentClass(line)` helper in
   libs/reporting/tb-hierarchy.js, mapped to .tb-indent-0..4 in the
@@ -24,10 +23,11 @@
   {@const showMovement = reportType === 'movement' || reportType === 'combined'}
   {@const showEnding = reportType === 'balance' || reportType === 'combined'}
   {@const showBalance = reportType === 'balance' || reportType === 'combined' || reportType === 'movement'}
-  {@const colCount = 2 + (showOpening ? 2 : 0) + (showMovement ? 2 : 0) + (showEnding ? 2 : 0) + (showBalance ? 1 : 0)}
+  {@const colCount = 3 + (showOpening ? 2 : 0) + (showMovement ? 2 : 0) + (showEnding ? 2 : 0) + (showBalance ? 1 : 0)}
 <table class="table table-bordered table-sm tb-v2-table">
   <thead class="tb-v2-thead">
     <tr>
+      <th scope="col" class="tb-col-expand" aria-label="expand"></th>
       <th scope="col" class="tb-col-code"><BilingualText primary="科目" secondary="Mã" /></th>
       <th scope="col" class="tb-col-name"><BilingualText key="account_name" /></th>
       {#if showOpening}
@@ -55,26 +55,33 @@
           class:tb-warning-row={(l.warningCodes || []).some((c) => c === 'TB-W005')}
           class={indentClass(l)}
           on:click={() => onRowClick(l)}>
-        <td class="tb-col-code">
-          {#if l.type === 'subtotal'}
-            <span class="tb-subtotal-label">【{l.level}】</span>
-          {:else if l.type === 'parent'}
+        <td class="tb-col-expand">
+          {#if l.type === 'parent'}
             <button type="button"
-              class="btn btn-sm btn-link tb-toggle p-0 me-1"
+              class="btn btn-sm btn-link tb-toggle p-0"
               aria-label={isExpanded(l.code) ? 'collapse' : 'expand'}
-              on:click={() => onToggle(l.code)}>
-              {isExpanded(l.code) ? '−' : '+'}
+              aria-expanded={isExpanded(l.code)}
+              on:click|stopPropagation={() => onToggle(l.code)}>
+              <i class="bi {isExpanded(l.code) ? 'bi-chevron-down' : 'bi-chevron-right'}" aria-hidden="true"></i>
             </button>
-            <span class="tb-code-text">{l.code}</span>
-          {:else if l.subCode != null}
-            {l.code}-{l.subCode}
-          {:else}
-            {l.code}
+          {/if}
+        </td>
+        <td class="tb-col-code" class:tb-code-parent={l.type === 'parent'} class:tb-code-sub={l.type === 'subAccount'}>
+          {#if l.type !== 'subtotal' && l.code != null}
+            {#if l.subCode != null}
+              {l.code}-{l.subCode}
+            {:else}
+              {l.code}
+            {/if}
           {/if}
         </td>
         <td class="tb-col-name">
           {#if l.type === 'subtotal'}
+            {@const lvl = subtotalLevelLabel(l.level)}
             {@const dn = pickDisplayName({ name: l.name, nameVi: l.nameVi, code: l.code }, languageMode)}
+            <span class="tb-subtotal-badge">
+              <BilingualText primary={lvl.primary} secondary={lvl.secondary} stacked={false} />
+            </span>
             <strong>{dn.primary}</strong>
             {#if dn.secondary}<span class="tb-name-vi"> / {dn.secondary}</span>{/if}
           {:else if l.type === 'parent'}
@@ -136,6 +143,15 @@
 
   const isExpanded = (code) => code != null && expanded.has(code);
 
+  const SUBTOTAL_LEVEL_LABELS = {
+    major: { primary: '大計', secondary: 'Tổng cấp lớn' },
+    middle: { primary: '中計', secondary: 'Tổng cấp trung' },
+    minor: { primary: '小計', secondary: 'Tổng cấp nhỏ' },
+  };
+
+  const subtotalLevelLabel = (level) =>
+    SUBTOTAL_LEVEL_LABELS[level] || { primary: level || '', secondary: null };
+
   const keyFor = (l) => {
     if (l.type === 'subtotal') return `subtotal:${l.level}:${l.major}:${l.middle}:${l.minor}`;
     if (l.type === 'parent') return `parent:${l.code}`;
@@ -167,23 +183,48 @@
     opacity: 1;
   }
   .tb-v2-thead th.tb-col-num { white-space: normal; text-align: right; }
+  .tb-col-expand {
+    width: 1.75rem;
+    min-width: 1.75rem;
+    max-width: 1.75rem;
+    padding: 0.25rem 0.15rem;
+    text-align: center;
+    vertical-align: middle;
+  }
+  .tb-v2-thead th.tb-col-expand { padding: 0.25rem; }
   .tb-col-num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
   .tb-col-code { font-family: monospace; word-break: break-all; max-width: 11rem; min-width: 6rem; }
+  .tb-code-parent { font-weight: 600; }
+  .tb-code-sub { color: #555; }
   .tb-col-name { min-width: 14rem; }
   .tb-col-balance { font-weight: 500; }
   .tb-balance-negative { color: #c00000; }
   .tb-subtotal { background: #f3f3f3; }
   .tb-subtotal .tb-col-num { font-weight: 600; }
-  .tb-subtotal-label { color: #666; font-size: 0.8rem; }
+  .tb-subtotal-badge {
+    display: inline-block;
+    margin-right: 0.4rem;
+    padding: 0.05rem 0.35rem;
+    border-radius: 0.2rem;
+    background: #e2e2e2;
+    color: #444;
+    font-size: 0.75rem;
+    font-weight: 600;
+    vertical-align: baseline;
+  }
+  .tb-subtotal-badge :global(.bilingual-secondary) {
+    color: #666;
+    font-weight: 500;
+  }
   .tb-sub-name { color: #555; }
   .tb-sub-name-vi, .tb-name-vi { color: #777; font-size: 0.85em; }
 
   /* 5-level indent: 大/中/小/勘定/補助 */
-  .tb-indent-0 td.tb-col-code { padding-left: 0.5rem; }
-  .tb-indent-1 td.tb-col-code { padding-left: 1.25rem; }
-  .tb-indent-2 td.tb-col-code { padding-left: 2.0rem; }
-  .tb-indent-3 td.tb-col-code { padding-left: 2.75rem; }
-  .tb-indent-4 td.tb-col-code { padding-left: 3.75rem; }
+  .tb-indent-0 td.tb-col-expand { padding-left: 0.25rem; }
+  .tb-indent-1 td.tb-col-expand { padding-left: 0.75rem; }
+  .tb-indent-2 td.tb-col-expand { padding-left: 1.25rem; }
+  .tb-indent-3 td.tb-col-expand { padding-left: 1.75rem; }
+  .tb-indent-4 td.tb-col-expand { padding-left: 2.25rem; }
   .tb-indent-3 td.tb-col-name,
   .tb-indent-4 td.tb-col-name { padding-left: 0.5rem; }
 
@@ -191,16 +232,17 @@
   .tb-parent .tb-col-name { font-weight: 600; }
   .tb-parent .tb-col-num { font-weight: 500; }
   .tb-toggle {
-    display: inline-block;
-    width: 1.4em;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
     line-height: 1;
-    font-weight: 600;
     color: #555;
     text-decoration: none;
-    font-family: monospace;
   }
   .tb-toggle:hover { color: #000; }
-  .tb-code-text { font-family: monospace; }
+  .tb-toggle .bi { font-size: 0.85rem; }
   .tb-clickable { cursor: pointer; }
   .tb-clickable:hover { background: #f0f6ff; }
   .tb-warning-row { background: #fde7e7; }

--- a/front/svelte/reports/trial-balance.svelte
+++ b/front/svelte/reports/trial-balance.svelte
@@ -644,7 +644,12 @@
     } else {
       return;
     }
-    drilldown?.open();
+    drilldown?.open({
+      term: status?.fy?.term,
+      accountCode: drillAccount.code,
+      subCode: drillAccount.subCode,
+      accountName: drillAccount.name,
+    });
   };
 
   const formatInt = (n) => {


### PR DESCRIPTION
## Summary

Merge epic **tb-ux-polish** — TB v2 code column UX (#321) + drill-down modal fixes (#323).

## Changes

- Separate expand column with chevron; code column shows numbers only
- Bilingual subtotal badges (大計/中計/小計)
- Drill-down modal: fix open timing, locale keys, backdrop dismiss

## Test plan

- [x] `npm run build` ✅ (verified on feature branches)
- [ ] Smoke: TB page hierarchy + row click drill-down

Closes #321
Closes #323
Closes #320
