### PR TITLE
chore(#330): update Harness framework to 0.1.9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,7 @@ project's DB. Use an inline, one-shot override only if ever needed.
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **fin-acc** (2163 symbols, 2810 relationships, 18 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **fin-acc** (3683 symbols, 5121 relationships, 86 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,7 +280,7 @@ project's DB. Use an inline, one-shot override only if ever needed.
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **fin-acc** (2163 symbols, 2810 relationships, 18 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **fin-acc** (3683 symbols, 5121 relationships, 86 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/scripts/harness-cli-release-tag
+++ b/scripts/harness-cli-release-tag
@@ -1,0 +1,1 @@
+harness-cli-v0.1.9


### PR DESCRIPTION
Closes #330

## Summary

- Pin Harness CLI release tag to `harness-cli-v0.1.9` for installer-driven refreshes.
- Refresh GitNexus metadata in both agent instruction files after re-indexing.
- Local ignored `scripts/bin/harness-cli.exe` was replaced with upstream Windows 0.1.9 binary after checksum verification.

## Verification

- `scripts/bin/harness-cli.exe --version` -> `harness-cli 0.1.9`
- SHA256 verified: `cfb5836d4c460add33b168c3f77f9572b6b3b82abff4c3dd5a75e7ffc30db739`
- `scripts/bin/harness-cli.exe migrate` -> current schema version 2, already up to date
- `scripts/bin/harness-cli.exe query matrix` -> pass
- `npm run build` -> pass
- `npm test` -> pass
- `gitnexus detect_changes` -> low risk, no affected processes
- Harness trace #39 -> standard tier, meets normal lane requirement