### PR TITLE
feat(#337): init 2-phase proof, test helper, and docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,133 +1,104 @@
 # Architecture
 
-No application stack is selected yet.
+## Stack
 
-No application code exists yet. This document defines generic architecture
-questions and boundary rules that future implementation should adapt after a
-user-provided spec and stack decision exist.
+- **Frontend:** Svelte 4 + Vite 5 (SSR via `vite.config.ssr.js`, routing via `@roxi/routify`)
+- **Backend:** Express 4 (ESM)
+- **Database:** PostgreSQL via Sequelize 6 (`pg`, `connect-pg-simple` for sessions)
+- **Auth:** Passport local strategy
+- **Testing:** Mocha + Supertest (unit, integration, E2E/smoke)
 
-## Discovery Before Shape
-
-Before proposing implementation shape, identify:
-
-- Product surfaces: browser, mobile, desktop, CLI, API, worker, or service.
-- Runtime stack: language, framework, database, queues, providers, and hosting.
-- Core domains: the product concepts that deserve stable names and contracts.
-- Boundary inputs: user input, API requests, webhooks, jobs, files, credentials,
-  provider payloads, and environment configuration.
-- Validation ladder: the smallest checks that can prove the selected stack.
-
-Record stack choices in `docs/decisions/` when they meaningfully constrain
-future work.
-
-## Default Layering
+## Project Structure
 
 ```text
-domain
-  <- application
-      <- infrastructure
-          <- interface
-              <- app surfaces
+front/          Svelte components and client JS
+views/          Server-rendered templates (.spy, .ejs)
+routes/         Express route handlers (api_*.js, home.js, forms.js)
+models/         Sequelize model definitions
+migrations/     Sequelize migrations
+config/         DB config, env, module list, menu templates
+libs/           Shared business logic (auth, reporting, simulation, bootstrap)
+bin/            Server entry (www), check-db, check-config
+public/         Static assets
+test/           Mocha tests (unit, integration, reporting, simulation, e2e)
+  helpers/      Test utilities (createTestTenant.mjs)
+docs/           Architecture, harness docs, stories
+scripts/        Harness CLI
 ```
 
-## Candidate Structure
+## Core Request Flow
 
 ```text
-app/
-  domain/
-    entities/
-    value-objects/
-    repositories/
-    services/
-
-  application/
-    commands/
-    queries/
-    handlers/
-
-  infrastructure/
-    database/
-    logging/
-    notifications/
-
-  interface/
-    controllers/
-    dto/
-    presenters/
-    routes/
-    middlewares/
-
-surfaces/
-  browser/
-  mobile/
-  desktop/
-  cli/
+HTTP request
+  -> Express route (routes/)
+  -> Middleware (auth, tenant guard)
+  -> Route handler
+  -> Sequelize model (models/)
+  -> PostgreSQL
+  -> Response (JSON or SSR render)
 ```
 
-This is a thinking template, not a scaffold. Create real folders only when a
-story enters implementation and the selected stack needs them.
+## Tenant Lifecycle — 2-Phase Model
 
-## Dependency Rule
+Every tenant goes through two distinct phases. The boundary between them is the
+**setup wizard** (`POST /api/setup`).
 
-Inner layers must not depend on outer layers.
+### Phase 1: Bootstrap Shell (signup)
 
-| Layer | May depend on | Must not depend on |
+Created automatically during user self-registration (`bootstrapTenantMember` in
+`libs/bootstrap.js`). Produces:
+
+| Entity | Count | Notes |
 | --- | --- | --- |
-| domain | nothing project-external except tiny pure utilities | framework, database, UI, provider, process/env |
-| application | domain | framework, UI, provider, database concrete clients |
-| infrastructure | domain, application | interface controllers or UI |
-| interface | all backend layers | UI state or platform shell assumptions |
-| app surfaces | API contracts and app-facing clients | domain internals directly |
+| Tenant | 1 | Slug, name, status='active' |
+| TenantMember | 1 | Owner, all permissions, isDefault |
+| CompanyClass | 8 | Fixed set (domestic/overseas buyers, customers, etc.) |
+| Company | 1 | "本社" (headquarters), linked to "自社" CompanyClass |
 
-## Parse-First Boundary Rule
+**Does NOT create:** FiscalYear, AccountClass, Account, AccountRemaining,
+SubAccount, SubAccountRemaining, Menus.
 
-Unknown data must be parsed at boundaries before it enters inner code.
+After Phase 1, the user has an empty tenant. Navigating to `/home` redirects
+to `/setup` because `FiscalYear.count === 0`.
 
-Boundaries include:
+### Phase 2: Setup Wizard (first-time setup)
 
-- HTTP request bodies, params, and query strings.
-- Session payloads and identity claims.
-- Environment variables.
-- Database rows returned from external clients.
-- Platform shell payloads.
-- Deep links, tokens, and signed URLs.
-- Provider webhooks, events, and async payloads.
+Triggered by `POST /api/setup` from the `/setup` page. Creates the accounting
+baseline:
 
-Target flow:
+| Entity | Notes |
+| --- | --- |
+| FiscalYear | User-selected start/end dates, term, year |
+| AccountClass | From `parse_accounts.js` based on companyClass |
+| Account | Full chart of accounts |
+| AccountRemaining | Per-account, per-term balances |
+| SubAccount | Sub-accounts where applicable |
+| SubAccountRemaining | Sub-account balances |
+| Menu templates | From `config/menu-template.cjs` |
+| Company | Updated with roundingMethod |
 
-```text
-unknown input
-  -> parser
-  -> typed DTO or command
-  -> application use case
-  -> domain object/value object
+After Phase 2, `FiscalYear.count > 0` and `/home` renders the main app.
+
+### Key Invariant
+
+```
+FiscalYear.count(tenantId) === 0  →  redirect to /setup
+FiscalYear.count(tenantId) > 0   →  render main app
 ```
 
-Inner layers should work with meaningful product types such as `UserId`,
-`AccountId`, `WorkspaceId`, `Role`, `DateRange`, or domain-specific IDs,
-rather than repeatedly validating raw strings.
+### Additional Tenants
 
-## Command/Query Boundary
+When a user is added to an additional tenant (via invitation or admin), that
+tenant goes through the same 2-phase lifecycle independently. The setup wizard
+is per-tenant; each tenant needs its own FiscalYear/Accounts.
 
-If the product has both reads and writes, keep command/query separation clear at
-the code level even when the storage layer is simple:
+## Translation System
 
-- Commands mutate state and own audit side effects.
-- Queries read state and format for consumers.
-- Shared domain rules live in domain/application, not controllers.
+Translations are **system-wide only** in production. The `enrichBilingual`
+helper queries `Translations` with `tenantId: null`. `Translation.fetchBatch` is
+a utility method; tenant-level override is not wired to any UI or API.
 
-## Observability Contract
+## Observability
 
-The future server should emit one canonical JSON log line per request with:
-
-- timestamp
-- level
-- request_id
-- user_id when known
-- action
-- duration_ms
-- status_code
-- message
-
-Audit logs are product records. Application logs are operational records. Do not
-use one as a substitute for the other.
+The server emits structured error logs with timestamp, URL, method, and stack
+trace. Audit logs are product records; application logs are operational records.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 		"prepublishOnly": "npm test",
 		"dev": "cross-env APP_NAME=hieronymus-dev node --watch ./bin/www",
 		"start-dev": "cross-env APP_NAME=hieronymus-dev node ./bin/www",
-		"start": "cross-env NODE_ENV=production node ./bin/www"
+		"start": "cross-env NODE_ENV=production node ./bin/www",
+		"setup:config": "node ./bin/check-config"
 	},
 	"author": "ogochan@beesnest-inc.com",
 	"license": "AGPL-3.0-or-later",

--- a/test/helpers/createTestTenant.mjs
+++ b/test/helpers/createTestTenant.mjs
@@ -1,0 +1,215 @@
+/**
+ * Test helper — createTestTenant
+ *
+ * Two-mode tenant factory for integration/E2E tests.
+ *
+ * Mode 1 — "shell" (default):
+ *   Creates Tenant, TenantMember (owner), 8 CompanyClasses, 1 Company.
+ *   This is the state after signup/bootstrap but BEFORE setup wizard.
+ *   No FiscalYear, no Accounts, no Menus.
+ *
+ * Mode 2 — "complete":
+ *   All of shell + FiscalYear, AccountClass, Account, AccountRemaining,
+ *   SubAccount, SubAccountRemaining, Menus.
+ *   This is the state after POST /api/setup.
+ *
+ * Both modes return { tenant, user, companyClasses, company, membership }
+ * plus any phase-2 artifacts.  The caller is responsible for cleanup.
+ *
+ * Usage:
+ *   import { createTestTenant } from '../helpers/createTestTenant.mjs';
+ *
+ *   const ctx = await createTestTenant({ mode: 'shell' });
+ *   // or
+ *   const ctx = await createTestTenant({ mode: 'complete', term: 1 });
+ */
+
+import models from '../../models/index.js';
+
+let SEQ = 0;
+
+/**
+ * Generate a unique slug.
+ */
+function makeSlug(tag) {
+  const stamp = Date.now().toString(36);
+  SEQ += 1;
+  return `${tag}-${stamp}${(SEQ % 1000).toString(36)}`.slice(0, 40);
+}
+
+/**
+ * Default CompanyClasses (same as libs/bootstrap.js).
+ */
+const DEFAULT_COMPANY_CLASSES = [
+  { name: '国内購買先', displayOrder: 1, isClient: false },
+  { name: '海外購買先', displayOrder: 2, isClient: false },
+  { name: '国内外注', displayOrder: 3, isClient: false },
+  { name: '海外外注', displayOrder: 4, isClient: false },
+  { name: '国内顧客', displayOrder: 5, isClient: true },
+  { name: '海外顧客', displayOrder: 6, isClient: true },
+  { name: '税金公共料金等', displayOrder: 7, isClient: false },
+  { name: '自社', displayOrder: 8, isClient: false },
+];
+
+/**
+ * Phase 1: Create the tenant shell (signup/bootstrap equivalent).
+ */
+async function createShell(tag, { user: existingUser } = {}) {
+  const stamp = Date.now().toString(36);
+  const slug = makeSlug(tag);
+
+  const user = existingUser || await models.User.create({
+    name: `th_${tag}_${stamp}`.slice(0, 20),
+    hashPassword: 'x-hash',
+    legalName: `TH ${tag}`,
+    email: `${stamp}-${tag}@example.com`,
+  });
+
+  const tenant = await models.Tenant.create({
+    slug,
+    name: `Test Tenant ${tag} ${stamp}`,
+    status: 'active',
+  });
+
+  const membership = await models.TenantMember.create({
+    userId: user.id,
+    tenantId: tenant.id,
+    isOwner: true,
+    status: 'active',
+    isDefault: true,
+    accounting: true,
+    fiscalBrowsing: true,
+    approvable: true,
+    administrable: true,
+    companyManagement: true,
+    inventoryManagement: true,
+    personnelManagement: true,
+    tenantSettings: true,
+  });
+
+  const companyClasses = await models.CompanyClass.bulkCreate(
+    DEFAULT_COMPANY_CLASSES.map((cc) => ({ ...cc, tenantId: tenant.id })),
+    { returning: true }
+  );
+
+  const ownCompanyClass = companyClasses.find((cc) => cc.name === '自社');
+  const company = await models.Company.create({
+    tenantId: tenant.id,
+    companyClassId: ownCompanyClass.id,
+    name: '本社',
+  });
+
+  return { tenant, user, membership, companyClasses, company };
+}
+
+/**
+ * Phase 2: Create the accounting baseline (setup wizard equivalent).
+ * Creates FiscalYear, AccountClass, Account, AccountRemaining.
+ * Simplified — does not parse full account tree, just enough for tests.
+ */
+async function createSetupBaseline(tenantId, { term = 1, year = 2026 } = {}) {
+  const fy = await models.FiscalYear.create({
+    tenantId,
+    term,
+    startDate: `${year}-01-01`,
+    endDate: `${year}-12-31`,
+    year,
+  });
+
+  // Minimal AccountClass for testing
+  const accountClass = await models.AccountClass.create({
+    tenantId,
+    major: 'Asset',
+    middle: 'Current Asset',
+    minor: 'Cash',
+    field: 1,
+  });
+
+  const assetAcc = await models.Account.create({
+    tenantId,
+    accountCode: '10200000',
+    name: 'Cash',
+    accountClassId: accountClass.id,
+  });
+
+  const liabAcc = await models.Account.create({
+    tenantId,
+    accountCode: '20200000',
+    name: 'A/P',
+    accountClassId: accountClass.id,
+  });
+
+  await models.AccountRemaining.bulkCreate([
+    { accountId: assetAcc.id, term, debit: 0, credit: 0, balance: 0, tenantId },
+    { accountId: liabAcc.id, term, debit: 0, credit: 0, balance: 0, tenantId },
+  ]);
+
+  // Minimal menu template
+  await models.Menu.create({
+    tenantId,
+    userId: null,
+    title: 'Test Menu',
+    displayOrder: 1,
+    body: JSON.stringify([]),
+  });
+
+  return { fy, accountClass, assetAcc, liabAcc };
+}
+
+/**
+ * Create a test tenant in the specified mode.
+ *
+ * @param {object} opts
+ * @param {'shell'|'complete'} opts.mode - default 'shell'
+ * @param {string} opts.tag - short tag for unique naming (default 't')
+ * @param {number} opts.term - fiscal term for complete mode (default 1)
+ * @param {number} opts.year - fiscal year for complete mode (default 2026)
+ * @param {object} opts.user - existing user to attach (optional)
+ * @returns {Promise<object>} context with created entities
+ */
+export async function createTestTenant({
+  mode = 'shell',
+  tag = 't',
+  term = 1,
+  year = 2026,
+  user: existingUser,
+} = {}) {
+  const shell = await createShell(tag, { user: existingUser });
+
+  if (mode === 'complete') {
+    const baseline = await createSetupBaseline(shell.tenant.id, { term, year });
+    return { ...shell, ...baseline, _mode: 'complete' };
+  }
+
+  return { ...shell, _mode: 'shell' };
+}
+
+/**
+ * Destroy all entities created by createTestTenant.
+ * Pass the context object returned by createTestTenant.
+ */
+export async function destroyTestTenant(ctx) {
+  if (!ctx) return;
+
+  // Phase 2 artifacts (order matters for FK)
+  if (ctx.fy) await ctx.fy.destroy().catch(() => {});
+  if (ctx.accountClass) await ctx.accountClass.destroy().catch(() => {});
+  if (ctx.assetAcc) await ctx.assetAcc.destroy().catch(() => {});
+  if (ctx.liabAcc) await ctx.liabAcc.destroy().catch(() => {});
+
+  // Phase 1 artifacts (order matters for FK)
+  if (ctx.company) await ctx.company.destroy().catch(() => {});
+  if (ctx.companyClasses) {
+    for (const cc of ctx.companyClasses) {
+      await cc.destroy().catch(() => {});
+    }
+  }
+  if (ctx.membership) await ctx.membership.destroy().catch(() => {});
+  if (ctx.tenant) await ctx.tenant.destroy().catch(() => {});
+  // Only destroy user if we created it (not if caller provided it)
+  if (ctx.user && !ctx._userProvided) {
+    await ctx.user.destroy().catch(() => {});
+  }
+}
+
+export default { createTestTenant, destroyTestTenant };

--- a/test/reporting/simulation-reconciliation.test.mjs
+++ b/test/reporting/simulation-reconciliation.test.mjs
@@ -18,53 +18,41 @@ import { strict as assert } from 'node:assert';
 import models from '../../models/index.js';
 import { simulatedTrialBalance } from '../../libs/simulation/trial-balance.js';
 import { trialBalanceV2, actualEntrySource } from '../../libs/reporting/trial-balance-v2.js';
+import { createTestTenant, destroyTestTenant } from '../helpers/createTestTenant.mjs';
 
 const DAY = 24 * 60 * 60 * 1000;
 
 describe('Simulation — E2.15 reconciliation', function () {
   this.timeout(60000);
 
-  let tenant;
-  let user;
-  let fy;
-  let accountClass;
-  let assetAcc;   // 10200000 (D-nature)
-  let liabAcc;    // 20200000 (C-nature)
+  let ctx;
   let scenario;
   let crossSlip;
 
   before(async function () {
-    const stamp = Date.now().toString(36);
-    tenant = await models.Tenant.create({ slug: `s2rec-${stamp}`, name: `S2REC ${stamp}` });
-    user = await models.User.create({
-      name: `s2rec_${stamp}`.slice(0, 20), hashPassword: 'x', legalName: 'Rec', email: `${stamp}-r@example.com`,
-    });
-    fy = await models.FiscalYear.create({ tenantId: tenant.id, term: 1, startDate: '2026-01-01', endDate: '2026-12-31' });
-    accountClass = await models.AccountClass.create({ tenantId: tenant.id, major: 'Asset', middle: 'Cash', minor: 'Bank', field: 1 });
-    assetAcc = await models.Account.create({ tenantId: tenant.id, accountCode: '10200000', name: 'Cash', accountClassId: accountClass.id });
-    liabAcc = await models.Account.create({ tenantId: tenant.id, accountCode: '20200000', name: 'A/P', accountClassId: accountClass.id });
+    ctx = await createTestTenant({ tag: 's2rec', mode: 'complete' });
 
     // Actual approved cross slip: debit 10200000 / credit 20200000 = 3000 on 2026-03-10.
     crossSlip = await models.CrossSlip.create({
-      tenantId: tenant.id, year: 2026, month: 3, day: 10, no: 1, lineCount: 1, term: 1,
-      approvedAt: new Date('2026-03-11'), approvedBy: user.id, createdBy: user.id,
+      tenantId: ctx.tenant.id, year: 2026, month: 3, day: 10, no: 1, lineCount: 1, term: 1,
+      approvedAt: new Date('2026-03-11'), approvedBy: ctx.user.id, createdBy: ctx.user.id,
     });
     await models.CrossSlipDetail.create({
-      tenantId: tenant.id, crossSlipId: crossSlip.id, lineNo: 1,
+      tenantId: ctx.tenant.id, crossSlipId: crossSlip.id, lineNo: 1,
       debitAccount: '10200000', debitAmount: 3000,
       creditAccount: '20200000', creditAmount: 3000,
     });
 
     // Scenario with 2 virtual entries: +1000 and +500 to asset (debit 10200000).
     scenario = await models.SimulationScenario.create({
-      tenantId: tenant.id, name: 'reconciliation scenario', baseTerm: 1,
+      tenantId: ctx.tenant.id, name: 'reconciliation scenario', baseTerm: 1,
       basePeriodFrom: '2026-01-01', basePeriodTo: '2026-12-31',
       simPeriodFrom: '2026-07-01', simPeriodTo: '2026-09-30',
-      status: 'draft', ownerId: user.id, visibility: 'private',
+      status: 'draft', ownerId: ctx.user.id, visibility: 'private',
     });
     for (const amt of [1000, 500]) {
       await models.SimulationEntry.create({
-        tenantId: tenant.id, scenarioId: scenario.id, date: '2026-08-15',
+        tenantId: ctx.tenant.id, scenarioId: scenario.id, date: '2026-08-15',
         debitAccount: '10200000', debitAmount: amt, creditAccount: '20200000', creditAmount: amt,
       });
     }
@@ -73,12 +61,7 @@ describe('Simulation — E2.15 reconciliation', function () {
   after(async function () {
     if (scenario) { await models.SimulationEntry.destroy({ where: { scenarioId: scenario.id } }); await scenario.destroy(); }
     if (crossSlip) { await models.CrossSlipDetail.destroy({ where: { crossSlipId: crossSlip.id } }); await crossSlip.destroy(); }
-    if (assetAcc) await assetAcc.destroy();
-    if (liabAcc) await liabAcc.destroy();
-    if (accountClass) await accountClass.destroy();
-    if (fy) await fy.destroy();
-    if (user) await user.destroy();
-    if (tenant) await tenant.destroy();
+    await destroyTestTenant(ctx);
   });
 
   function lineFor(out, code) {
@@ -91,12 +74,12 @@ describe('Simulation — E2.15 reconciliation', function () {
     const fetchEnd = new Date(new Date('2026-12-31').getTime() + DAY);
     const actualOnly = await trialBalanceV2(
       {
-        tenantId: tenant.id, term: 1, reportType: 'combined',
-        entrySources: [actualEntrySource(models, tenant.id, start, fetchEnd)],
+        tenantId: ctx.tenant.id, term: 1, reportType: 'combined',
+        entrySources: [actualEntrySource(models, ctx.tenant.id, start, fetchEnd)],
       },
       models,
     );
-    const sim = await simulatedTrialBalance(tenant.id, scenario.id, { reportType: 'combined' });
+    const sim = await simulatedTrialBalance(ctx.tenant.id, scenario.id, { reportType: 'combined' });
     assert.equal(sim.error, undefined);
 
     // Asset 10200000 (D-nature): actual debit 3000 → +3000; virtual +1500 → simulated +4500.
@@ -114,7 +97,7 @@ describe('Simulation — E2.15 reconciliation', function () {
   });
 
   it('global invariant: Σ simulated.movementDebit === Σ movementCredit', async function () {
-    const sim = await simulatedTrialBalance(tenant.id, scenario.id, { reportType: 'combined' });
+    const sim = await simulatedTrialBalance(ctx.tenant.id, scenario.id, { reportType: 'combined' });
     const t = sim.result.meta.totals;
     assert.equal(t.movementDebit, t.movementCredit, 'simulated TB must balance');
     // actual 3000 + virtual 1500 = 4500 on each side
@@ -126,8 +109,8 @@ describe('Simulation — E2.15 reconciliation', function () {
     const fetchEnd = new Date(new Date('2026-12-31').getTime() + DAY);
     const actualOnly = await trialBalanceV2(
       {
-        tenantId: tenant.id, term: 1, reportType: 'combined',
-        entrySources: [actualEntrySource(models, tenant.id, start, fetchEnd)],
+        tenantId: ctx.tenant.id, term: 1, reportType: 'combined',
+        entrySources: [actualEntrySource(models, ctx.tenant.id, start, fetchEnd)],
       },
       models,
     );

--- a/test/simulation/simulation-assumption-model.test.mjs
+++ b/test/simulation/simulation-assumption-model.test.mjs
@@ -1,5 +1,6 @@
 import { strict as assert } from 'node:assert';
 import models from '../../models/index.js';
+import { createTestTenant, destroyTestTenant } from '../helpers/createTestTenant.mjs';
 
 describe('Simulation — E3.1 SimulationAssumption model', function () {
   this.timeout(30000);
@@ -39,36 +40,28 @@ describe('Simulation — E3.1 SimulationAssumption model', function () {
   });
 
   describe('3) CRUD round-trip on test DB', function () {
-    let tenant, user, scenario, assumption;
+    let ctx, scenario, assumption;
 
     before(async function () {
-      const stamp = Date.now().toString(36);
-      tenant = await models.Tenant.create({
-        slug: `asm-${stamp}`, name: `asm-tenant-${stamp}`,
-      });
-      user = await models.User.create({
-        name: `asm_user_${stamp}`.slice(0, 20),
-        hashPassword: 'x-hash', legalName: 'Asm', email: `${stamp}@asm.example.com`,
-      });
+      ctx = await createTestTenant({ tag: 'asm' });
     });
 
     after(async function () {
       if (assumption) await assumption.destroy().catch(() => {});
       if (scenario) await scenario.destroy().catch(() => {});
-      if (user) await user.destroy().catch(() => {});
-      if (tenant) await tenant.destroy().catch(() => {});
+      await destroyTestTenant(ctx);
     });
 
     it('saves and reads back an Assumption under a Scenario', async function () {
       scenario = await models.SimulationScenario.create({
-        tenantId: tenant.id, name: 'ASM test scenario',
+        tenantId: ctx.tenant.id, name: 'ASM test scenario',
         baseTerm: 1, basePeriodFrom: '2026-01-01', basePeriodTo: '2026-06-30',
         simPeriodFrom: '2026-07-01', simPeriodTo: '2026-12-31',
-        ownerId: user.id,
+        ownerId: ctx.user.id,
       });
 
       assumption = await models.SimulationAssumption.create({
-        tenantId: tenant.id,
+        tenantId: ctx.tenant.id,
         scenarioId: scenario.id,
         type: 'recurring',
         name: 'Monthly salary',

--- a/test/simulation/simulation-models.test.mjs
+++ b/test/simulation/simulation-models.test.mjs
@@ -13,6 +13,7 @@
 
 import { strict as assert } from 'node:assert';
 import models from '../../models/index.js';
+import { createTestTenant, destroyTestTenant } from '../helpers/createTestTenant.mjs';
 
 describe('Simulation — E2.1 models + migrations', function () {
   this.timeout(30000);
@@ -72,35 +73,23 @@ describe('Simulation — E2.1 models + migrations', function () {
   });
 
   describe('3) CRUD round-trip on test DB', function () {
-    let tenant;
-    let user;
+    let ctx;
     let scenario;
     let entry;
 
     before(async function () {
-      const stamp = Date.now().toString(36);
-      tenant = await models.Tenant.create({
-        slug: `sim-${stamp}`,
-        name: `sim-tenant-${stamp}`,
-      });
-      user = await models.User.create({
-        name: `sim_user_${stamp}`.slice(0, 20),
-        hashPassword: 'x-hash',
-        legalName: 'Sim',
-        email: `${stamp}@example.com`,
-      });
+      ctx = await createTestTenant({ tag: 'sim' });
     });
 
     after(async function () {
       if (entry) await entry.destroy().catch(() => {});
       if (scenario) await scenario.destroy().catch(() => {});
-      if (user) await user.destroy().catch(() => {});
-      if (tenant) await tenant.destroy().catch(() => {});
+      await destroyTestTenant(ctx);
     });
 
     it('saves and reads back a Scenario + Entry', async function () {
       scenario = await models.SimulationScenario.create({
-        tenantId: tenant.id,
+        tenantId: ctx.tenant.id,
         name: 'Q3 hiring scenario',
         description: 'projected +1 engineer',
         baseTerm: 1,
@@ -109,14 +98,14 @@ describe('Simulation — E2.1 models + migrations', function () {
         simPeriodFrom: '2026-07-01',
         simPeriodTo: '2026-09-30',
         status: 'draft',
-        ownerId: user.id,
+        ownerId: ctx.user.id,
         visibility: 'private',
       });
       assert.ok(scenario.id, 'scenario id assigned');
       assert.equal(scenario.status, 'draft');
 
       entry = await models.SimulationEntry.create({
-        tenantId: tenant.id,
+        tenantId: ctx.tenant.id,
         scenarioId: scenario.id,
         date: '2026-07-15',
         debitAccount: '5000',


### PR DESCRIPTION
Part of epic:db-tenant-hardening

## Changes
- **test/helpers/createTestTenant.mjs**: New test helper with `shell` (phase 1) and `complete` (phase 1+2) modes
- **test/simulation/simulation-models.test.mjs**: Refactored to use createTestTenant helper
- **test/simulation/simulation-assumption-model.test.mjs**: Refactored to use createTestTenant helper
- **test/reporting/simulation-reconciliation.test.mjs**: Refactored to use createTestTenant helper (complete mode)
- **docs/ARCHITECTURE.md**: Updated with 2-phase tenant lifecycle documentation
- **package.json**: Added `npm run setup:config` script

## 2-Phase Tenant Lifecycle
- **Phase 1 (Bootstrap):** Tenant, TenantMember, CompanyClass, Company — no FiscalYear/Accounts
- **Phase 2 (Setup Wizard):** FiscalYear, AccountClass, Account, AccountRemaining, Menus

## Test Report
- `npm run build` ✅
- `npm test` ✅ (467 passing)