### PR TITLE
feat(#336): mapping robustness, translation invariant, debug cleanup

### DIFF
--- a/migrations/20260616210000-add-tenant-status-check-constraints.cjs
+++ b/migrations/20260616210000-add-tenant-status-check-constraints.cjs
@@ -1,0 +1,55 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // Preflight: enumerate existing status values in both tables.
+    // If any value other than 'active' or 'inactive' exists, fail loudly
+    // so the operator can review before applying the constraint.
+    const [tenantRows] = await queryInterface.sequelize.query(
+      `SELECT DISTINCT "status" FROM "Tenants";`
+    );
+    const tenantStatuses = tenantRows.map(r => r.status);
+    const invalidTenant = tenantStatuses.filter(s => !['active', 'inactive'].includes(s));
+    if (invalidTenant.length > 0) {
+      throw new Error(
+        `Migration aborted: Tenants table contains unexpected status values: ${invalidTenant.join(', ')}. ` +
+        `Normalize them to 'active' or 'inactive' before running this migration.`
+      );
+    }
+
+    const [memberRows] = await queryInterface.sequelize.query(
+      `SELECT DISTINCT "status" FROM "TenantMembers";`
+    );
+    const memberStatuses = memberRows.map(r => r.status);
+    const invalidMember = memberStatuses.filter(s => !['active', 'inactive'].includes(s));
+    if (invalidMember.length > 0) {
+      throw new Error(
+        `Migration aborted: TenantMembers table contains unexpected status values: ${invalidMember.join(', ')}. ` +
+        `Normalize them to 'active' or 'inactive' before running this migration.`
+      );
+    }
+
+    // Add CHECK constraints
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "Tenants"
+        ADD CONSTRAINT "tenants_status_chk"
+        CHECK (status IN ('active', 'inactive'));
+    `);
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "TenantMembers"
+        ADD CONSTRAINT "tenantmembers_status_chk"
+        CHECK (status IN ('active', 'inactive'));
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(
+      `ALTER TABLE "TenantMembers" DROP CONSTRAINT IF EXISTS "tenantmembers_status_chk";`
+    );
+    await queryInterface.sequelize.query(
+      `ALTER TABLE "Tenants" DROP CONSTRAINT IF EXISTS "tenants_status_chk";`
+    );
+  }
+};

--- a/models/index.js
+++ b/models/index.js
@@ -43,9 +43,10 @@ import VoucherFile from './voucherfile.js';
 import {Sequelize, DataTypes} from 'sequelize';
 import fs from 'fs';
 
+const __dirname = import.meta.dirname;
 const env = process.env.NODE_ENV || 'development';
 
-const jsonData = JSON.parse(fs.readFileSync('config/config.json', 'utf-8'));
+const jsonData = JSON.parse(fs.readFileSync(new URL('../config/config.json', import.meta.url), 'utf-8'));
 const config = jsonData[env];
 
 let sequelize;

--- a/models/tenant.js
+++ b/models/tenant.js
@@ -30,7 +30,10 @@ export default (sequelize, DataTypes) => {
     status: {
       type: DataTypes.STRING,
       allowNull: false,
-      defaultValue: 'active'
+      defaultValue: 'active',
+      validate: {
+        isIn: [['active', 'inactive']]
+      }
     },
     settings: {
       type: DataTypes.JSONB,

--- a/models/tenantmember.js
+++ b/models/tenantmember.js
@@ -117,7 +117,10 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: 'active',
-      comment: 'active | inactive'
+      comment: 'active | inactive',
+      validate: {
+        isIn: [['active', 'inactive']]
+      }
     },
 
     // Permissions (from UserTenant)

--- a/models/translation.js
+++ b/models/translation.js
@@ -12,10 +12,16 @@ export default (sequelize, DataTypes) => {
      * Fetch translations for a batch of records in one query.
      * Returns a nested map: { language: { recordKey: { field: value } } }
      *
+     * Design note: this method is a utility for bulk-fetching translations.
+     * The production path (enrichBilingual) only reads system-wide translations
+     * (tenantId:null). Tenant-level override is not wired to any UI or API;
+     * if needed in the future, add a two-pass merge (tenant then system) at
+     * the call site — not inside this method.
+     *
      * @param {string} tableName - e.g. 'AccountClass'
      * @param {string[]} recordKeys - logical record keys
      * @param {string[]} languages - e.g. ['vi']
-     * @param {number|null} tenantId - null = system-wide only
+     * @param {number|null} tenantId - null = system-wide only (current usage)
      * @returns {object}
      */
     static async fetchBatch(tableName, recordKeys, languages, tenantId = null) {
@@ -27,7 +33,6 @@ export default (sequelize, DataTypes) => {
         language: languages
       };
       if (tenantId !== null) {
-        // Tenant-specific overrides take priority — but we fetch system-wide too
         where.tenantId = tenantId;
       }
 

--- a/test/tenant-status-check-constraints.test.mjs
+++ b/test/tenant-status-check-constraints.test.mjs
@@ -1,0 +1,255 @@
+/**
+ * Issue #334: Tenant and TenantMember status CHECK constraint tests.
+ *
+ * Validates model validation and DB CHECK constraints on the status column.
+ */
+import { expect } from 'chai';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { Sequelize } from 'sequelize';
+
+const projectRoot = resolve(import.meta.dirname, '..');
+
+// ---------------------------------------------------------------------------
+// Helper: get a Sequelize instance connected to the test DB
+// ---------------------------------------------------------------------------
+function getTestSequelize() {
+  const raw = readFileSync(resolve(projectRoot, 'config/config.json'), 'utf8');
+  const cfg = JSON.parse(raw).test;
+  return new Sequelize({
+    dialect: 'postgres',
+    host: cfg.host,
+    port: cfg.port || 5432,
+    database: cfg.database,
+    username: cfg.username,
+    password: cfg.password,
+    logging: false
+  });
+}
+
+// ===========================================================================
+// Test suite
+// ===========================================================================
+describe('Issue #334 — Tenant/TenantMember status CHECK constraints', function () {
+  this.timeout(15000);
+
+  let sequelize;
+
+  before(async () => {
+    sequelize = getTestSequelize();
+    await sequelize.authenticate();
+  });
+
+  after(async () => {
+    if (sequelize) await sequelize.close();
+  });
+
+  // -----------------------------------------------------------------------
+  // 1. Model validation rejects invalid status
+  // -----------------------------------------------------------------------
+  describe('Model validation', () => {
+    // We test via raw Sequelize model definitions that mirror the validate config
+    it('Tenant model rejects status="bogus"', async () => {
+      const [results] = await sequelize.query(
+        `SELECT id FROM "Tenants" LIMIT 1`
+      );
+      const tenantId = results[0]?.id;
+
+      // Direct Sequelize insert with invalid status should fail validation
+      try {
+        await sequelize.query(
+          `UPDATE "Tenants" SET "status" = :status WHERE "id" = :id`,
+          { replacements: { status: 'bogus', id: tenantId } }
+        );
+        // If raw SQL succeeds, the CHECK constraint should catch it
+        // (this tests the DB-level constraint, not Sequelize validation)
+      } catch (err) {
+        // Expected: CHECK constraint violation
+        expect(err.message).to.include('tenants_status_chk');
+      }
+    });
+
+    it('TenantMember model rejects status="bogus"', async () => {
+      const [results] = await sequelize.query(
+        `SELECT id FROM "TenantMembers" LIMIT 1`
+      );
+      const memberId = results[0]?.id;
+
+      try {
+        await sequelize.query(
+          `UPDATE "TenantMembers" SET "status" = :status WHERE "id" = :id`,
+          { replacements: { status: 'bogus', id: memberId } }
+        );
+      } catch (err) {
+        expect(err.message).to.include('tenantmembers_status_chk');
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. DB CHECK constraints reject invalid values
+  // -----------------------------------------------------------------------
+  describe('DB CHECK constraints', () => {
+    it('Tenants CHECK constraint exists', async () => {
+      const [results] = await sequelize.query(`
+        SELECT conname, contype
+        FROM pg_constraint
+        WHERE conrelid = '"Tenants"'::regclass
+          AND conname = 'tenants_status_chk';
+      `);
+      expect(results).to.have.length(1);
+      expect(results[0].contype).to.equal('c'); // c = check constraint
+    });
+
+    it('TenantMembers CHECK constraint exists', async () => {
+      const [results] = await sequelize.query(`
+        SELECT conname, contype
+        FROM pg_constraint
+        WHERE conrelid = '"TenantMembers"'::regclass
+          AND conname = 'tenantmembers_status_chk';
+      `);
+      expect(results).to.have.length(1);
+      expect(results[0].contype).to.equal('c');
+    });
+
+    it('Raw INSERT with status="bogus" rejected on Tenants', async () => {
+      try {
+        await sequelize.query(`
+          INSERT INTO "Tenants" ("slug", "name", "status", "createdAt", "updatedAt")
+          VALUES ('test-bogus', 'Test Bogus', 'bogus', NOW(), NOW());
+        `);
+        // If we get here, constraint is missing — fail the test
+        expect.fail('Expected CHECK constraint violation');
+      } catch (err) {
+        expect(err.message).to.include('tenants_status_chk');
+      }
+    });
+
+    it('Raw INSERT with status="bogus" rejected on TenantMembers', async () => {
+      try {
+        await sequelize.query(`
+          INSERT INTO "TenantMembers" ("tenantId", "status", "createdAt", "updatedAt")
+          VALUES (1, 'bogus', NOW(), NOW());
+        `);
+        expect.fail('Expected CHECK constraint violation');
+      } catch (err) {
+        expect(err.message).to.include('tenantmembers_status_chk');
+      }
+    });
+
+    it('Raw UPDATE with status="bogus" rejected on Tenants', async () => {
+      const [results] = await sequelize.query(
+        `SELECT id FROM "Tenants" LIMIT 1`
+      );
+      if (results.length === 0) return this.skip();
+
+      try {
+        await sequelize.query(
+          `UPDATE "Tenants" SET "status" = 'bogus' WHERE "id" = :id`,
+          { replacements: { id: results[0].id } }
+        );
+        expect.fail('Expected CHECK constraint violation');
+      } catch (err) {
+        expect(err.message).to.include('tenants_status_chk');
+      }
+    });
+
+    it('Raw UPDATE with status="bogus" rejected on TenantMembers', async () => {
+      const [results] = await sequelize.query(
+        `SELECT id FROM "TenantMembers" LIMIT 1`
+      );
+      if (results.length === 0) return this.skip();
+
+      try {
+        await sequelize.query(
+          `UPDATE "TenantMembers" SET "status" = 'bogus' WHERE "id" = :id`,
+          { replacements: { id: results[0].id } }
+        );
+        expect.fail('Expected CHECK constraint violation');
+      } catch (err) {
+        expect(err.message).to.include('tenantmembers_status_chk');
+      }
+    });
+
+    it('Raw INSERT with status="active" succeeds on Tenants', async () => {
+      const [results] = await sequelize.query(`
+        INSERT INTO "Tenants" ("slug", "name", "status", "createdAt", "updatedAt")
+        VALUES ('test-valid-active', 'Test Valid Active', 'active', NOW(), NOW())
+        RETURNING id;
+      `);
+      expect(results).to.have.length(1);
+      // Clean up
+      await sequelize.query(
+        `DELETE FROM "Tenants" WHERE "slug" = 'test-valid-active';`
+      );
+    });
+
+    it('Raw INSERT with status="inactive" succeeds on Tenants', async () => {
+      const [results] = await sequelize.query(`
+        INSERT INTO "Tenants" ("slug", "name", "status", "createdAt", "updatedAt")
+        VALUES ('test-valid-inactive', 'Test Valid Inactive', 'inactive', NOW(), NOW())
+        RETURNING id;
+      `);
+      expect(results).to.have.length(1);
+      // Clean up
+      await sequelize.query(
+        `DELETE FROM "Tenants" WHERE "slug" = 'test-valid-inactive';`
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. Migration source code verification
+  // -----------------------------------------------------------------------
+  describe('Migration source', () => {
+    it('migration file exists', () => {
+      const migrationPath = resolve(
+        projectRoot,
+        'migrations/20260616210000-add-tenant-status-check-constraints.cjs'
+      );
+      expect(existsSync(migrationPath)).to.be.true;
+    });
+
+    it('migration has preflight check for Tenants', () => {
+      const src = readFileSync(
+        resolve(projectRoot, 'migrations/20260616210000-add-tenant-status-check-constraints.cjs'),
+        'utf8'
+      );
+      expect(src).to.include('Migration aborted');
+      expect(src).to.include('Tenants');
+      expect(src).to.include('DISTINCT');
+    });
+
+    it('migration has preflight check for TenantMembers', () => {
+      const src = readFileSync(
+        resolve(projectRoot, 'migrations/20260616210000-add-tenant-status-check-constraints.cjs'),
+        'utf8'
+      );
+      expect(src).to.include('TenantMembers');
+    });
+
+    it('migration down drops correct constraint names', () => {
+      const src = readFileSync(
+        resolve(projectRoot, 'migrations/20260616210000-add-tenant-status-check-constraints.cjs'),
+        'utf8'
+      );
+      expect(src).to.include('DROP CONSTRAINT IF EXISTS "tenantmembers_status_chk"');
+      expect(src).to.include('DROP CONSTRAINT IF EXISTS "tenants_status_chk"');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. Model source code verification
+  // -----------------------------------------------------------------------
+  describe('Model source verification', () => {
+    it('Tenant model has validate.isIn for status', () => {
+      const src = readFileSync(resolve(projectRoot, 'models/tenant.js'), 'utf8');
+      expect(src).to.include("isIn: [['active', 'inactive']]");
+    });
+
+    it('TenantMember model has validate.isIn for status', () => {
+      const src = readFileSync(resolve(projectRoot, 'models/tenantmember.js'), 'utf8');
+      expect(src).to.include("isIn: [['active', 'inactive']]");
+    });
+  });
+});


### PR DESCRIPTION
Part of epic:db-tenant-hardening

## Changes
- **models/index.js**: Config path uses `import.meta.url` instead of cwd-relative path
- **models/translation.js**: Updated `fetchBatch` design note — system-only translations in production, tenant override not wired
- **models/tenant.js, models/tenantmember.js**: Added `validate.isIn` for status fields (leftover from #335)
- **migrations/**: New migration for tenant status check constraints
- **test/**: Test for tenant status check constraints

## Test Report
- `npm run build` ✅
- `npm test` ✅ (467 passing)